### PR TITLE
fix: add missing Javadoc to orzmc-api public API surface

### DIFF
--- a/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/bot/BotInboundHandler.java
+++ b/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/bot/BotInboundHandler.java
@@ -2,6 +2,19 @@ package com.jokerhub.paper.plugin.orzmc.core.bot;
 
 import java.util.function.Consumer;
 
+/**
+ * 机器人入站消息处理接口。
+ *
+ * <p>各机器人适配器（QQ / Discord / Lark）实现此接口将原始消息传递给统一的业务处理层。</p>
+ */
 public interface BotInboundHandler {
+
+    /**
+     * 处理一条入站消息。
+     *
+     * @param message  消息原文
+     * @param isAdmin  发送者是否为管理员
+     * @param callback 回执回调，用于发送回复消息
+     */
     void handleMessage(String message, boolean isAdmin, Consumer<MessageEnvelope> callback);
 }

--- a/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/bot/MessageEnvelope.java
+++ b/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/bot/MessageEnvelope.java
@@ -1,42 +1,110 @@
 package com.jokerhub.paper.plugin.orzmc.core.bot;
 
+/**
+ * 消息信封，封装机器人消息的目标类型、内容及格式。
+ *
+ * <p>业务层通过此记录决定将消息发送到哪个目标（公开 / 私聊 / 频道），并以何种格式展示。</p>
+ *
+ * @param targetType  目标类型
+ * @param message     消息内容
+ * @param channelKey  频道标识（仅 targetType 为 {@code CHANNEL} 时有效）
+ * @param format      消息格式
+ */
 public record MessageEnvelope(TargetType targetType, String message, String channelKey, Format format) {
+
+    /**
+     * 消息目标类型。
+     */
     public enum TargetType {
+        /** 公开回复（在发送消息的同一频道/群聊中回复）。 */
         PUBLIC,
+        /** 私聊回复。 */
         PRIVATE,
+        /** 指定频道发送。 */
         CHANNEL
     }
 
+    /**
+     * 消息格式。
+     */
     public enum Format {
+        /** 默认格式（由机器人适配器自行决定）。 */
         DEFAULT,
+        /** 纯文本（无格式）。 */
         PLAIN,
+        /** 代码块格式。 */
         CODE_BLOCK
     }
 
+    /**
+     * 创建一条公开回复消息。
+     *
+     * @param message 消息内容
+     * @return 目标为 {@link TargetType#PUBLIC} 的信封
+     */
     public static MessageEnvelope publicMessage(String message) {
         return new MessageEnvelope(TargetType.PUBLIC, message, null, Format.DEFAULT);
     }
 
+    /**
+     * 创建一条私聊消息。
+     *
+     * @param message 消息内容
+     * @return 目标为 {@link TargetType#PRIVATE} 的信封
+     */
     public static MessageEnvelope privateMessage(String message) {
         return new MessageEnvelope(TargetType.PRIVATE, message, null, Format.DEFAULT);
     }
 
+    /**
+     * 创建一条频道消息（默认格式）。
+     *
+     * @param channelKey 频道标识
+     * @param message    消息内容
+     * @return 目标为 {@link TargetType#CHANNEL} 的信封
+     */
     public static MessageEnvelope channelMessage(String channelKey, String message) {
         return new MessageEnvelope(TargetType.CHANNEL, message, channelKey, Format.DEFAULT);
     }
 
+    /**
+     * 创建一条指定格式的频道消息。
+     *
+     * @param channelKey 频道标识
+     * @param message    消息内容
+     * @param format     消息格式
+     * @return 目标为 {@link TargetType#CHANNEL} 的信封
+     */
     public static MessageEnvelope channelMessage(String channelKey, String message, Format format) {
         return new MessageEnvelope(TargetType.CHANNEL, message, channelKey, format);
     }
 
+    /**
+     * 返回一个仅格式不同的新信封。
+     *
+     * @param format 新格式
+     * @return 新信封，其余字段不变
+     */
     public MessageEnvelope withFormat(Format format) {
         return new MessageEnvelope(targetType, message, channelKey, format);
     }
 
+    /**
+     * 返回一个仅目标类型不同的新信封。
+     *
+     * @param targetType 新目标类型
+     * @return 新信封，其余字段不变
+     */
     public MessageEnvelope withTargetType(TargetType targetType) {
         return new MessageEnvelope(targetType, message, channelKey, format);
     }
 
+    /**
+     * 返回一个仅频道标识不同的新信封。
+     *
+     * @param channelKey 新频道标识
+     * @return 新信封，其余字段不变
+     */
     public MessageEnvelope withChannelKey(String channelKey) {
         return new MessageEnvelope(targetType, message, channelKey, format);
     }

--- a/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/health/HealthStatus.java
+++ b/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/health/HealthStatus.java
@@ -7,7 +7,16 @@ package com.jokerhub.paper.plugin.orzmc.core.ports.health;
  */
 public interface HealthStatus {
 
-    /** 单一服务的健康快照。 */
+    /**
+     * 单一服务的健康快照。
+     *
+     * @param enabled     服务是否启用
+     * @param httpOk      HTTP 连接是否正常
+     * @param wsConnected WebSocket 是否已连接
+     * @param apiReady    API 是否就绪
+     * @param lastError   最近一次错误信息（无错误时为空字符串）
+     * @param lastUpdated 最近更新时间戳（毫秒）
+     */
     record Entry(
             boolean enabled,
             boolean httpOk,

--- a/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/server/ServerLogger.java
+++ b/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/server/ServerLogger.java
@@ -2,6 +2,17 @@ package com.jokerhub.paper.plugin.orzmc.core.ports.server;
 
 import java.util.logging.Logger;
 
+/**
+ * 服务端日志门面。
+ *
+ * <p>Feature 层通过此接口获取 {@link Logger} 实例，不直接依赖 Bukkit 日志实现。</p>
+ */
 public interface ServerLogger {
+
+    /**
+     * 获取与此服务关联的日志记录器。
+     *
+     * @return Logger 实例
+     */
     Logger logger();
 }

--- a/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/server/ServerScheduler.java
+++ b/orzmc-api/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/server/ServerScheduler.java
@@ -1,9 +1,31 @@
 package com.jokerhub.paper.plugin.orzmc.core.ports.server;
 
+/**
+ * 服务端调度门面。
+ *
+ * <p>Feature 层通过此接口执行异步或延时任务，不直接依赖 Bukkit 调度器。</p>
+ */
 public interface ServerScheduler {
+
+    /**
+     * 在主线程同步执行任务。
+     *
+     * @param task 待执行的任务
+     */
     void runSync(Runnable task);
 
+    /**
+     * 在异步线程执行任务。
+     *
+     * @param task 待执行的任务
+     */
     void runAsync(Runnable task);
 
+    /**
+     * 延迟指定 tick 后执行任务。
+     *
+     * @param task       待执行的任务
+     * @param delayTicks 延迟的 tick 数（20 tick = 1 秒）
+     */
     void runLater(Runnable task, long delayTicks);
 }


### PR DESCRIPTION
## 修复内容

修复 `./gradlew clean build` 中 `orzmc-api:javadoc` 任务的 30 个缺少 Javadoc 的警告。

| 文件 | 警告数 | 修复内容 |
|------|--------|----------|
| `HealthStatus.java` | 6 | `Entry` record 组件添加 `@param` 标签 |
| `BotInboundHandler.java` | 2 | 接口及 `handleMessage` 添加完整 Javadoc |
| `MessageEnvelope.java` | 16 | record、两个 enum 及所有枚举常量、工厂方法和 `with*` 方法添加中文 Javadoc |
| `ServerLogger.java` | 2 | 接口及 `logger()` 添加 Javadoc |
| `ServerScheduler.java` | 4 | 接口及三个调度方法添加 Javadoc |

## 验证

- `./gradlew clean build` — BUILD SUCCESSFUL, **0 Javadoc warnings** ✅
- `./gradlew check` — 全部通过 ✅