### PR TITLE
fix: bump version 回退到 PR 方式

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -150,7 +150,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           git fetch origin main
-          git checkout main
+
+          # 从 tag 创建 Bump 分支
+          BRANCH="bump-version-${{ github.ref_name }}"
+          git checkout -b "$BRANCH" origin/main
 
           # 读取当前版本，递增 patch
           CURRENT=$(sed -n 's/^version: *//p' src/main/resources/paper-plugin.yml)
@@ -162,9 +165,22 @@ jobs:
           # 写入新版本
           sed -i 's/^version:.*/version: '"$NEW"'/' src/main/resources/paper-plugin.yml
 
-          # 直接提交并推送到 main
+          # 提交并推送
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add src/main/resources/paper-plugin.yml
           git commit -m "chore: bump version to $NEW"
-          git push origin main
+          git push origin "$BRANCH" --force
+
+          # 创建 Bump PR 并启用 auto-merge
+          if gh pr list --head "$BRANCH" --json number --jq 'length > 0' | grep -q true; then
+            echo "⚠️  PR for branch $BRANCH already exists, skipping creation"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: bump version to $NEW" \
+              --body "Automated version bump after release ${{ github.ref_name }}"
+          fi
+
+          gh pr merge "$BRANCH" --auto --merge || true


### PR DESCRIPTION
### 背景

PR #132 中将 bump version 从 **创建 PR → auto-merge** 改为了 **直接 push main**，但 main 分支有 branch protection rules（必须通过 PR 合入），导致 `git push origin main` 被拒绝：

```
remote: - Changes must be made through a pull request.
remote: - Required status check "build" is expected.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

### 修复内容

将 bump version 回退到原来的 PR 方式：推分支 → 创建 PR → 启用 auto-merge。CI 自动合并后会触发主分支的 publish.yml 推送 dev 快照。

### 保留的改动

Modrinth 上传前版本号唯一性检查（API 预查询）保持不变。