### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,14 @@ jobs:
 
       - name: bump version (tag only)
         if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git fetch origin main
-          git checkout main
+
+          # 从 tag 创建 Bump 分支
+          BRANCH="bump-version-${{ github.ref_name }}"
+          git checkout -b "$BRANCH" main
 
           # 读取当前版本，递增 patch
           CURRENT=$(yq '.version' src/main/resources/paper-plugin.yml)
@@ -60,4 +65,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/main/resources/paper-plugin.yml
           git commit -m "chore: bump version to $NEW"
-          git push
+          git push origin "$BRANCH"
+
+          # 创建 Bump PR 并设置为自动合并
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: bump version to $NEW" \
+            --body "Automated version bump after release ${{ github.ref_name }}" \
+            --auto --merge

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,6 +1,6 @@
 # paper-plugin.yml: https://docs.papermc.io/paper/dev/paper-plugin-yml
 name: OrzMC
-version: 1.0.1
+version: 1.0.2
 main: com.jokerhub.paper.plugin.orzmc.OrzMC
 description: OrzMC for Paper Server Plugin
 authors: [ wangzhizhou ]


### PR DESCRIPTION
手动版本 bump：上次发布 1.0.1 后 CI 自动 bump 因分支保护规则失败，因此手动提升至 1.0.2。