### PR TITLE
fix: force-push bump branch and tolerate existing PR in bump step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,19 +104,19 @@ jobs:
           # 写入新版本
           sed -i 's/^version:.*/version: '"$NEW"'/' src/main/resources/paper-plugin.yml
 
-          # 提交并推送
+          # 提交并推送（force-push 覆盖之前失败运行残留的分支）
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/main/resources/paper-plugin.yml
           git commit -m "chore: bump version to $NEW"
-          git push origin "$BRANCH"
+          git push origin "$BRANCH" --force
 
-          # 创建 Bump PR
+          # 创建 Bump PR（PR 可能已存在，忽略错误）
           gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "chore: bump version to $NEW" \
-            --body "Automated version bump after release ${{ github.ref_name }}"
+            --body "Automated version bump after release ${{ github.ref_name }}" || true
 
-          # 启用自动合并（PR 可能已存在，忽略错误）
-          gh pr merge "$BRANCH" --auto --merge
+          # 启用自动合并
+          gh pr merge "$BRANCH" --auto --merge || true


### PR DESCRIPTION
The bump-version branch may already exist from a previous failed run, causing git push to be rejected. Use --force and add || true to gh pr create/merge.