### PR TITLE
fix: IP 黑名单重启后无法加载数据导致文件清空

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/BlacklistService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/BlacklistService.java
@@ -5,7 +5,6 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
 public final class BlacklistService {
@@ -67,9 +66,8 @@ public final class BlacklistService {
     private List<String> loadPatterns() {
         FileConfiguration cfg = configService.getConfig(CONFIG_NAME);
         if (cfg == null) return List.of();
-        ConfigurationSection section = cfg.getConfigurationSection(CONFIG_NAME);
-        return com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpBlacklist.from(section)
-                .patterns();
+        List<String> list = cfg.getStringList(CONFIG_NAME);
+        return Collections.unmodifiableList(list);
     }
 
     private void persist(List<String> list) {

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/BlacklistServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/BlacklistServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
 import java.util.List;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,17 +15,15 @@ class BlacklistServiceTest {
 
     private ConfigService configService;
     private FileConfiguration fileConfig;
-    private ConfigurationSection section;
     private BlacklistService service;
 
     @BeforeEach
     void setUp() {
         configService = mock(ConfigService.class);
         fileConfig = mock(FileConfiguration.class);
-        section = mock(ConfigurationSection.class);
 
         when(configService.getConfig("ip_blacklist")).thenReturn(fileConfig);
-        when(fileConfig.getConfigurationSection("ip_blacklist")).thenReturn(section);
+        when(fileConfig.getStringList("ip_blacklist")).thenReturn(List.of());
 
         service = new BlacklistService(configService);
     }
@@ -173,7 +170,7 @@ class BlacklistServiceTest {
     // ---- helper ----
 
     private void setupPatterns(String... patterns) {
-        when(section.get("ip_blacklist")).thenReturn(java.util.List.of(patterns));
+        when(fileConfig.getStringList("ip_blacklist")).thenReturn(java.util.List.of(patterns));
         service.reload();
     }
 }


### PR DESCRIPTION
## 问题

IP 黑名单在服务器重启后数据丢失，`ip_blacklist.yml` 文件内容被清空。

## 根因

`BlacklistService.persist()` 将 IP 列表保存为 YAML List 类型：

```java
cfg.set("ip_blacklist", new ArrayList<>(list));  // -> ip_blacklist: [val1, val2]
```

但 `loadPatterns()` 使用 `getConfigurationSection()` 读取，当路径值为 List 类型时返回 `null`，导致启动时加载为空列表。

```java
// 修改前
ConfigurationSection section = cfg.getConfigurationSection("ip_blacklist");  // null!
return IpBlacklist.from(section).patterns();  // 返回空列表
```

## 连锁效应

1. 重启后黑名单加载为空 → `BlacklistService.patterns = []`
2. 此后任何 `add()` 调用都基于空列表追加 + 覆盖写入文件，丢失已有数据
3. 多次重启+添加后文件内容完全变空

## 修复

`loadPatterns()` 改为直接使用 `getStringList()` 读取，读写路径一致：

```java
// 修改后
List<String> list = cfg.getStringList("ip_blacklist");
return Collections.unmodifiableList(list);
```

## 其他排查

已检查所有可能导致文件变空的路径（`/config set`、`reloadConfig`、`saveDirtyConfigs`、多线程竞争等），确认仅此一处 bug。