### PR TITLE
fix: GeoIP 区域拦截改为阻塞等待查询结果并加超时告警

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
@@ -56,15 +56,14 @@ public class OrzPlayerEvent extends OrzBaseListener {
         if (ipAddress.isEmpty()) {
             return;
         }
-        geoIpAccessService
-                .decide(ipAddress)
-                .thenAccept(decision -> {
-                    service.handleGeoIpDecision(event, playerName, ipAddress, decision);
-                })
-                .exceptionally(e -> {
-                    service.handleGeoIpException(e);
-                    return null;
-                });
+        // 阻塞等待本次查询结果：只在异步处理器线程上等待，不阻塞主线程；
+        // 超时/异常由 handleGeoIpPreLogin 内部按 fail-open 放行并告警。
+        service.handleGeoIpPreLogin(
+                event,
+                playerName,
+                ipAddress,
+                geoIpAccessService.decide(ipAddress),
+                GeoIpAccessService.DECISION_TIMEOUT_MS);
     }
 
     @EventHandler

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventService.java
@@ -54,7 +54,7 @@ public final class PlayerEventService {
         vars.put("ip", ipAddress);
         vars.put("country_code", decision.countryCode());
         vars.put("allow_list", String.join(",", decision.allowList()));
-        vars.put("address_info", decision.rawJson());
+        vars.put("address_info", formatAddressInfo(decision.rawJson()));
         MessageEnvelope envelope = configs.renderEvent("geoip_block", vars);
         notifier.event("geoip_block", envelope);
         event.disallow(
@@ -63,12 +63,67 @@ public final class PlayerEventService {
                         + String.join(",", decision.allowList())));
     }
 
+    /** 将 GeoIP 返回的原始 JSON 格式化为可读的多行形式；空或非法内容原样返回。 */
+    static String formatAddressInfo(String rawJson) {
+        if (rawJson == null || rawJson.isBlank()) {
+            return "";
+        }
+        try {
+            return new com.google.gson.GsonBuilder()
+                    .setPrettyPrinting()
+                    .create()
+                    .toJson(com.google.gson.JsonParser.parseString(rawJson));
+        } catch (com.google.gson.JsonSyntaxException e) {
+            return rawJson;
+        }
+    }
+
     public void handleGeoIpException(Throwable e) {
         String msgText = "IP地址解析服务异常: " + e.toString();
         server.logger().warning(msgText);
         MessageEnvelope envelope = configs.renderEvent(
                 "exception_alert",
                 java.util.Map.of("message", msgText, "stack_summary", ExceptionFormatter.summarize(e)));
+        notifier.event("exception_alert", envelope);
+    }
+
+    /**
+     * 阻塞等待 GeoIP 决策结果并据此放行/拦截。
+     *
+     * <p>在异步的 AsyncPlayerPreLoginEvent 处理器内调用：只阻塞当前 netty 线程，
+     * 不会阻塞主线程。超时未取到结果或查询异常均 fail-open 放行，但告警到日志与群。</p>
+     *
+     * @param decisionFuture GeoIP 查询的异步结果
+     * @param timeoutMs 阻塞等待上限，超过则按超时处理
+     */
+    public void handleGeoIpPreLogin(
+            AsyncPlayerPreLoginEvent event,
+            String playerName,
+            String ipAddress,
+            java.util.concurrent.CompletableFuture<GeoIpAccessService.Decision> decisionFuture,
+            long timeoutMs) {
+        GeoIpAccessService.Decision decision;
+        try {
+            decision = decisionFuture.get(timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS);
+        } catch (java.util.concurrent.TimeoutException e) {
+            handleGeoIpTimeout(playerName, ipAddress, timeoutMs);
+            return;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            handleGeoIpException(e);
+            return;
+        } catch (Exception e) {
+            handleGeoIpException(e);
+            return;
+        }
+        handleGeoIpDecision(event, playerName, ipAddress, decision);
+    }
+
+    public void handleGeoIpTimeout(String playerName, String ipAddress, long timeoutMs) {
+        String msgText = "IP地址解析超时(" + timeoutMs + "ms)，已放行: " + playerName + "(" + ipAddress + ")";
+        server.logger().warning(msgText);
+        MessageEnvelope envelope = configs.renderEvent(
+                "exception_alert", java.util.Map.of("message", msgText, "stack_summary", "geoip lookup timeout"));
         notifier.event("exception_alert", envelope);
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/GeoIpAccessService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/GeoIpAccessService.java
@@ -6,6 +6,14 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public final class GeoIpAccessService {
+    /**
+     * 单次登录时 GeoIP 查询的阻塞等待上限（毫秒）。
+     *
+     * <p>阻塞发生在异步的 AsyncPlayerPreLoginEvent 处理器线程（netty 线程），不会阻塞主线程。
+     * 超时未拿到结果则 fail-open 放行，并告警到日志与群。</p>
+     */
+    public static final long DECISION_TIMEOUT_MS = 3_000L;
+
     public record Decision(boolean allowed, String countryCode, List<String> allowList, String rawJson) {}
 
     private final GeoIpClient client;

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzDebugEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzDebugEventTest.java
@@ -1,0 +1,88 @@
+package com.jokerhub.paper.plugin.orzmc.events;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.core.bot.BotInboundHandler;
+import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import org.bukkit.Server;
+import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+class OrzDebugEventTest extends ServiceTestBase {
+
+    @Mock
+    private OrzMC plugin;
+
+    @Mock
+    private BotInboundHandler inboundHandler;
+
+    @Mock
+    private ServerCommandEvent event;
+
+    @Mock
+    private Server server;
+
+    @Mock
+    private BukkitScheduler scheduler;
+
+    private OrzDebugEvent listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new OrzDebugEvent(plugin, inboundHandler);
+        OrzDebugEvent.debug = false;
+    }
+
+    @AfterEach
+    void tearDown() {
+        OrzDebugEvent.debug = false;
+    }
+
+    @Test
+    void cmdDebugHandler_nonDebugCommand_ignored() {
+        when(event.getCommand()).thenReturn("say hello");
+
+        listener.cmdDebugHandler(event);
+
+        assertFalse(OrzDebugEvent.debug);
+        verifyNoInteractions(inboundHandler, plugin);
+    }
+
+    @Test
+    void cmdDebugHandler_debugCommand_setsFlagAndDispatchesAsync() {
+        when(event.getCommand()).thenReturn("debug hello $a");
+        when(plugin.getServer()).thenReturn(server);
+        when(server.getScheduler()).thenReturn(scheduler);
+
+        listener.cmdDebugHandler(event);
+
+        assertTrue(OrzDebugEvent.debug);
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).runTaskAsynchronously(eq(plugin), captor.capture());
+        captor.getValue().run();
+        verify(inboundHandler).handleMessage(eq("hello $a"), eq(true), any());
+    }
+
+    @Test
+    void cmdDebugHandler_debugCommandEmptyBody_dispatchesEmpty() {
+        when(event.getCommand()).thenReturn("debug   ");
+        when(plugin.getServer()).thenReturn(server);
+        when(server.getScheduler()).thenReturn(scheduler);
+
+        listener.cmdDebugHandler(event);
+
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).runTaskAsynchronously(eq(plugin), captor.capture());
+        captor.getValue().run();
+        verify(inboundHandler).handleMessage(eq(""), eq(true), any());
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEventTest.java
@@ -1,0 +1,138 @@
+package com.jokerhub.paper.plugin.orzmc.events;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.features.guide.GuideService;
+import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
+import com.jokerhub.paper.plugin.orzmc.features.player.PlayerEventService;
+import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
+import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
+import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import java.net.InetAddress;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import net.kyori.adventure.text.Component;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class OrzPlayerEventTest extends ServiceTestBase {
+
+    @Mock
+    private OrzMC plugin;
+
+    @Mock
+    private GeoIpAccessService geoIpAccessService;
+
+    @Mock
+    private BlacklistService blacklistService;
+
+    @Mock
+    private PlayerEventService service;
+
+    @Mock
+    private GuideService guideService;
+
+    @Mock
+    private OrzTextStyles styles;
+
+    @Mock
+    private WorldMaintenanceService maintenanceService;
+
+    @Mock
+    private AsyncPlayerPreLoginEvent event;
+
+    @Mock
+    private PlayerProfile profile;
+
+    private OrzPlayerEvent listener;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(event.getLoginResult()).thenReturn(AsyncPlayerPreLoginEvent.Result.ALLOWED);
+        when(event.getAddress()).thenReturn(InetAddress.getByName("1.2.3.4"));
+        when(event.getPlayerProfile()).thenReturn(profile);
+        when(profile.getName()).thenReturn("player1");
+        when(maintenanceService.isRunning()).thenReturn(false);
+        when(blacklistService.isBlocked(anyString())).thenReturn(false);
+        when(styles.warn(anyString())).thenReturn(Component.text("warn"));
+        when(styles.error(anyString())).thenReturn(Component.text("error"));
+
+        listener = new OrzPlayerEvent(
+                plugin, geoIpAccessService, blacklistService, service, guideService, styles, maintenanceService);
+    }
+
+    @Test
+    void onPlayerPreLogin_maintenance_disallowsAndSkipsChecks() {
+        when(maintenanceService.isRunning()).thenReturn(true);
+
+        listener.onPlayerPreLogin(event);
+
+        verify(event).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+        verifyNoInteractions(geoIpAccessService, blacklistService, service);
+    }
+
+    @Test
+    void onPlayerPreLogin_alreadyDisallowed_returnsEarly() {
+        when(event.getLoginResult()).thenReturn(AsyncPlayerPreLoginEvent.Result.KICK_BANNED);
+
+        listener.onPlayerPreLogin(event);
+
+        verifyNoInteractions(geoIpAccessService, blacklistService, service);
+        verify(event, never()).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+    }
+
+    @Test
+    void onPlayerPreLogin_blacklisted_disallowsAndSkipsGeoIp() {
+        when(blacklistService.isBlocked("1.2.3.4")).thenReturn(true);
+
+        listener.onPlayerPreLogin(event);
+
+        verify(event).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+        verifyNoInteractions(geoIpAccessService, service);
+    }
+
+    @Test
+    void onPlayerPreLogin_emptyIp_skipsGeoIp() {
+        InetAddress emptyAddr = mock(InetAddress.class);
+        when(emptyAddr.getHostAddress()).thenReturn("");
+        when(event.getAddress()).thenReturn(emptyAddr);
+
+        listener.onPlayerPreLogin(event);
+
+        verify(blacklistService).isBlocked("");
+        verifyNoInteractions(geoIpAccessService, service);
+        verify(event, never()).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+    }
+
+    @Test
+    void onPlayerPreLogin_geoIpBlocked_forwardsDecision() {
+        when(geoIpAccessService.decide("1.2.3.4"))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new GeoIpAccessService.Decision(false, "US", List.of("CN"), "{}")));
+
+        listener.onPlayerPreLogin(event);
+
+        verify(service)
+                .handleGeoIpPreLogin(
+                        eq(event), eq("player1"), eq("1.2.3.4"), any(), eq(GeoIpAccessService.DECISION_TIMEOUT_MS));
+    }
+
+    @Test
+    void onPlayerPreLogin_geoIpAllowed_forwardsDecision() {
+        when(geoIpAccessService.decide("1.2.3.4"))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new GeoIpAccessService.Decision(true, "CN", List.of("CN"), "{}")));
+
+        listener.onPlayerPreLogin(event);
+
+        verify(service)
+                .handleGeoIpPreLogin(
+                        eq(event), eq("player1"), eq("1.2.3.4"), any(), eq(GeoIpAccessService.DECISION_TIMEOUT_MS));
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzTPEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzTPEventTest.java
@@ -1,0 +1,61 @@
+package com.jokerhub.paper.plugin.orzmc.events;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import java.util.logging.Logger;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Tameable;
+import org.bukkit.event.entity.EntityTeleportEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class OrzTPEventTest extends ServiceTestBase {
+
+    @Mock
+    private OrzMC plugin;
+
+    @Mock
+    private ServerFacade server;
+
+    @Mock
+    private EntityTeleportEvent event;
+
+    @Mock
+    private Logger logger;
+
+    private OrzTPEvent listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new OrzTPEvent(plugin, server);
+    }
+
+    @Test
+    void onEntityTeleport_disallowedEntity_cancelsAndLogs() {
+        Entity entity = mock(Entity.class);
+        when(event.getEntity()).thenReturn(entity);
+        when(entity.getName()).thenReturn("zombie");
+        when(server.logger()).thenReturn(logger);
+
+        listener.onEntityTeleport(event);
+
+        verify(event).setCancelled(true);
+        verify(logger).info(contains("实体传送被禁用"));
+    }
+
+    @Test
+    void onEntityTeleport_tameableEntity_doesNothing() {
+        Tameable tameable = mock(Tameable.class);
+        when(event.getEntity()).thenReturn(tameable);
+
+        listener.onEntityTeleport(event);
+
+        verify(event, never()).setCancelled(anyBoolean());
+        verifyNoInteractions(server);
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventServiceTest.java
@@ -1,5 +1,7 @@
 package com.jokerhub.paper.plugin.orzmc.features.player;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -12,6 +14,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
@@ -79,5 +82,84 @@ class PlayerEventServiceTest extends ServiceTestBase {
 
         verify(logger).warning(contains("lookup failed"));
         verify(notifier).event(eq("exception_alert"), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void handleGeoIpPreLogin_blocked_disallows() {
+        when(configs.renderEvent(eq("geoip_block"), anyMap())).thenReturn(MessageEnvelope.publicMessage("blocked"));
+        when(styles.error(anyString())).thenReturn(net.kyori.adventure.text.Component.text("error"));
+        CompletableFuture<GeoIpAccessService.Decision> future =
+                CompletableFuture.completedFuture(new GeoIpAccessService.Decision(false, "US", List.of("CN"), "{}"));
+
+        service.handleGeoIpPreLogin(loginEvent, "player1", "1.2.3.4", future, 1000);
+
+        verify(loginEvent).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+        verify(notifier).event(eq("geoip_block"), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void handleGeoIpPreLogin_allowed_doesNothing() {
+        CompletableFuture<GeoIpAccessService.Decision> future =
+                CompletableFuture.completedFuture(new GeoIpAccessService.Decision(true, "CN", List.of("CN"), "{}"));
+
+        service.handleGeoIpPreLogin(loginEvent, "player1", "1.2.3.4", future, 1000);
+
+        verifyNoInteractions(loginEvent, notifier, configs, styles);
+    }
+
+    @Test
+    void handleGeoIpPreLogin_timeout_allowsAndWarns() {
+        when(server.logger()).thenReturn(logger);
+        when(configs.renderEvent(eq("exception_alert"), anyMap())).thenReturn(MessageEnvelope.publicMessage("timeout"));
+        CompletableFuture<GeoIpAccessService.Decision> never = new CompletableFuture<>();
+
+        service.handleGeoIpPreLogin(loginEvent, "player1", "1.2.3.4", never, 50);
+
+        verify(logger).warning(contains("超时"));
+        verify(notifier).event(eq("exception_alert"), any(MessageEnvelope.class));
+        verifyNoInteractions(loginEvent);
+    }
+
+    @Test
+    void handleGeoIpPreLogin_lookupError_allowsAndWarns() {
+        when(server.logger()).thenReturn(logger);
+        when(configs.renderEvent(eq("exception_alert"), anyMap())).thenReturn(MessageEnvelope.publicMessage("error"));
+        CompletableFuture<GeoIpAccessService.Decision> failed =
+                CompletableFuture.failedFuture(new RuntimeException("boom"));
+
+        service.handleGeoIpPreLogin(loginEvent, "player1", "1.2.3.4", failed, 1000);
+
+        verify(logger).warning(contains("boom"));
+        verify(notifier).event(eq("exception_alert"), any(MessageEnvelope.class));
+        verifyNoInteractions(loginEvent);
+    }
+
+    @Test
+    void handleGeoIpTimeout_logsWarningAndNotifies() {
+        when(server.logger()).thenReturn(logger);
+        when(configs.renderEvent(eq("exception_alert"), anyMap())).thenReturn(MessageEnvelope.publicMessage("timeout"));
+
+        service.handleGeoIpTimeout("player1", "1.2.3.4", 3000);
+
+        verify(logger).warning(contains("超时"));
+        verify(notifier).event(eq("exception_alert"), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void handleGeoIpDecision_blocked_prettyPrintsAddressInfo() {
+        when(configs.renderEvent(eq("geoip_block"), anyMap())).thenReturn(MessageEnvelope.publicMessage("blocked"));
+        when(styles.error(anyString())).thenReturn(net.kyori.adventure.text.Component.text("error"));
+        String compact = "{\"ip\":\"1.2.3.4\",\"country_code\":\"US\"}";
+
+        service.handleGeoIpDecision(
+                loginEvent, "player1", "1.2.3.4", new GeoIpAccessService.Decision(false, "US", List.of("CN"), compact));
+
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<java.util.Map<String, String>> captor =
+                org.mockito.ArgumentCaptor.forClass(java.util.Map.class);
+        verify(configs).renderEvent(eq("geoip_block"), captor.capture());
+        String addressInfo = captor.getValue().get("address_info");
+        assertNotNull(addressInfo, "address_info should be present");
+        assertTrue(addressInfo.contains("\n  \"ip\""), "JSON should be pretty-printed, got: " + addressInfo);
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/guidebook/GuideBookConfigParserTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/guidebook/GuideBookConfigParserTest.java
@@ -1,0 +1,162 @@
+package com.jokerhub.paper.plugin.orzmc.infra.guidebook;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.*;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
+import com.jokerhub.paper.plugin.orzmc.infra.guidebook.models.ContentItem;
+import com.jokerhub.paper.plugin.orzmc.infra.guidebook.models.GuideBookConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.guidebook.models.LinkContent;
+import com.jokerhub.paper.plugin.orzmc.infra.guidebook.models.TextContent;
+import java.io.StringReader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class GuideBookConfigParserTest {
+
+    @Mock
+    private JavaPlugin plugin;
+
+    @Mock
+    private ConfigService configService;
+
+    @Mock
+    private Logger logger;
+
+    private GuideBookConfigParser parser;
+
+    @BeforeEach
+    void setUp() {
+        plugin = mock(JavaPlugin.class);
+        configService = mock(ConfigService.class);
+        logger = mock(Logger.class);
+        parser = new GuideBookConfigParser(plugin, configService);
+    }
+
+    private YamlConfiguration load(String yaml) {
+        return YamlConfiguration.loadConfiguration(new StringReader(yaml));
+    }
+
+    @Test
+    void parseConfig_fullConfig_parsesAllFields() {
+        String yaml = """
+                enable: true
+                title: "服务器指南"
+                author: "OrzMC"
+                content:
+                  - text:
+                      content: "欢迎"
+                      newline_count: 2
+                      page_break: true
+                      style:
+                        bold: true
+                        color: "AQUA"
+                  - link:
+                      content: "官网"
+                      url: "https://example.com"
+                      hover_text: "点击访问"
+                """;
+        when(configService.getConfig("guide_book")).thenReturn(load(yaml));
+
+        GuideBookConfig config = parser.parseConfig();
+
+        assertNotNull(config);
+        assertTrue(config.enable());
+        assertEquals("服务器指南", config.title());
+        assertEquals("OrzMC", config.author());
+        assertEquals(2, config.content().size());
+
+        ContentItem first = config.content().get(0);
+        assertTrue(first.isText());
+        TextContent text = first.getText();
+        assertEquals("欢迎", text.content());
+        assertEquals(2, text.newlineCount());
+        assertTrue(text.pageBreak());
+        assertTrue(text.style().getBold());
+        assertEquals("AQUA", text.style().getColor());
+
+        ContentItem second = config.content().get(1);
+        assertTrue(second.isLink());
+        LinkContent link = second.getLink();
+        assertEquals("官网", link.content());
+        assertEquals("https://example.com", link.url());
+        assertEquals("点击访问", link.hoverText());
+        assertFalse(link.style().getBold());
+        assertEquals("", link.style().getColor());
+    }
+
+    @Test
+    void parseConfig_minimalConfig_usesDefaults() {
+        String yaml = "content: []\n";
+        when(configService.getConfig("guide_book")).thenReturn(load(yaml));
+
+        GuideBookConfig config = parser.parseConfig();
+
+        assertNotNull(config);
+        assertTrue(config.enable(), "enable 默认应为 true");
+        assertEquals("新手指南", config.title(), "title 默认应为 新手指南");
+        assertEquals("服务器", config.author(), "author 默认应为 服务器");
+        assertTrue(config.content().isEmpty());
+    }
+
+    @Test
+    void parseConfig_unknownContentType_skipsWithWarning() {
+        when(plugin.getLogger()).thenReturn(logger);
+        String yaml = """
+                content:
+                  - foo: "bar"
+                """;
+        when(configService.getConfig("guide_book")).thenReturn(load(yaml));
+
+        GuideBookConfig config = parser.parseConfig();
+
+        assertNotNull(config);
+        assertFalse(config.content().isEmpty());
+        assertFalse(config.content().get(0).isText());
+        assertFalse(config.content().get(0).isLink());
+        verify(logger).warning(contains("类型未知"));
+    }
+
+    @Test
+    void parseConfig_textStyleUnderlined_parsed() {
+        String yaml = """
+                content:
+                  - text:
+                      content: "下划线"
+                      style:
+                        underlined: true
+                """;
+        when(configService.getConfig("guide_book")).thenReturn(load(yaml));
+
+        GuideBookConfig config = parser.parseConfig();
+
+        ContentItem item = config.content().get(0);
+        assertTrue(item.getText().style().getUnderlined());
+        assertFalse(item.getText().style().getBold());
+    }
+
+    @Test
+    void parseConfig_nonYamlConfig_returnsNull() {
+        when(configService.getConfig("guide_book")).thenReturn(mock(FileConfiguration.class));
+
+        assertNull(parser.parseConfig());
+    }
+
+    @Test
+    void parseConfig_reloadThrows_returnsNullAndLogsSevere() {
+        when(plugin.getLogger()).thenReturn(logger);
+        doThrow(new RuntimeException("io error")).when(configService).reloadConfig("guide_book");
+
+        assertNull(parser.parseConfig());
+
+        verify(logger).log(eq(Level.SEVERE), contains("guide_book"), any(Throwable.class));
+    }
+}


### PR DESCRIPTION
## 问题

`AsyncPlayerPreLoginEvent` 是异步事件，服务器在事件处理器返回后就读取登录结果，**不会等待插件注册的外部 CompletableFuture**。原实现通过 `decide().thenAccept(...)` 在 HTTP 查询完成后才调用 `event.disallow()`，几乎总是晚于服务器放行，导致**国家码不在允许列表的玩家实际仍可加入游戏**。

## 改动

- **`OrzPlayerEvent`**：`onPlayerPreLogin` 改为阻塞等待本次查询结果（阻塞在 netty 异步线程，不阻塞主线程），查询有 3s 超时上限。
- **`PlayerEventService`**：
  - 新增 `handleGeoIpPreLogin(...)`：`.get(timeoutMs)` 阻塞等待决策，超时/中断/异常分别路由；
  - 新增 `handleGeoIpTimeout(...)`：超时 **fail-open 放行**，但写后台日志 + 通过 `exception_alert` 通知群；
  - 新增 `formatAddressInfo(...)`：`geoip_block` 群消息中的原始 JSON 用 Gson 格式化为多行可读形式。
- **`GeoIpAccessService`**：新增 `DECISION_TIMEOUT_MS = 3000` 常量。

## 行为矩阵

| 场景 | 玩家能否进入 | 后台日志 | 群通知 |
|------|:---:|---|---|
| 允许的国家码 | ✅ | — | — |
| 不允许的国家码 | ❌ 被拒 | — | `geoip_block` |
| 查询超时(3s) | ✅ 放行 | warning | `exception_alert` |
| 查询异常 | ✅ 放行 | warning | `exception_alert` |

## 测试

- 新增 `handleGeoIpPreLogin` 阻塞/放行/超时/异常及 `geoip_block` JSON 格式化共 5 个用例，全部通过。
- `spotlessCheck` 通过。