### PR TITLE
fix: add pull-requests write permission for bump version PR creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   publish:


### PR DESCRIPTION
The bump version step uses gh pr create which requires pull-requests: write permission. Previously masked by Hangar 504 failure.