### PR TITLE
fix: publish workflow bump 分支从 origin/main 创建

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
           # 从 tag 创建 Bump 分支
           BRANCH="bump-version-${{ github.ref_name }}"
-          git checkout -b "$BRANCH" main
+          git checkout -b "$BRANCH" origin/main
 
           # 读取当前版本，递增 patch
           CURRENT=$(yq '.version' src/main/resources/paper-plugin.yml)


### PR DESCRIPTION
git fetch origin main 后本地没有 main 分支，git checkout -b 使用的 main 作为起始点不存在，导致 release tag CI 的 bump 步骤失败。

修改：main -> origin/main