### PR TITLE
feat(teleport): 实体传送可配置化——默认不禁止，开启时白名单豁免

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -29,6 +29,7 @@ import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
 import com.jokerhub.paper.plugin.orzmc.features.server.ServerEventService;
 import com.jokerhub.paper.plugin.orzmc.features.server.ServerFeedbackService;
 import com.jokerhub.paper.plugin.orzmc.features.server.ServerLifecycleService;
+import com.jokerhub.paper.plugin.orzmc.features.teleport.EntityTeleportPolicyService;
 import com.jokerhub.paper.plugin.orzmc.features.teleport.TeleportBowEventService;
 import com.jokerhub.paper.plugin.orzmc.features.teleport.TeleportBowService;
 import com.jokerhub.paper.plugin.orzmc.features.tnt.TntEventService;
@@ -37,6 +38,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.binding.EventBinder;
 import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigPath;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.CommandPolicies;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.CommandPolicy;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MainConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.StringArgumentType;
@@ -97,12 +99,14 @@ public final class FeatureModule implements ServiceModule {
     private final PlatformModule platform;
     private final BotModule botModule;
     private final MaintenanceModule maintenanceModule;
+    private final MainConfig mainConfig;
 
     public FeatureModule(
             PlatformModule platform,
             BotModule botModule,
             PortalModule portalModule,
             MaintenanceModule maintenanceModule) {
+        this.mainConfig = MainConfig.from(platform.configService().getConfig("config"));
         // Feature services
         this.geoIpAccessService = new GeoIpAccessService(platform.configs());
         this.blacklistService = new BlacklistService(platform.configService());
@@ -219,7 +223,11 @@ public final class FeatureModule implements ServiceModule {
                     guideService,
                     platform.textStyles(),
                     maintenanceModule.worldMaintenanceService()),
-            new OrzTPEvent(plugin, platform.serverFacade()),
+            new OrzTPEvent(
+                    plugin,
+                    platform.serverFacade(),
+                    new EntityTeleportPolicyService(
+                            mainConfig.entityTeleportEnabled(), mainConfig.entityTeleportWhitelist())),
             new OrzTNTEvent(plugin, tntEventService),
             new OrzMenuEvent(plugin, menuEventService),
             new OrzServerEvent(plugin, serverEventService),

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzTPEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzTPEvent.java
@@ -7,12 +7,13 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityTeleportEvent;
 
 public class OrzTPEvent extends OrzBaseListener {
-    private final EntityTeleportPolicyService policyService = new EntityTeleportPolicyService();
+    private final EntityTeleportPolicyService policyService;
     private final ServerFacade server;
 
-    public OrzTPEvent(OrzMC plugin, ServerFacade server) {
+    public OrzTPEvent(OrzMC plugin, ServerFacade server, EntityTeleportPolicyService policyService) {
         super(plugin);
         this.server = server;
+        this.policyService = policyService;
     }
 
     @EventHandler

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/EntityTeleportPolicyService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/EntityTeleportPolicyService.java
@@ -1,19 +1,56 @@
 package com.jokerhub.paper.plugin.orzmc.features.teleport;
 
+import java.util.List;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Enderman;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Shulker;
 import org.bukkit.entity.Tameable;
 
+/**
+ * 实体传送策略（2026-08-09 可配置化）：
+ * <ul>
+ *   <li>默认（enabled=false）不禁止——所有实体可正常传送（原版行为，兼容旧版村民过传送门等场景）</li>
+ *   <li>配置为禁止（enabled=true）时，仅白名单内实体豁免（默认白名单兼容旧逻辑：
+ *       TAMEABLE / ENDERMAN / ARMOR_STAND / SHULKER）</li>
+ * </ul>
+ * 白名单项：大写 EntityType 名（如 VILLAGER）或特殊接口键（TAMEABLE）。
+ */
 public final class EntityTeleportPolicyService {
+
+    private final boolean cancelEnabled;
+    private final List<String> whitelist;
+
+    /** 兼容旧行为：禁止实体传送 + 旧白名单（历史默认）。 */
+    public EntityTeleportPolicyService() {
+        this(true, List.of("TAMEABLE", "ENDERMAN", "ARMOR_STAND", "SHULKER"));
+    }
+
+    public EntityTeleportPolicyService(boolean cancelEnabled, List<String> whitelist) {
+        this.cancelEnabled = cancelEnabled;
+        this.whitelist = whitelist == null ? List.of() : List.copyOf(whitelist);
+    }
+
     public boolean shouldCancel(Entity entity) {
-        if (entity instanceof Tameable) {
+        if (!cancelEnabled) {
             return false;
         }
-        if (entity instanceof Enderman || entity instanceof ArmorStand || entity instanceof Shulker) {
-            return false;
+        for (String w : whitelist) {
+            if (matches(entity, w)) {
+                return false;
+            }
         }
         return true;
+    }
+
+    private boolean matches(Entity entity, String whitelistEntry) {
+        String key = whitelistEntry == null ? "" : whitelistEntry.trim().toUpperCase();
+        return switch (key) {
+            case "TAMEABLE" -> entity instanceof Tameable;
+            case "ENDERMAN" -> entity instanceof Enderman;
+            case "ARMOR_STAND" -> entity instanceof ArmorStand;
+            case "SHULKER" -> entity instanceof Shulker;
+            default -> entity.getType().name().equals(key);
+        };
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/MainConfig.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/MainConfig.java
@@ -16,6 +16,8 @@ public record MainConfig(
         int backupRetentionCount,
         String backupMaintenanceMotd,
         List<String> allowCountryCode,
+        boolean entityTeleportEnabled,
+        List<String> entityTeleportWhitelist,
         Map<String, CommandPolicy> commandPolicies) {
 
     public static MainConfig from(ConfigurationSection cfg) {
@@ -33,6 +35,11 @@ public record MainConfig(
             for (Object o : list) {
                 if (o != null) allowCodes.add(String.valueOf(o));
             }
+        }
+        boolean entityTeleportEnabled = cfg.getBoolean("entity_teleport_enabled", false);
+        List<String> entityTeleportWhitelist = new ArrayList<>(cfg.getStringList("entity_teleport_whitelist"));
+        if (entityTeleportWhitelist.isEmpty()) {
+            entityTeleportWhitelist.addAll(List.of("TAMEABLE", "ENDERMAN", "ARMOR_STAND", "SHULKER"));
         }
         Map<String, CommandPolicy> policies = new HashMap<>();
         Object rawCmds = cfg.get("commands");
@@ -56,6 +63,8 @@ public record MainConfig(
                 backupRetentionCount,
                 backupMaintenanceMotd,
                 allowCodes,
+                entityTeleportEnabled,
+                entityTeleportWhitelist,
                 policies);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -68,6 +68,20 @@ geoip:
   allow_country_code: []
 
 # ==================================================
+#              实体传送策略（2026-08-09）
+# ==================================================
+# 默认不禁止实体传送（false = 所有实体可正常传送，兼容原版行为，
+# 如村民/动物过下界传送门）。设为 true 时仅白名单内实体可传送：
+#   - 白名单项：大写 EntityType 名（如 VILLAGER），或特殊键
+#     TAMEABLE / ENDERMAN / ARMOR_STAND / SHULKER
+entity_teleport_enabled: false
+entity_teleport_whitelist:
+  - TAMEABLE
+  - ENDERMAN
+  - ARMOR_STAND
+  - SHULKER
+
+# ==================================================
 #              命令策略
 # ==================================================
 command_policies:

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzTPEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzTPEventTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.features.teleport.EntityTeleportPolicyService;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
 import java.util.logging.Logger;
@@ -32,7 +33,7 @@ class OrzTPEventTest extends ServiceTestBase {
 
     @BeforeEach
     void setUp() {
-        listener = new OrzTPEvent(plugin, server);
+        listener = new OrzTPEvent(plugin, server, new EntityTeleportPolicyService());
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/EntityTeleportPolicyServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/EntityTeleportPolicyServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import java.util.List;
 import org.bukkit.entity.*;
 import org.junit.jupiter.api.Test;
 
@@ -39,5 +40,37 @@ class EntityTeleportPolicyServiceTest extends ServiceTestBase {
     void shouldCancel_shulker_returnsFalse() {
         Entity entity = mock(Shulker.class);
         assertFalse(service.shouldCancel(entity));
+    }
+
+    // ---- 2026-08-09 可配置化：默认不禁止（enabled=false 全放行）+ 白名单豁免 ----
+
+    @Test
+    void shouldCancel_disabled_neverCancels() {
+        EntityTeleportPolicyService disabled = new EntityTeleportPolicyService(false, List.of());
+        Entity villager = mock(Entity.class);
+        when(villager.getType()).thenReturn(EntityType.VILLAGER);
+        Entity zombie = mock(Entity.class);
+        when(zombie.getType()).thenReturn(EntityType.ZOMBIE);
+        assertFalse(disabled.shouldCancel(villager));
+        assertFalse(disabled.shouldCancel(zombie));
+    }
+
+    @Test
+    void shouldCancel_enabledWithTypeWhitelist_exemptsListedType() {
+        EntityTeleportPolicyService service = new EntityTeleportPolicyService(true, List.of("VILLAGER"));
+        Entity villager = mock(Entity.class);
+        when(villager.getType()).thenReturn(EntityType.VILLAGER);
+        Entity zombie = mock(Entity.class);
+        when(zombie.getType()).thenReturn(EntityType.ZOMBIE);
+        assertFalse(service.shouldCancel(villager));
+        assertTrue(service.shouldCancel(zombie));
+    }
+
+    @Test
+    void shouldCancel_enabledEmptyWhitelist_cancelsEverything() {
+        EntityTeleportPolicyService service = new EntityTeleportPolicyService(true, List.of());
+        Entity villager = mock(Entity.class);
+        when(villager.getType()).thenReturn(EntityType.VILLAGER);
+        assertTrue(service.shouldCancel(villager));
     }
 }


### PR DESCRIPTION
## 背景
下界传送门村民无法通过：OrzTPEvent 监听 EntityTeleportEvent（EntityPortalEvent 是其子类），
EntityTeleportPolicyService 默认取消所有非白名单实体传送。

## 方案（用户决策）
- entity_teleport_enabled 默认 false = 不禁止（所有实体可传送，兼容原版）
- 设为 true 时启用禁用逻辑，白名单内实体豁免（默认兼容旧逻辑四类）

## 验证
- 本地实测：村民过标准 4x5 下界传送门传送成功（原被禁用）
- 全量测试通过 + shadowJar