### PR TITLE
修复NapCatQQ WebSocketServer 客户端发送ping会导致断连的问题

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/ws/RobustWebSocketClient.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/ws/RobustWebSocketClient.java
@@ -92,7 +92,7 @@ public class RobustWebSocketClient {
                 }
             }
         };
-        client.setConnectionLostTimeout(30);
+        client.setConnectionLostTimeout(0);
     }
 
     public void connect() {


### PR DESCRIPTION
原因是，NapCatQQ的Websocket服务端仅使用业务层的心跳包保活，完成不处理ping/pong逻辑，客户端如果错误的发送ping，会导致WebSocket服务端主动断连，表现为客户端频繁断连无法稳定