### PR TITLE
chore: bump version to 1.0.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,14 +51,14 @@ jobs:
           git checkout -b "$BRANCH" origin/main
 
           # 读取当前版本，递增 patch
-          CURRENT=$(yq '.version' src/main/resources/paper-plugin.yml)
+          CURRENT=$(sed -n 's/^version: *//p' src/main/resources/paper-plugin.yml)
           MAJOR=$(echo "$CURRENT" | cut -d. -f1)
           MINOR=$(echo "$CURRENT" | cut -d. -f2)
           PATCH=$(echo "$CURRENT" | cut -d. -f3)
           NEW="$MAJOR.$MINOR.$((PATCH + 1))"
 
           # 写入新版本
-          yq -i ".version = \"$NEW\"" src/main/resources/paper-plugin.yml
+          sed -i 's/^version:.*/version: '"$NEW"'/' src/main/resources/paper-plugin.yml
 
           # 提交并推送
           git config user.name "github-actions[bot]"

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,6 +1,6 @@
 # paper-plugin.yml: https://docs.papermc.io/paper/dev/paper-plugin-yml
 name: OrzMC
-version: 1.0.4
+version: 1.0.5
 main: com.jokerhub.paper.plugin.orzmc.OrzMC
 description: OrzMC for Paper Server Plugin
 authors: [ wangzhizhou ]


### PR DESCRIPTION
Automated version bump after release 1.0.4

- fix publish workflow: replace yq with sed (not installed on runner)
- bump version: 1.0.4 → 1.0.5