### PR TITLE
chore: bump version to 1.0.4

### DIFF
--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,6 +1,6 @@
 # paper-plugin.yml: https://docs.papermc.io/paper/dev/paper-plugin-yml
 name: OrzMC
-version: 1.0.3
+version: 1.0.4
 main: com.jokerhub.paper.plugin.orzmc.OrzMC
 description: OrzMC for Paper Server Plugin
 authors: [ wangzhizhou ]


### PR DESCRIPTION
将 paper-plugin.yml 版本从 1.0.3 更新为 1.0.4，以修复 1.0.4 tag CI 中版本不匹配导致的 Hangar 发布冲突。