### PR TITLE
fix: resolve deprecation and removal compilation warnings

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalLabelRenderer.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalLabelRenderer.java
@@ -88,8 +88,8 @@ public final class PortalLabelRenderer {
         }
         if (signBlock.getState() instanceof Sign sign) {
             SignSide front = sign.getSide(Side.FRONT);
-            front.setLine(0, "传送门");
-            front.setLine(1, host + ":" + port);
+            front.line(0, Component.text("传送门"));
+            front.line(1, Component.text(host + ":" + port));
             sign.update(true, false);
         }
     }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/TestRegistryAccess.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/TestRegistryAccess.java
@@ -57,6 +57,7 @@ public class TestRegistryAccess implements RegistryAccess {
 
     @Override
     @Deprecated
+    @SuppressWarnings("removal")
     public <T extends Keyed> Registry<T> getRegistry(final Class<T> type) {
         return emptyRegistry();
     }
@@ -254,6 +255,7 @@ public class TestRegistryAccess implements RegistryAccess {
     // stub menu type
     // ---------------------------------------------------------------
 
+    @SuppressWarnings({"deprecation", "removal"})
     private static final class StubMenuType
             implements MenuType.Typed<InventoryView, InventoryViewBuilder<InventoryView>> {
         private final NamespacedKey key;
@@ -310,6 +312,7 @@ public class TestRegistryAccess implements RegistryAccess {
     // stub item type
     // ---------------------------------------------------------------
 
+    @SuppressWarnings({"deprecation", "removal"})
     private static final class StubItemType implements ItemType {
         private final NamespacedKey key;
         private final @Nullable Material material;
@@ -543,6 +546,7 @@ public class TestRegistryAccess implements RegistryAccess {
     // stub block type
     // ---------------------------------------------------------------
 
+    @SuppressWarnings({"deprecation", "removal"})
     private static final class StubBlockType implements BlockType {
         private final NamespacedKey key;
 
@@ -688,6 +692,7 @@ public class TestRegistryAccess implements RegistryAccess {
     // stub enchantment
     // ---------------------------------------------------------------
 
+    @SuppressWarnings({"deprecation", "removal"})
     private static final class StubEnchantment extends Enchantment {
         private final NamespacedKey key;
 
@@ -839,6 +844,7 @@ public class TestRegistryAccess implements RegistryAccess {
     // map-backed registry
     // ---------------------------------------------------------------
 
+    @SuppressWarnings({"deprecation", "removal"})
     private static final class MapBackedRegistry<T extends Keyed> implements Registry<T> {
         private final Map<NamespacedKey, T> entries;
 
@@ -935,7 +941,7 @@ public class TestRegistryAccess implements RegistryAccess {
     // empty fallback registry
     // ---------------------------------------------------------------
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({"rawtypes", "deprecation", "removal"})
     private static final Registry EMPTY = new Registry<Keyed>() {
         @Override
         public Iterator<Keyed> iterator() {


### PR DESCRIPTION
## 修复内容

清除 > Task :checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :orzmc-api:compileJava UP-TO-DATE
> Task :compileKotlin NO-SOURCE
> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :jar SKIPPED
> Task :compileTestKotlin NO-SOURCE
> Task :compileTestJava UP-TO-DATE
> Task :processTestResources UP-TO-DATE
> Task :testClasses UP-TO-DATE
> Task :orzmc-api:processResources NO-SOURCE
> Task :orzmc-api:classes UP-TO-DATE
> Task :orzmc-api:jar UP-TO-DATE
> Task :test UP-TO-DATE
> Task :compileIntegrationTestKotlin NO-SOURCE
> Task :compileIntegrationTestJava UP-TO-DATE
> Task :processIntegrationTestResources NO-SOURCE
> Task :integrationTestClasses UP-TO-DATE
> Task :integrationTest UP-TO-DATE
> Task :spotlessJava UP-TO-DATE
> Task :spotlessJavaCheck UP-TO-DATE
> Task :spotlessCheck UP-TO-DATE
> Task :jacocoTestReport UP-TO-DATE
> Task :check UP-TO-DATE
> Task :orzmc-api:compileTestJava UP-TO-DATE
> Task :orzmc-api:processTestResources NO-SOURCE
> Task :orzmc-api:testClasses UP-TO-DATE
> Task :orzmc-api:test UP-TO-DATE
> Task :orzmc-api:check UP-TO-DATE

BUILD SUCCESSFUL in 823ms
14 actionable tasks: 14 up-to-date 中所有 29 个编译警告（deprecation + removal），构建输出零警告。

### PortalLabelRenderer.java（2 个 deprecation 警告）

`SignSide.setLine(int, String)` 已废弃，替换为 `SignSide.line(int, Component)` 现代 API。

### TestRegistryAccess.java（27 个 deprecation/removal 警告）

测试桩类（StubMenuType, StubItemType, StubBlockType, StubEnchantment, MapBackedRegistry, EMPTY registry）因必须实现 Paper API 接口的已弃用/待移除方法而产生警告。添加 `@SuppressWarnings({deprecation, removal})` 注解至类级别抑制这些不可避免的警告。

## 验证

- `./gradlew check` — BUILD SUCCESSFUL, 0 warnings ✅
- spotlessCheck 通过 ✅
- 所有单元测试 + 集成测试通过 ✅