### PR TITLE
fix: remove Aliyun Maven mirror to resolve CI 502 failures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,11 +31,7 @@ repositories {
         name = "sonatype"
         url = uri("https://oss.sonatype.org/content/groups/public/")
     }
-    // 官方Maven中心仓（放在阿里云镜像之前，避免 CI 被阿里云 502 阻断）
     mavenCentral()
-    // 中国大陆备用镜像站：阿里云（仅作 fallback）
-    maven("https://maven.aliyun.com/repository/central")
-    maven("https://maven.aliyun.com/repository/public")
 }
 dependencies {
     // orc-mc-api 子模块（纯 Java 端口与模型）


### PR DESCRIPTION
CI 构建因阿里云 Maven 镜像返回 502 Bad Gateway 频繁失败。移除项目内硬编码的阿里云镜像配置，改用直接的 mavenCentral()。国内开发者如需加速可在本地 `~/.gradle/init.gradle.kts` 自行配置。