### PR TITLE
chore: bump version to 1.0.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,17 +60,21 @@ jobs:
           # 写入新版本
           sed -i 's/^version:.*/version: '"$NEW"'/' src/main/resources/paper-plugin.yml
 
-          # 提交并推送
+          # 提交并推送（先清理可能残留的远端分支）
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/main/resources/paper-plugin.yml
           git commit -m "chore: bump version to $NEW"
+          git push origin --delete "$BRANCH" 2>/dev/null || true
           git push origin "$BRANCH"
 
-          # 创建 Bump PR 并设置为自动合并
+          # 创建 Bump PR
           gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "chore: bump version to $NEW" \
             --body "Automated version bump after release ${{ github.ref_name }}" \
-            --auto --merge
+            2>/dev/null || true
+
+          # 启用自动合并（PR 可能已存在，忽略错误）
+          gh pr merge "$BRANCH" --auto --merge 2>/dev/null || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,12 +60,11 @@ jobs:
           # 写入新版本
           sed -i 's/^version:.*/version: '"$NEW"'/' src/main/resources/paper-plugin.yml
 
-          # 提交并推送（先清理可能残留的远端分支）
+          # 提交并推送
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/main/resources/paper-plugin.yml
           git commit -m "chore: bump version to $NEW"
-          git push origin --delete "$BRANCH" 2>/dev/null || true
           git push origin "$BRANCH"
 
           # 创建 Bump PR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,8 +72,7 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "chore: bump version to $NEW" \
-            --body "Automated version bump after release ${{ github.ref_name }}" \
-            2>/dev/null || true
+            --body "Automated version bump after release ${{ github.ref_name }}"
 
           # 启用自动合并（PR 可能已存在，忽略错误）
-          gh pr merge "$BRANCH" --auto --merge 2>/dev/null || true
+          gh pr merge "$BRANCH" --auto --merge

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,6 +1,6 @@
 # paper-plugin.yml: https://docs.papermc.io/paper/dev/paper-plugin-yml
 name: OrzMC
-version: 1.0.5
+version: 1.0.6
 main: com.jokerhub.paper.plugin.orzmc.OrzMC
 description: OrzMC for Paper Server Plugin
 authors: [ wangzhizhou ]


### PR DESCRIPTION
Manual version bump after 1.0.5 release (CI bump step failed on the previous run).