### PR TITLE
docs: 全量文档更新，对齐项目最新实现

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ OrzMC/
 │   │   ├── PortalModule.java       跨服传送门
 │   │   ├── MaintenanceModule.java  世界备份与地图优化
 │   │   └── FeatureModule.java      所有 Feature 服务 + 命令/事件注册
-│   ├── core/ports/            含 Bukkit 依赖的端口（PortalPort, ServerAccess 等）
+│   ├── core/ports/            含 Bukkit 依赖的端口（PortalPort, ServerAccess, TypedConfigProvider 等）
 │   ├── features/              业务逻辑层（36 个文件）
 │   │   ├── botcommands/       Bot 命令解析（$a, $r, $b, $o 等）
 │   │   ├── maintenance/       世界备份/优化编排
@@ -53,7 +53,7 @@ OrzMC/
 │   │   ├── server/            服务端生命周期事件
 │   │   └── ...                guide, menu, teleport, player
 │   ├── infra/                 基础设施实现
-│   │   ├── config/            ConfigService, TypedConfigs, ConfigHealthCheck
+│   │   ├── config/            ConfigService + 类型化配置记录类、ConfigHealthCheck
 │   │   ├── bot/               OrzBotManager, OrzQQBot, OrzDiscordBot, OrzLarkBot
 │   │   ├── notify/            Notifier + ThrottledNotifier
 │   │   ├── ws/                RobustWebSocketClient（自动重连 + 心跳检测）
@@ -87,6 +87,6 @@ Tag 使用严格 SemVer，**不加 `v` 前缀**。
 
 - **无数据库**：所有状态存储在 YAML 配置文件中（portals.yml 在运行时修改）
 - **无 DI 框架**：通过显式组合根进行构造器注入
-- **类型化配置**：所有 YAML 访问通过 `TypedConfigs` 记录类型，附带健康检查
+- **类型化配置**：所有 YAML 访问通过 `configs/` 子包中的记录类（如 `WhitelistConfig`, `TntConfig`），附带健康检查
 - **异步安全**：`SafeScheduler` 包装 Bukkit 调度器，统一异常日志
 - **健康注册表**：`HealthStatus` 接口在 orzmc-api 中，`HealthAccessor` 适配器桥接静态 `HealthRegistry`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,5 +56,5 @@ docs/*      文档
 
 ## 问题反馈
 
-- Bug 报告和建议请通过 [GitHub Issues](https://github.com/OrzGeeker/OrzMCPlugin/issues/new/choose) 提交
+- Bug 报告和建议请通过 [GitHub Issues](https://github.com/OrzMC/OrzMCPlugin/issues/new/choose) 提交
 - 其他问题可通过项目主页的 QQ 频道联系

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OrzMCPlugin
 
-[![Pull Request Build Check](https://github.com/OrzGeeker/OrzMCPlugin/actions/workflows/build.yml/badge.svg)](https://github.com/OrzGeeker/OrzMCPlugin/actions/workflows/build.yml)
-[![Publish to Hangar](https://github.com/OrzGeeker/OrzMCPlugin/actions/workflows/publish.yml/badge.svg)](https://github.com/OrzGeeker/OrzMCPlugin/actions/workflows/publish.yml)
+[![Pull Request Build Check](https://github.com/OrzMC/OrzMCPlugin/actions/workflows/build.yml/badge.svg)](https://github.com/OrzMC/OrzMCPlugin/actions/workflows/build.yml)
+[![Publish to Hangar](https://github.com/OrzMC/OrzMCPlugin/actions/workflows/publish.yml/badge.svg)](https://github.com/OrzMC/OrzMCPlugin/actions/workflows/publish.yml)
 
 [![OrzMC](https://img.shields.io/hangar/dt/OrzMC?link=https%3A%2F%2Fhangar.papermc.io%2Fwangzhizhou666%2FOrzMC&style=flat)](https://hangar.papermc.io/wangzhizhou666/OrzMC)
 [![OrzMC](https://img.shields.io/hangar/stars/OrzMC?link=https%3A%2F%2Fhangar.papermc.io%2Fwangzhizhou666%2FOrzMC&style=flat)](https://hangar.papermc.io/wangzhizhou666/OrzMC)
@@ -11,7 +11,7 @@
 
 ## 参与贡献
 
-欢迎通过 [Issue](https://github.com/OrzGeeker/OrzMCPlugin/issues/new/choose) 报告 Bug 或提出建议。
+欢迎通过 [Issue](https://github.com/OrzMC/OrzMCPlugin/issues/new/choose) 报告 Bug 或提出建议。
 提交代码前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 [私服](https://orzmc.jokerhub.cn)开服自研插件，用来辅助管理员运维。
@@ -21,14 +21,15 @@
 
 ## 插件能力
 - 📋服务器开启强制白名单: 未添加到白名单的玩家无法进入服务器
-- 💬社交软件群内管理服务器（命令前缀来自 bot.yml 的 cmd_prompt_char，默认 `$`）
+- 💬社交软件群内管理服务器（命令前缀来自 `config.yml` → `bot.cmd_prompt_char`，默认 `$`）
   ```
   👨‍💼 管理员命令：
   $a	添加玩家到白名单
   $r	从白名单移除玩家
   $b	地图备份
   $o	地图优化
-  👨🏻‍💻 通用命令: 
+  $e	执行控制台命令
+  👨🏻‍💻 通用命令:
   $l	查看在线玩家
   $w	查看白名单玩家
   $h	查看帮助信息
@@ -44,7 +45,9 @@
   - `/bot` 查看当前机器人状态，用来随时进行机器人通知服务的状态查询
   - `/portal <host> [port]` 创建跨服跳转传送门
   - `/portal remove|rm <host> [port]` 移除跨服跳转传送门（需 OP 或 orzmc.admin）
-  - `/menu` 打开内置菜单(当前为占位界面，点击提示“功能开发中”，后续将逐步增加快捷功能)
+  - `/menu` 打开内置菜单(当前为占位界面，点击提示”功能开发中”，后续将逐步增加快捷功能)
+  - `/orzmc reload [config-name]` 管理员热重载配置
+  - `/orzmc config <子命令>` 管理员运行时配置查看/修改/重置/导出
 - TNT服务器防护：可通过配置文件设置，开启服务器爆炸监听、报警和防护。支持在不同世界配置TNT可用区域白名单，在设置的白名单区域内，TNT相关功能可正常生效
 - 服务区域限制：为了防止一些国家玩家对服务器的扫描和破坏，可通过配置文件设置服务器允许玩家登录的国家区域
 
@@ -59,7 +62,7 @@
 2. 下次服务端重启时，插件会被自动移到`plugins/`目录下面，完成插件升级
 
 ## 问题反馈
-- 如果你在使用过程中发现问题，欢迎给项目提建议：[issues](https://github.com/OrzGeeker/OrzMCPlugin/issues)
+- 如果你在使用过程中发现问题，欢迎给项目提建议：[issues](https://github.com/OrzMC/OrzMCPlugin/issues)
 - 问题反馈可进入QQ频道：<br/> ![lark_issue_feedback_group](./images/lark_issue_feedback.png)
 
 ## 架构概览

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,217 +1,316 @@
 # 架构设计
 
-核心目标：组合根显式装配、服务层收敛业务逻辑、适配层只做转发，核心层沉淀端口与消息模型，基础设施提供可替换实现。
+核心目标：组合根显式装配模块、服务层收敛业务逻辑、适配层只做转发，
+核心层沉淀端口与消息模型，基础设施提供可替换实现。
 
 ## 分层说明
 
-- 组合根（Composition Root）
-    - 入口：OrzMC
-    - 负责实例化并装配：OrzTextStyles / Notifier / Throttled* / ConfigService 等依赖
-- 适配层（Events/Commands）
+- **组合根（Composition Root）**
+    - `OrzServices` 作为显式组合根，按依赖顺序创建 5 个领域模块
+    - `OrzMC` (JavaPlugin) 入口，仅调用 `OrzServices.assemble(this)` 和生命周期方法
+- **适配层（Events/Commands）**
     - 事件监听、命令入口只采集参数并调用服务
-    - 示例：OrzPlayerEvent、OrzTNTEvent、OrzTPBow、OrzMenuCommand
-- 服务层（Features/Use Cases）
+    - `events/` 包中每个 Listener 只做参数转发
+    - `commands/` 包中每个 CommandExecutor 只做参数采集与拦截器壳
+- **服务层（Features）**
     - 承载业务流程与规则，依赖通过构造注入
-    - 示例：PlayerEventService、TntEventService、WorldMaintenanceService
-- 核心层（Core）
-    - 业务端口与基础消息模型
-    - 示例：PortalPort/PortalInfo、TypedConfigProvider、MessageEnvelope
-- 基础设施层（Infra）
+    - 示例：`features/player/PlayerEventService`, `features/tnt/TntEventService`, `features/whitelist/WhitelistService`
+- **核心层（Core / 端口与消息）**
+    - `core/ports/` 定义业务端口接口（`ServerAccess`, `ServerLogger`, `ServerScheduler`, `TypedConfigProvider`）
+    - `core/bot/` 定义消息模型（`MessageEnvelope`, `BotInboundHandler`）
+    - `assembly/` 定义生命周期契约（`ServiceModule`, `Initializable`）
+- **基础设施层（Infra）**
     - 通知、网络、限流、样式、配置、Bot 适配等实现细节
-    - 示例：Notifier、ThrottledLogger、ThrottledNotifier、BotRouter、RobustWebSocketClient
+    - 示例：`infra/notify/Notifier`, `infra/logging/ThrottledLogger`, `infra/ws/RobustWebSocketClient`
 
 ## 架构设计图
 
 ![architecture](../images/architecture.svg)
 
-## 架构/模块职责
+## 模块构成
 
-- Infra 层（基础设施能力）
-    - config：配置加载、包装与健康检查
-        - ConfigService/AdvancedConfigManager/ConfigManager/ConfigWrapper/ConfigHealthCheck
-        - DefaultTypedConfigProvider（对外提供 TypedConfigProvider）
-    - notify：限流与事件派发
-        - ThrottledNotifier、Notifier(支持自定义 NotifierSink)
-    - logging：日志限流
-        - ThrottledLogger
-    - health：健康状态注册与查询
-        - HealthRegistry(Status: enabled/httpOk/wsConnected/apiReady/lastError/lastUpdated)
-    - styles：统一文本样式与颜色
-        - OrzTextStyles（读取 styles.yml）
-    - server：服务端交互
-        - ServerFacade + ServerAccess/ServerLogger/ServerScheduler + OrzUtil（控制台命令执行、成功/失败/警告文本）
-    - net：HTTP 客户端封装
-        - AsyncHttp（超时/重试/退避）
-    - ws：WebSocket 客户端封装
-        - WsClient/WebSocketClientFactory(默认 DefaultWebSocketClientFactory)/RobustWebSocketClient/WebSocketEventListener（指数退避与抖动、稳定期重置、工厂注入便于测试替身与异常场景覆盖）
-    - core：通用常量
-        - OrzConstants（TPBOW_KEY、告警前缀）
-    - templates：消息模板与解析
-        - TemplateService/TemplateResolvers/ExceptionFormatter
-    - bot：机器人适配与路由
-        - BotMessageServiceProvider/OrzBotManager/BotRouter
-    - scheduler/paging：调度与分页
-        - Schedulers/Paginator
-- Feature 层（业务编排）
-    - 维护、传送门、玩家/TNT/白名单事件、菜单、传送弓、新手指南等
-- Core 层（端口与消息）
-    - server：ServerAccess/ServerLogger/ServerScheduler
-    - portal：PortalPort/PortalInfo
-    - config：TypedConfigProvider
-    - bot：MessageEnvelope/BotInboundHandler
-- Feature 层（业务编排）
-    - 维护、传送门、玩家/TNT/白名单事件、菜单、传送弓、新手指南等
-    - 通过 TypedConfigProvider 获取类型化配置，依赖 Infra 能力进行通知派发、样式渲染与服务端交互
+### 1. PlatformModule — 平台基础设施（零依赖）
 
-## 依赖关系图（简述）
+```
+PlatformModule
+├── ServerFacade          ← 服务端门面（聚合 ServerAccess / ServerLogger / ServerScheduler）
+├── ConfigService         ← YAML 配置加载与管理
+├── DefaultTypedConfigProvider ← 类型化配置统一入口（通过各个 Config 记录类转型）
+├── OrzTextStyles         ← 文本样式（从 templates.yml → styles 段读取，兼容旧 styles.yml）
+├── ThrottledLogger       ← 日志限流
+├── ThrottledNotifier     ← 通知限流
+└── HealthRegistry         ← 健康状态注册与查询
+```
 
-- OrzMC（入口）
-    - 组合根负责实例化与装配 ConfigService/OrzTextStyles/Throttled*/Notifier
-    - 通过 BotMessageServiceProvider 创建 BotMessageService
-- 事件/功能（features.*）
-    - 读取配置：core.ports.config.TypedConfigProvider
-    - 渲染样式：infra.styles.OrzTextStyles
-    - 服务端交互：infra.server.OrzUtil
-    - 通知派发：infra.notify.Notifier
-    - 健康状态：infra.health.HealthRegistry
-    - 网络与WS：infra.net.AsyncHttp、infra.ws.WsClient/RobustWebSocketClient/WebSocketEventListener
+- **config/** — 配置加载、类型化包装与健康检查
+    - ConfigService, ConfigManager, ConfigHealthCheck
+    - `configs/` 子包中每个配置对应一个记录类（`BotConfig`, `Styles`, `TntConfig`, `WhitelistConfig`, `Portals`, `MainConfig`, `MaintenanceConfig`, `CommandPolicies`, `TemplateOptions`, `Templates`, `NotifyPolicy`, `IpWhitelist`, `WhitelistKickMessage`）
+    - `SafeKeys` 端口 YAML 键名编码（解决 '.' 被识别为层级分隔的问题）
+    - `PortalsWriter` 持久化传送门配置
+- **notify/** — 通知派发与限流
+    - Notifier（支持自定义 NotifierSink）
+    - ThrottledNotifier
+- **logging/** — 日志限流
+    - ThrottledLogger
+- **health/** — 健康状态注册与查询
+    - HealthRegistry（Status: enabled/httpOk/wsConnected/apiReady/lastError/lastUpdated）
+    - HealthAccessor（桥接静态 HealthRegistry 与 HealthStatus 接口）
+- **styles/** — 统一文本样式与颜色
+    - OrzTextStyles（读取 templates.yml → styles 段，兼容旧 styles.yml）
+- **server/** — 服务端交互
+    - ServerFacade（聚合 serverAccess / serverLogger / serverScheduler）
+- **net/** — HTTP 客户端封装
+    - AsyncHttp（超时/重试/指数退避）
+- **ws/** — WebSocket 客户端封装
+    - RobustWebSocketClient（指数退避与抖动、稳定期重置）
+- **bot/** — 机器人适配与路由
+    - BotMessageServiceProvider 工厂创建 BotMessageService
+    - OrzBotManager 路由消息至 QQ / Discord / 飞书
+- **binding/** — 命令/事件注册
+    - CommandBinder（使用 CommandMap API 注册命令）
+    - EventBinder（注册事件监听器）
+- **templates/** — 消息模板与解析
+    - TemplateService, TemplateResolvers
+- **paging/** — 分页
+    - Paginator（白名单分页展示）
+
+### 2. BotModule — 机器人消息模块
+
+创建 BotCommandService → BotMessageService（QQ/Discord/飞书）→ Notifier 的依赖链。
+
+```
+BotModule
+├── BotCommandService     ← 机器人消息解析与路由（实现 BotInboundHandler）
+│   ├── 命令分发映射（OrzUserCmd 枚举 → CmdHandler）
+│   ├── $a / $r / $b / $o / $e / $l / $w / $h
+│   └── setMaintenanceService() 跨模块注入
+├── BotMessageService     ← QQ/Discord/飞书适配器
+├── Notifier              ← 通知派发（依赖 BotMessageService）
+├── BotStatusService      ← 机器人状态查询
+└── HealthRegistry        ← 机器人相关健康检查
+```
+
+- 循环依赖处理：BotModule 实现 `Initializable.afterPropertiesSet()`，
+  在组合根完成跨模块注入后触发二阶段初始化
+- 跨模块回引用：`setWorldMaintenanceService()` 向 BotCommandService 注入维护服务
+
+### 3. PortalModule — 传送门模块
+
+管理跨服传送门的创建、查找和移除，持久化到 portals.yml。
+
+```
+PortalModule
+├── PortalService         ← 传送门业务逻辑（实现 PortalPort）
+└── portals.yml           ← 运行时修改的 YAML 存储
+```
+
+- `PortalsWriter` 持久化抽象，支持未来替换存储方式
+
+### 4. MaintenanceModule — 维护模块
+
+```
+MaintenanceModule
+└── WorldMaintenanceService  ← 世界备份与地图优化
+```
+
+- 依赖 PlatformModule（ConfigService）和 BotModule（Notifier）
+- 通过 BotCommandService 暴露给 $b / $o 命令
+
+### 5. FeatureModule — 功能模块（依赖所有其他模块）
+
+将所有 Feature 服务集中创建，并注册 Bukkit 事件监听器和命令。
+
+**注册的事件监听器**：
+- OrzBowShootEvent — 传送弓射箭事件
+- OrzPlayerEvent — 玩家进出服 / 首次加入向导
+- OrzTPEvent — 跨服传送
+- OrzTNTEvent — TNT 检测
+- OrzMenuEvent — 菜单交互
+- OrzServerEvent — 服务端生命周期
+- OrzWhiteListEvent — 白名单检查
+- OrzDebugEvent — 调试事件
+- OrzPortalEvent — 传送门交互
+
+**注册的命令**（通过 CommandMap API，替代 plugin.yml 声明）：
+- `/tpbow` — 获取传送弓
+- `/guide` — 获取玩家指南
+- `/menu` — 打开菜单
+- `/bot` — 查看机器人状态
+- `/portal` — 管理传送门
+- `/orzmc` — 管理员命令（reload config 子命令）
+
+**命令拦截器**（`features/command/binding/`）：
+- `PlayerOnlyInterceptor` — 玩家限定（bot 命令例外）
+- `AdminOnlyInterceptor` — OP 或 `orzmc.admin` 权限检查
+- `CooldownInterceptor` — 秒级冷却（按 commandName|senderName 维度）
+- `InterceptorExecutor` — 拦截器链执行壳
+
+**白名单管理**：
+- `enableForceWhitelist()` 在启动时根据配置设置强制白名单
+
+## 模块生命周期
+
+`OrzServices.assemble()` 是显式组合根，严格按依赖顺序装配：
+
+```
+OrzServices.assemble(OrzMC)
+  │
+  ├── 1. new PlatformModule(plugin)      ← 零依赖基础设施
+  │       └── platform.setup()           ← 初始化配置系统
+  │
+  ├── 2. new BotModule(platform)         ← 依赖 Platform
+  ├── 3. new PortalModule(platform)      ← 依赖 Platform
+  │
+  ├── 4. new MaintenanceModule(platform, bot)  ← 依赖 Platform + Bot
+  │
+  ├── 5. bot.setWorldMaintenanceService(...)   ← 跨模块回引用注入
+  ├── 6. ((Initializable) bot).afterPropertiesSet()  ← 二阶段初始化
+  │
+  ├── 7. new FeatureModule(platform, bot, portal, maintenance)  ← 依赖所有模块
+  │
+  └── OrzServices.setupAll(plugin)
+        ├── botModule.setup()             ← 启动 Bot 连接
+        ├── portalModule.setup()          ← 初始化传送门
+        ├── featureModule.setupEventListeners(plugin)   ← 注册事件
+        ├── featureModule.setupCommandHandlers(plugin)  ← 注册命令
+        └── featureModule.enableForceWhitelist(plugin)   ← 设置白名单
+```
+
+`OrzServices.shutdownAll()` 逆序销毁：
+- 先发停服通知 → BotModule.tearDown() → PortalModule.tearDown() → PlatformModule.tearDown()
+
+## 依赖关系图
+
+- OrzServices（入口）
+    - PlatformModule 提供：ServerFacade, ConfigService, TypedConfigProvider, OrzTextStyles, ThrottledLogger, ThrottledNotifier, HealthRegistry
+    - BotModule 利用 PlatformModule 创建 BotCommandService → BotMessageService → Notifier
+    - PortalModule 利用 PlatformModule 创建 PortalService
+    - MaintenanceModule 利用 PlatformModule + BotModule 创建 WorldMaintenanceService
+    - FeatureModule 利用所有模块创建 Feature 服务并注册命令/事件
 
 ## 设计原则
 
-- 分层清晰：Feature 只编排业务，Infra 提供能力
-- 显式依赖：通过构造注入与组合根装配，避免静态耦合
-- 配置类型化：集中 TypedConfigs/默认值与迁移
-- 可测试性：NotifierSink/接口封装便于替换与隔离外部交互，WS 通过工厂注入替身覆盖心跳/重连/异常路径
-- 线程安全：Bukkit 主线程进行方块与实体操作；异步任务做 I/O
+- **分层清晰**：Feature 只编排业务，Infra 提供能力，Events/Commands 仅做转发
+- **显式依赖**：通过构造注入与组合根装配，避免静态耦合
+- **配置类型化**：集中配置记录类，默认值与迁移，附带健康检查
+- **可测试性**：NotifierSink 接口便于替换，WS 通过工厂注入替身覆盖心跳/重连/异常路径
+- **线程安全**：Bukkit 主线程进行方块与实体操作；异步任务做 I/O（ServerFacade 提供 runSync/runAsync）
 
-## 类型化配置示例
+## 配置结构
 
-- Styles（styles.yml）
-    - [TypedConfigs.Styles](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TypedConfigs.java#L174-L195)
-      统一颜色键与默认值
-    - [OrzTextStyles.java](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/styles/OrzTextStyles.java#L11-L19)
-      通过类型化读取颜色
-- Portals（portals.yml）
-    - [TypedConfigs.Portals](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TypedConfigs.java#L196-L235)
-      统一中心坐标/轴向与目标地址
-    - 健康检查：端口范围与键格式校验 [ConfigHealthCheck.validatePortals](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java#L22-L42)
-    - 写入器抽象：[PortalsWriter](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/PortalsWriter.java)
-      支持未来替换存储方式
-        - 接入位置：[PortalService.saveToStorage](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalService.java#L219-L230)
-
-## 策略拦截器示例
-
-- 定义拦截器
-    - AdminOnlyInterceptor：管理员权限校验
-    - CooldownInterceptor：命令冷却控制
-- 注册与使用
-    - 在 OrzMC.setupCommandHandler 中，根据 commands.yml 的策略为每个命令注入拦截器链
-    - 参见 [InterceptorExecutor.java](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/binding/InterceptorExecutor.java)
-
-## 序列图（文本示意）
-
-```
-OrzMC.onEnable
-  -> new ConfigService
-  -> new DefaultTypedConfigProvider
-  -> new OrzTextStyles/ThrottledLogger/ThrottledNotifier
-  -> new BotCommandService
-  -> BotMessageServiceProvider.create(...)
-  -> new Notifier
-  -> configService.setup
-  -> botMessageService.setup
-  -> portalService.setup
-  -> setupEventListener(EventBinder.bind)
-  -> setupCommandHandler(CommandBinder.bind)
-```
-
-## 示例代码段
-
-- 类型化配置读取（通过 TypedConfigProvider）
-
-```java
-TypedConfigs.TemplateOptions opt = configs.templateOptions();
-double scale = opt.coordScale() <= 0 ? 1.0 : opt.coordScale();
-```
-
-- 命令拦截器接入
-
-```java
-List<CommandInterceptor> list = new ArrayList<>();
-list.add(new PlayerOnlyInterceptor());
-list.add(new AdminOnlyInterceptor(p.adminOnly()));
-list.add(new CooldownInterceptor("portal", p.cooldownSeconds()));
-CommandBinder.bind(this, Map.of("portal", new InterceptorExecutor("portal", new OrzPortalCommand(portalService, textStyles), list)));
-```
-
-## 命令用法
-
-- /bot
-    - 查看机器人健康状态
-- /portal
-    - 创建传送门：/portal <host> [port]
-    - 移除传送门：/portal remove <host> [port] 或 /portal rm <host> [port]
-    - 需 OP 权限
-
-## 命令策略（冷却/权限）
-
-- 配置示例（commands.yml）
+### config.yml（核心配置，合并管理）
 
 ```yaml
-commands:
-  tpbow:
-    cooldown_secs: 5
-    admin_only: false
-  menu:
-    cooldown_secs: 5
-    admin_only: false
-  portal:
-    cooldown_secs: 5
-    admin_only: true
+# config.yml 包含所有配置段：whitelist, maintenance, tnt, geoip, command_policies
+# 参考 src/main/resources/config.yml
 ```
-备注：如需为 bot/guide 等其他命令设置策略，可在 commands.yml 中自行新增条目。
 
-- 加载与注入
-    - 类型化解析：[TypedConfigs.CommandPolicies](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TypedConfigs.java)
-    - 注册拦截器：[OrzMC.setupCommandHandler](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzMC.java)
-        - PlayerOnlyInterceptor：玩家限定
-        - AdminOnlyInterceptor：基于 OP 或权限节点 orzmc.admin
-        - CooldownInterceptor：按 commandName|senderName 维度进行秒级冷却
-    - 执行器：[InterceptorExecutor.java](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/binding/InterceptorExecutor.java)
+- 详见 `infra/config/configs/` 包中的各个记录类
+- 每个配置段对应一个 record 类型（`WhitelistConfig`, `TntConfig`, `MaintenanceConfig` 等）
+- 通过 `TypedConfigProvider` 统一访问：
+  ```java
+  TypedConfigs.WhitelistConfig wl = configs.whitelist();
+  boolean forceWhitelist = wl.forceWhitelist();
+  ```
 
-## Portals 配置结构（按服务器地址分组）
+### portals.yml（按服务器地址分组）
 
-```
+```yaml
 portals:
   "example_com:25565":
     "world:100:64:200": "X"
     "world:200:64:300": "Z"
 ```
 
-- 说明
-    - 为避免 YAML 将 '.' 识别为层级分隔，写入时对地址进行安全编码：将 '.' 替换为 '_'，如 mc.jokerhub.cn:25565 →
-      mc_jokerhub_cn:25565
-    - 读取时自动解码为原始地址使用
-    - 参考：[SafeKeys.java](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/SafeKeys.java) [PortalsWriter.java](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/PortalsWriter.java) [TypedConfigs.Portals.from](file:///Users/bytedance/Documents/OrzMC/plugin/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TypedConfigs.java#L225-L241)
+- 为避免 YAML 将 '.' 识别为层级分隔，写入时对地址进行安全编码：'.' → '_'
+- 读取时自动解码为原始地址
+- 参考：SafeKeys, PortalsWriter, Portals
 
-## 调用示例
+### 文本样式（templates.yml → styles 段）
 
-- 事件派发
-    - notifier.event("tnt_alert", envelope)
-- 控制台命令
-    - com.jokerhub.paper.plugin.orzmc.infra.server.OrzUtil.executeConsoleCmd(() -> {}, "save-all")
-- 样式渲染
-    - styles.warn("仅 OP 可用")
-- 注入自定义通知器
-    - notifier.registerSink(customSink)
+样式与模板统一管理在 `templates.yml` 中：
+
+```yaml
+styles:
+  info: "#00AAFF"
+  success: "#00FF00"
+  warn: "#FFAA00"
+  error: "#FF5555"
+```
+
+兼容旧 `styles.yml` 文件（自动 fallback 读取）。
+
+## 命令策略（冷却/权限）
+
+命令策略通过 `config.yml` → `command_policies` 配置，兼容旧 `commands.yml`（作为 fallback）：
+
+```yaml
+command_policies:
+  tpbow:
+    cooldown_secs: 3
+    admin_only: false
+  menu:
+    cooldown_secs: 0
+    admin_only: false
+  portal:
+    cooldown_secs: 5
+    admin_only: true
+```
+
+加载与注入：
+- 类型化解析：`infra/config/configs/CommandPolicies`, `CommandPolicy`
+- 注册拦截器：`FeatureModule.setupCommandHandlers()`
+  - `PlayerOnlyInterceptor`：玩家限定（bot 命令例外）
+  - `AdminOnlyInterceptor`：基于 OP 或权限节点 `orzmc.admin`
+  - `CooldownInterceptor`：按 commandName|senderName 维度进行秒级冷却
+- 执行器：`features/command/binding/InterceptorExecutor`
+
+## Bot 命令
+
+机器人命令前缀来自 `config.yml` → `bot.cmd_prompt_char`（默认 `$`）：
+
+| 命令 | 权限 | 说明 |
+|------|------|------|
+| `$a <玩家名>` | 管理员 | 添加玩家到白名单 |
+| `$r <玩家名>` | 管理员 | 从白名单移除玩家 |
+| `$b` | 管理员 | 地图备份 |
+| `$o` | 管理员 | 地图优化 |
+| `$e <命令>` | 管理员 | 执行控制台命令 |
+| `$l` | 通用 | 查看在线玩家 |
+| `$w [页码]` | 通用 | 查看白名单玩家 |
+| `$h` | 通用 | 查看帮助信息 |
+
+参考：`features/botcommands/OrzUserCmd` 枚举、`BotCommandService`。
 
 ## 测试指南
 
-- 单元测试
+- **单元测试**
     - 对服务类注入替身 Notifier/NotifierSink/OrzTextStyles，验证逻辑与路由
-    - 对配置接口 TypedConfigs 使用内存配置对象，验证默认值与路径解析
+    - 对配置接口使用内存配置对象，验证默认值与路径解析
     - 对 WS 工厂注入（OrzQQBot）验证健康状态与异常路径，心跳逻辑验证缺失应答与恢复路径
     - 对 AsyncHttp 进行重试与请求头/请求体行为验证
-- 集成测试
-    - 使用 MockBukkit 模拟 Paper 环境，验证命令与事件行为（运行：./gradlew integrationTest）
+    - 对命令拦截器（InterceptorExecutor, PlayerOnlyInterceptor, AdminOnlyInterceptor, CooldownInterceptor）分别验证
+- **集成测试**
+    - 使用 MockBukkit 模拟 Paper 环境，验证命令与事件完整链路（运行：`./gradlew integrationTest`）
     - 对高频事件（TNT/爆炸）启用 ThrottledLogger/Notifier 限流，验证日志与通知频率
+
+## 关键文件索引
+
+| 层级 | 路径 | 说明 |
+|------|------|------|
+| 入口 | `src/main/java/.../orzmc/OrzMC.java` | JavaPlugin 入口 |
+| 组合根 | `src/main/java/.../orzmc/OrzServices.java` | 模块装配与生命周期 |
+| 模块 | `assembly/PlatformModule.java` | 平台基础设施 |
+| 模块 | `assembly/BotModule.java` | 机器人消息模块 |
+| 模块 | `assembly/PortalModule.java` | 传送门模块 |
+| 模块 | `assembly/MaintenanceModule.java` | 维护模块 |
+| 模块 | `assembly/FeatureModule.java` | 功能模块（注册命令/事件） |
+| 事件 | `events/` | 事件适配层（9 个监听器） |
+| 命令 | `commands/` | 命令适配层（6 个执行器） |
+| 配置 | `infra/config/configs/` | 类型化配置记录类（14 个） |
+| 拦截器 | `features/command/binding/` | 命令拦截器（4 个 + InterceptorExecutor） |
+| 绑定 | `infra/binding/CommandBinder.java` | CommandMap API 注册 |
+| 绑定 | `infra/binding/EventBinder.java` | 事件监听器注册 |
+| 端口 | `orzmc-api/src/main/java/.../orzmc/core/ports/` | 纯 Java 接口 |
+| 消息 | `orzmc-api/src/main/java/.../orzmc/core/bot/` | 消息模型 |
+| 配置 | `src/main/resources/paper-plugin.yml`  | Paper 插件声明（替代旧 plugin.yml） |

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,7 @@
 
 ## 环境要求
 
-- Java 25（CI 与 integrationTest 固定使用 Java 25）
+- **Java 25**（CI 与 integrationTest 固定使用 Java 25；如果默认 JDK 版本较高，通过 `JAVA_HOME=/path/to/jdk25 ./gradlew ...` 指定）
 
 ## 使用 Gradle 构建
 
@@ -44,13 +44,19 @@ $ ./gradlew test
 
 配置与模板的冒烟测试会直接读取 resources 下的默认配置，确保类型化映射与模板解析可用。
 
-代码格式检查：
+代码格式检查（Palantir 风格，使用 spotless 8.6.0 + Palantir 2.93.0）：
 
 ```bash
 $ ./gradlew spotlessCheck
 ```
 
-对齐 CI 的一键检查：
+自动修复格式问题：
+
+```bash
+$ ./gradlew spotlessApply
+```
+
+对齐 CI 的一键检查（spotless + test + integrationTest + shadowJar）：
 
 ```bash
 $ ./gradlew check

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -22,8 +22,13 @@
 - 新配置先写入 resources 默认配置，并在 TypedConfigs 中建立类型映射，透出到 TypedConfigProvider
 - 旧配置废弃需给出迁移说明与默认兼容策略
 
+## 版本发布
+
+- 推送 Strict SemVer 标签（如 `1.0.0`，**无 `v` 前缀**）到 GitHub 自动触发 CI 构建并创建 GitHub Release
+- 版本命名规则见 CLAUDE.md
+
 ## 质量与验证
 
-- 本地构建：./gradlew spotlessApply && ./gradlew build
+- 本地构建：`./gradlew spotlessApply && ./gradlew build`
 - 关键流程需补齐日志与通知事件（如维护、玩家上下线）
-- 变更 README 同步更新功能与配置说明
+- 变更需同步更新 README 文档中的功能与配置说明


### PR DESCRIPTION
全量审查并更新文档以对齐项目最新代码状态：

- **README.md**: 补全 $e 命令、/orzmc 管理命令、修复仓库 URL
- **docs/architecture.md**: 重写——修正序列图、方法名、拦截器路径、配置记录类拆分
- **CLAUDE.md**: 配置记录类引用更新
- **docs/development.md**: 补充 spotlessApply、Java 25 说明
- **docs/governance.md**: 补充版本发布规则
- **CONTRIBUTING.md**: Issue 链接更新