### PR TITLE
发布1.0.0第一版

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,7 @@ hangarPublish {
     }
 }
 
+val debug_server_vesion = property("plugin_debug_server_version") as String
 tasks {
     // 配置工程内直接调试服务端插件
     // gradle-plugin: https://github.com/jpenilla/run-task#basic-usage
@@ -95,7 +96,7 @@ tasks {
         // Configure the Minecraft version for our task.
         // This is the only required configuration besides applying the plugin.
         // Your plugin's jar (or shadowJar if present) will be used automatically.
-        minecraftVersion(property("plugin_debug_server_version") as String)
+        minecraftVersion(debug_server_vesion)
     }
     // Mojang mappings: https://docs.papermc.io/paper/dev/project-setup/#mojang-mappings
     jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,10 @@ plugin_version=1.0.0
 plugin_description=Plugin for OrzMC Paper Server Admin
 plugin_jdk_min_version=21
 plugin_use_papermc_api_version=1.21.7
-plugin_debug_server_version=1.21.7
+plugin_debug_server_version=1.21.8
 
 # Publish To Hangar Meta Info
-plugin_support_paper_versions=1.21.7-1.21.x
+plugin_support_paper_versions=1.21.7-1.21.8
 
 # Common
 org.gradle.warning.mode=all

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzMC.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzMC.java
@@ -19,9 +19,9 @@ import java.util.logging.Logger;
 public final class OrzMC extends JavaPlugin implements Listener {
 
     // 机器人配置
-    private static final OrzDiscordBot discordBot = new OrzDiscordBot();
+    public static final OrzDiscordBot discordBot = new OrzDiscordBot();
+    public static final OrzQQBot qqBot = new OrzQQBot();
     private static final OrzLarkBot larkBot = new OrzLarkBot();
-    private static final OrzQQBot qqBot = new OrzQQBot();
 
     // 公共静态成员
     public static JavaPlugin plugin() {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
@@ -63,20 +63,20 @@ public class OrzPlayerEvent implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         OrzGuideBook.giveNewPlayerAGuideBook(event.getPlayer());
-        notifyQQGroupWithMsg(event.getPlayer(), PlayerState.JOIN);
+        notifyPlayerChatGroupWithMsg(event.getPlayer(), PlayerState.JOIN);
     }
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
-        notifyQQGroupWithMsg(event.getPlayer(), PlayerState.QUIT);
+        notifyPlayerChatGroupWithMsg(event.getPlayer(), PlayerState.QUIT);
     }
 
     @EventHandler
     public void onPlayerKickLeave(PlayerKickEvent event) {
-        notifyQQGroupWithMsg(event.getPlayer(), PlayerState.KICK);
+        notifyPlayerChatGroupWithMsg(event.getPlayer(), PlayerState.KICK);
     }
 
-    private void notifyQQGroupWithMsg(Player player, PlayerState state) {
+    private void notifyPlayerChatGroupWithMsg(Player player, PlayerState state) {
         ArrayList<Player> onlinePlayers = new ArrayList<>();
 
         Object[] objects = OrzMC.server().getOnlinePlayers().toArray();

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzTNTEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzTNTEvent.java
@@ -57,9 +57,11 @@ public class OrzTNTEvent implements Listener {
                     .append(Component.text("在"))
                     .append(blockLocationInfo(placedBlock, "放置了 " + placedBlockType.name()))
                     .build();
+            // MC服务器内部通告
             OrzMC.server().sendMessage(msg);
-            String qqGroupMsg = OrzMessageParser.playerDisplayName(player) + " 在" + locationString(placedBlock) + "放置了 " + placedBlockType.name();
-            OrzMC.sendPublicMessage(qqGroupMsg);
+            // 通过机器人发送到玩家群里通告
+            String noticeMsg = OrzMessageParser.playerDisplayName(player) + " 在" + locationString(placedBlock) + "放置了 " + placedBlockType.name();
+            OrzMC.sendPublicMessage(noticeMsg);
         }
     }
 
@@ -94,8 +96,9 @@ public class OrzTNTEvent implements Listener {
         int x = block.getX();
         int y = block.getY();
         int z = block.getZ();
-        if (x >= 30746 && x <= 30808 && y >= 62 && z >= 10139 && z <= 10227) return true;
-        OrzMC.logger().info(x + ", " + y + ", " + z + "处的" + block.getType().name() + "不在豁免区");
+        // TODO: 可获取配置信息，处理豁免区域
+        // if (x >= 30746 && x <= 30808 && y >= 62 && z >= 10139 && z <= 10227) return true;
+        // OrzMC.debugInfo(x + ", " + y + ", " + z + "处的" + block.getType().name() + "不在豁免区");
         return false;
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzWhiteListEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzWhiteListEvent.java
@@ -5,6 +5,9 @@ import com.destroystokyo.paper.profile.PlayerProfile;
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -18,18 +21,28 @@ public class OrzWhiteListEvent implements Listener {
         if (event.isWhitelisted()) {
             return;
         }
+        TextComponent.Builder kickMsgBuilder = Component.text();
         String qqGroupId = OrzMC.config().getString("qq_group_id");
-        String discordChannelLink = OrzMC.config().getString("discord_link");
-        TextComponent kickMsg = Component.text(player.getName())
-                .append(Component.text(" 不在白名单中，请先加入QQ群: " + qqGroupId + " 联系管理员进行添加"))
-                .append(Component.newline())
-                .append(Component.text("you are not in the whitelist, you can join the discord channel: " + discordChannelLink + " and ask the admin add your id into the whitelist!")
-                );
-        event.kickMessage(kickMsg);
+        if (qqGroupId != null && !qqGroupId.isEmpty()) {
+            if (!kickMsgBuilder.build().equals(Component.empty())) {
+                kickMsgBuilder.append(Component.newline()).append(Component.newline());
+            }
+            kickMsgBuilder.append(Component.text(player.getName()).color(NamedTextColor.RED).decorate(TextDecoration.BOLD)).append(Component.space()).append(Component.text("不在服务器白名单中，请先加入QQ群:")).append(Component.space()).append(Component.text(qqGroupId).color(NamedTextColor.YELLOW)).append(Component.space()).append(Component.text("，联系管理员添加白名单"));
+        }
+        String discordServerLink = OrzMC.config().getString("discord_server_link");
+        if (discordServerLink != null && !discordServerLink.isEmpty()) {
+            if (!kickMsgBuilder.build().equals(Component.empty())) {
+                kickMsgBuilder.append(Component.newline()).append(Component.newline());
+            }
+            kickMsgBuilder.append(Component.text("you can also join the discord server: ")).append(Component.text(discordServerLink).color(NamedTextColor.BLUE).decorate(TextDecoration.UNDERLINED).clickEvent(ClickEvent.openUrl(discordServerLink)));
+        }
+        if (!kickMsgBuilder.build().equals(Component.empty())) {
+            event.kickMessage(kickMsgBuilder.build());
+        }
 
-        // 通知QQ群
-        String qqGroupMsg = player.getName() + " 尝试加入服务器，被白名单拦截";
-        OrzMC.sendPublicMessage(qqGroupMsg);
+        // 通知玩家群
+        String playChatGroupMsg = player.getName() + " 尝试加入服务器，被白名单拦截";
+        OrzMC.sendPublicMessage(playChatGroupMsg);
     }
 }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/utils/OrzMessageParser.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/utils/OrzMessageParser.java
@@ -151,6 +151,10 @@ public class OrzMessageParser {
                 OfflinePlayer player = OrzMC.server().getOfflinePlayer(userName);
                 if (player.isWhitelisted()) {
                     player.setWhitelisted(false);
+                    Player onlinePlayer = OrzMC.server().getPlayer(player.getUniqueId());
+                    if (onlinePlayer != null) {
+                        onlinePlayer.kick();
+                    }
                 }
             }
             // 回调异步执行

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,10 +2,9 @@
 
 # 服务器是否开启强制白名单
 force_whitelist: true
+
 # 服务器爆炸事件监听
 explosion_report: false
-# Discord 频道链接，用于提示玩家加入Discord讨论群
-discord_link: 'https://discord.gg/MnKfFQ58rD'
 
 # 机器人消息发送服务配置
 
@@ -32,6 +31,8 @@ discord_bot_token_base64_encoded: 'TVRFd01UUTJNVEl3TWpZeU56azRPVFUzTkEuR1lTMU5IL
 # Discord 玩家文字频道，用来发送服务端上下线通知的频道
 # 获取方法，设置 -> 高级设置 -> 开发者模式 打开，长按对应文字频道，在弹出的菜单中选择最后一项：复制频道ID
 discord_player_text_channel_id: '1101910610033250468'
+# Discord玩家服务器链接
+discord_server_link: 'https://discord.gg/mHGKYNWw'
 
 # Lark飞书群机器人开关
 enable_lark_bot: false


### PR DESCRIPTION
# 管理员收发消息
## 支持的机器人
- 双向收发：
  -  QQ机器人(NapCatQQ)
  -  Discord机器人
- 单向接收：
  -  飞书机器人webhoook单向消息接收
## 支持的用户指令
> 为与主流聊天命令提示符不冲突插件配置文件可以修改命令提示符，
> 
> 例如：可配置为： / ，当前默认为：$
```
👨‍💼 管理员命令：
$a	添加玩家到服务器白名单中
$r	从服务器白名单中移除玩家
👨🏻‍💻 通用命令: 
$l	查看当前在线玩家
$w	查看当前在白名单中的玩家
$h	查看QQ群中可以使用的命令信息  
```