### PR TITLE
fix: Modrinth 版本号唯一性检查 & bump version 直推 main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,28 @@ jobs:
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         run: |
+          # 计算版本号（与 build.gradle.kts 中的 shadowJarVersion 逻辑一致）
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            CURRENT_VERSION=$(sed -n 's/^version: *//p' src/main/resources/paper-plugin.yml)
+            VERSION="${CURRENT_VERSION}-dev.${{ github.run_number }}"
+          fi
+          echo "Target Modrinth version: ${VERSION}"
+
+          # 先查询 Modrinth API，检查是否已存在相同版本号。
+          # Modrinth 不保证 version_number 唯一，不主动检查会导致重复上传产生多条记录。
+          PROJECT_ID="${MODRINTH_PROJECT_ID:-r8ZufLjY}"
+          echo "::group::Check if version ${VERSION} already exists on Modrinth"
+          EXISTING=$(curl -s "https://api.modrinth.com/v2/project/${PROJECT_ID}/version" | jq --arg v "$VERSION" '[.[] | select(.version_number == $v)] | length')
+          echo "Existing versions with number '${VERSION}': ${EXISTING}"
+          echo "::endgroup::"
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "✅ Version ${VERSION} already exists on Modrinth — skipping upload"
+            exit 0
+          fi
+
           max_attempts=3
           for attempt in $(seq 1 $max_attempts); do
             echo "::group::Modrinth publish attempt ${attempt}/${max_attempts}"
@@ -128,10 +150,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           git fetch origin main
-
-          # 从 tag 创建 Bump 分支
-          BRANCH="bump-version-${{ github.ref_name }}"
-          git checkout -b "$BRANCH" origin/main
+          git checkout main
 
           # 读取当前版本，递增 patch
           CURRENT=$(sed -n 's/^version: *//p' src/main/resources/paper-plugin.yml)
@@ -143,24 +162,9 @@ jobs:
           # 写入新版本
           sed -i 's/^version:.*/version: '"$NEW"'/' src/main/resources/paper-plugin.yml
 
-          # 提交并推送（force-push 覆盖之前失败运行残留的分支）
+          # 直接提交并推送到 main
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/main/resources/paper-plugin.yml
           git commit -m "chore: bump version to $NEW"
-          git push origin "$BRANCH" --force
-
-          # 创建 Bump PR
-          # 先检查是否已存在同分支的 PR，避免重复创建
-          if gh pr list --head "$BRANCH" --json number --jq 'length > 0' | grep -q true; then
-            echo "⚠️  PR for branch $BRANCH already exists, skipping creation"
-          else
-            gh pr create \
-              --base main \
-              --head "$BRANCH" \
-              --title "chore: bump version to $NEW" \
-              --body "Automated version bump after release ${{ github.ref_name }}"
-          fi
-
-          # 启用自动合并（如果 PR 存在）
-          gh pr merge "$BRANCH" --auto --merge || true
+          git push origin main


### PR DESCRIPTION
### 修改内容

**1. Modrinth 上传前版本号唯一性检查**
- 上传前先查询 `GET /v2/project/{projectId}/version` API
- 若相同版本号已存在则跳过上传（Modrinth 不强制 version_number 唯一）
- 版本号计算逻辑与 `build.gradle.kts` 的 `shadowJarVersion` 保持一致

**2. bump version 改为直接推送到 main**
- 去掉创建分支 → PR → auto-merge 的三步流程
- 改为：`checkout main → 递增版本 → commit → push origin main`

### 发版流程对比

| 步骤 | 改前 | 改后 |
|------|------|------|
| Modrinth 重复版本 | 仅失败时被动检查返回值 | 上传前主动查 API，跳过 |
| Tag 后 bump version | 创建 PR → auto-merge | 直接 push main |