### PR TITLE
feat(maintenance): 备份/优化完成消息耗时改为中文可读格式

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
@@ -56,6 +56,37 @@ public class WorldMaintenanceService {
         return MaintenanceStage.Running;
     }
 
+    /**
+     * 将毫秒耗时格式化为中文可读形式（分级取整）：
+     * <ul>
+     *   <li>&lt; 1 秒 → {@code 854毫秒}</li>
+     *   <li>&lt; 1 分钟 → {@code 35秒}</li>
+     *   <li>&lt; 1 小时 → {@code 2分35秒}</li>
+     *   <li>≥ 1 小时 → {@code 1小时2分3秒}（整小时省略秒）</li>
+     * </ul>
+     * 秒数按四舍五入取整（154901ms → 155s → {@code 2分35秒}）。
+     */
+    public static String formatDuration(long ms) {
+        if (ms < 1000) {
+            return ms + "毫秒";
+        }
+        long totalSec = Math.round(ms / 1000.0);
+        long hours = totalSec / 3600;
+        long minutes = (totalSec % 3600) / 60;
+        long seconds = totalSec % 60;
+        StringBuilder sb = new StringBuilder();
+        if (hours > 0) {
+            sb.append(hours).append("小时");
+        }
+        if (minutes > 0) {
+            sb.append(minutes).append("分");
+        }
+        if (seconds > 0 || (hours == 0 && minutes == 0)) {
+            sb.append(seconds).append("秒");
+        }
+        return sb.toString();
+    }
+
     private static String stageDisplayCN(ProgressStage s) {
         if (s == null) return "进行中";
         String n = s.name();
@@ -118,7 +149,14 @@ public class WorldMaintenanceService {
                 long durationMs = Math.max(0, System.currentTimeMillis() - startMs);
                 String doneKey = "备份".equals(label) ? "maintenance_backup_done" : "maintenance_optimize_done";
                 MessageEnvelope done = configs.renderEvent(
-                        doneKey, java.util.Map.of("label", label, "duration_ms", String.valueOf(durationMs)));
+                        doneKey,
+                        java.util.Map.of(
+                                "label",
+                                label,
+                                "duration_ms",
+                                String.valueOf(durationMs),
+                                "duration_human",
+                                formatDuration(durationMs)));
                 callback.accept(done.message());
             }
             return Unit.INSTANCE;
@@ -131,7 +169,14 @@ public class WorldMaintenanceService {
             long durationMs = Math.max(0, System.currentTimeMillis() - startMs);
             String errKey = "备份".equals(label) ? "maintenance_backup_error" : "maintenance_optimize_error";
             MessageEnvelope err = configs.renderEvent(
-                    errKey, java.util.Map.of("label", label, "duration_ms", String.valueOf(durationMs)));
+                    errKey,
+                    java.util.Map.of(
+                            "label",
+                            label,
+                            "duration_ms",
+                            String.valueOf(durationMs),
+                            "duration_human",
+                            formatDuration(durationMs)));
             callback.accept(err.message());
             notifier.event(errKey, err);
             callback.accept("地图" + label + "失败");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
@@ -62,15 +62,16 @@ public class WorldMaintenanceService {
      *   <li>&lt; 1 秒 → {@code 854毫秒}</li>
      *   <li>&lt; 1 分钟 → {@code 35秒}</li>
      *   <li>&lt; 1 小时 → {@code 2分35秒}</li>
-     *   <li>≥ 1 小时 → {@code 1小时2分3秒}（整小时省略秒）</li>
+     *   <li>≥ 1 小时 → {@code 1小时2分3秒}（整分/整小时省略低位；如 {@code 1小时0分5秒}、{@code 2小时3分}）</li>
      * </ul>
-     * 秒数按四舍五入取整（154901ms → 155s → {@code 2分35秒}）。
+     * 秒数按四舍五入取整（154901ms → 155s → {@code 2分35秒}）；负值按 0 处理。
      */
     public static String formatDuration(long ms) {
-        if (ms < 1000) {
-            return ms + "毫秒";
+        long safeMs = Math.max(0, ms);
+        if (safeMs < 1000) {
+            return safeMs + "毫秒";
         }
-        long totalSec = Math.round(ms / 1000.0);
+        long totalSec = Math.round(safeMs / 1000.0);
         long hours = totalSec / 3600;
         long minutes = (totalSec % 3600) / 60;
         long seconds = totalSec % 60;
@@ -78,7 +79,7 @@ public class WorldMaintenanceService {
         if (hours > 0) {
             sb.append(hours).append("小时");
         }
-        if (minutes > 0) {
+        if (minutes > 0 || (hours > 0 && seconds > 0)) {
             sb.append(minutes).append("分");
         }
         if (seconds > 0 || (hours == 0 && minutes == 0)) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/Templates.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/Templates.java
@@ -40,13 +40,13 @@ public record Templates(
         String mbStage = cfg.getString(
                 base + ".maintenance_backup_stage",
                 "地图{label} 阶段:{stage}({stage_name}/{stage_i18n}) 进度:{percent}% {current}/{total} 速率:{rate_per}{rate_unit} 预计剩余:{eta_value}{eta_unit}");
-        String mbDone = cfg.getString(base + ".maintenance_backup_done", "地图{label} 完成 用时:{duration_ms}ms");
-        String mbErr = cfg.getString(base + ".maintenance_backup_error", "地图{label} 失败 用时:{duration_ms}ms");
+        String mbDone = cfg.getString(base + ".maintenance_backup_done", "地图{label} 完成 用时:{duration_human}");
+        String mbErr = cfg.getString(base + ".maintenance_backup_error", "地图{label} 失败 用时:{duration_human}");
         String moStage = cfg.getString(
                 base + ".maintenance_optimize_stage",
                 "地图{label} 阶段:{stage}({stage_name}/{stage_i18n}) 进度:{percent}% {current}/{total} 速率:{rate_per}{rate_unit} 预计剩余:{eta_value}{eta_unit}");
-        String moDone = cfg.getString(base + ".maintenance_optimize_done", "地图{label} 完成 用时:{duration_ms}ms");
-        String moErr = cfg.getString(base + ".maintenance_optimize_error", "地图{label} 失败 用时:{duration_ms}ms");
+        String moDone = cfg.getString(base + ".maintenance_optimize_done", "地图{label} 完成 用时:{duration_human}");
+        String moErr = cfg.getString(base + ".maintenance_optimize_error", "地图{label} 失败 用时:{duration_human}");
         String serverLoad = cfg.getString(base + ".server_load", "{message}");
         String serverStop = cfg.getString(base + ".server_stop", "{message}");
         String whitelistBlock = cfg.getString(base + ".whitelist_block", "{message}");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplatePlaceholderValidator.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplatePlaceholderValidator.java
@@ -134,10 +134,10 @@ public final class TemplatePlaceholderValidator {
                 "eta_unit");
         m.put("maintenance_backup_stage", progressVars);
         m.put("maintenance_optimize_stage", progressVars);
-        m.put("maintenance_backup_done", Set.of("label", "duration_ms"));
-        m.put("maintenance_backup_error", Set.of("label", "duration_ms"));
-        m.put("maintenance_optimize_done", Set.of("label", "duration_ms"));
-        m.put("maintenance_optimize_error", Set.of("label", "duration_ms"));
+        m.put("maintenance_backup_done", Set.of("label", "duration_ms", "duration_human"));
+        m.put("maintenance_backup_error", Set.of("label", "duration_ms", "duration_human"));
+        m.put("maintenance_optimize_done", Set.of("label", "duration_ms", "duration_human"));
+        m.put("maintenance_optimize_error", Set.of("label", "duration_ms", "duration_human"));
         m.put("server_load", Set.of("message"));
         m.put("server_stop", Set.of("message"));
         m.put("whitelist_block", Set.of("message"));

--- a/src/main/resources/templates.yml
+++ b/src/main/resources/templates.yml
@@ -84,11 +84,11 @@ templates:
   geoip_block: "{name}({ip}) 地区:{country_code} 不在允许列表({allow_list})\n{address_info}"
   tnt_alert: "{msg}\n世界:{world_alias} 坐标:{x_unit},{y_unit},{z_unit}({coord_unit})\n触发:{actor} 方块:{block_type}"
   maintenance_backup_stage: "地图{label} 阶段:{stage}({stage_name}/{stage_i18n}) 进度:{percent}% {current}/{total} 速率:{rate_per}{rate_unit} 预计剩余:{eta_value}{eta_unit}"
-  maintenance_backup_done: "地图{label} 完成 用时:{duration_ms}ms"
-  maintenance_backup_error: "地图{label} 失败 用时:{duration_ms}ms"
+  maintenance_backup_done: "地图{label} 完成 用时:{duration_human}"
+  maintenance_backup_error: "地图{label} 失败 用时:{duration_human}"
   maintenance_optimize_stage: "地图{label} 阶段:{stage}({stage_name}/{stage_i18n}) 进度:{percent}% {current}/{total} 速率:{rate_per}{rate_unit} 预计剩余:{eta_value}{eta_unit}"
-  maintenance_optimize_done: "地图{label} 完成 用时:{duration_ms}ms"
-  maintenance_optimize_error: "地图{label} 失败 用时:{duration_ms}ms"
+  maintenance_optimize_done: "地图{label} 完成 用时:{duration_human}"
+  maintenance_optimize_error: "地图{label} 失败 用时:{duration_human}"
   stage_cn:
     Region: 区域
     Chunk: 区块

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
@@ -34,6 +34,9 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         Assertions.assertEquals("0毫秒", WorldMaintenanceService.formatDuration(0));
         Assertions.assertEquals("854毫秒", WorldMaintenanceService.formatDuration(854));
         Assertions.assertEquals("999毫秒", WorldMaintenanceService.formatDuration(999));
+        // 负值按 0 处理
+        Assertions.assertEquals("0毫秒", WorldMaintenanceService.formatDuration(-5));
+        Assertions.assertEquals("0毫秒", WorldMaintenanceService.formatDuration(-1_000));
     }
 
     @Test
@@ -59,5 +62,9 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         Assertions.assertEquals("1小时", WorldMaintenanceService.formatDuration(3_600_000));
         Assertions.assertEquals("1小时1分1秒", WorldMaintenanceService.formatDuration(3_661_000));
         Assertions.assertEquals("2小时3分", WorldMaintenanceService.formatDuration(7_380_000));
+        // 小时>0、分钟=0、秒>0 → 补 0 分占位
+        Assertions.assertEquals("1小时0分5秒", WorldMaintenanceService.formatDuration(3_605_000));
+        // 59分59.5 秒四舍五入进位到整小时
+        Assertions.assertEquals("1小时", WorldMaintenanceService.formatDuration(3_599_500));
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
@@ -28,4 +28,36 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         File[] left = tmp.listFiles((d, n) -> n.endsWith(".zip"));
         Assertions.assertTrue(Objects.requireNonNull(left).length <= 2);
     }
+
+    @Test
+    public void formatDuration_milliseconds() {
+        Assertions.assertEquals("0毫秒", WorldMaintenanceService.formatDuration(0));
+        Assertions.assertEquals("854毫秒", WorldMaintenanceService.formatDuration(854));
+        Assertions.assertEquals("999毫秒", WorldMaintenanceService.formatDuration(999));
+    }
+
+    @Test
+    public void formatDuration_seconds() {
+        Assertions.assertEquals("1秒", WorldMaintenanceService.formatDuration(1000));
+        // 四舍五入到秒
+        Assertions.assertEquals("2秒", WorldMaintenanceService.formatDuration(1500));
+        Assertions.assertEquals("59秒", WorldMaintenanceService.formatDuration(59_000));
+        // 59.6 秒四舍五入进位为 1 分
+        Assertions.assertEquals("1分", WorldMaintenanceService.formatDuration(59_600));
+    }
+
+    @Test
+    public void formatDuration_minutes() {
+        Assertions.assertEquals("1分", WorldMaintenanceService.formatDuration(60_000));
+        // 老板示例：154901ms ≈ 2分35秒
+        Assertions.assertEquals("2分35秒", WorldMaintenanceService.formatDuration(154_901));
+        Assertions.assertEquals("59分59秒", WorldMaintenanceService.formatDuration(3_599_000));
+    }
+
+    @Test
+    public void formatDuration_hours() {
+        Assertions.assertEquals("1小时", WorldMaintenanceService.formatDuration(3_600_000));
+        Assertions.assertEquals("1小时1分1秒", WorldMaintenanceService.formatDuration(3_661_000));
+        Assertions.assertEquals("2小时3分", WorldMaintenanceService.formatDuration(7_380_000));
+    }
 }


### PR DESCRIPTION
## 背景
`$b` 备份完成后群里消息显示 `地图备份 完成 用时:154901ms`，毫秒原值可读性差，无法直观感受耗时大小。

## 改动
1. **WorldMaintenanceService.formatDuration(long ms)**：毫秒分级转中文可读格式
   - <1秒 → `854毫秒`
   - <1分 → `35秒`
   - <1小时 → `2分35秒`
   - ≥1小时 → `1小时2分3秒`（整小时省略秒）
   - 秒数四舍五入（154901ms → 155s → `2分35秒`）
2. done/error 消息新增 `duration_human` 变量（备份/优化共 4 条模板），**保留 `duration_ms` 兼容旧模板**（旧模板不受影响）
3. 模板占位符白名单（TemplatePlaceholderValidator）注册 `duration_human`
4. 默认模板 templates.yml + Templates.java fallback 改用 `{duration_human}`

## 效果
`地图备份 完成 用时:154901ms` → `地图备份 完成 用时:2分35秒`

## 测试
- 新增 formatDuration 边界单测 4 组（毫秒/秒/分/小时），含老板示例 154901ms → 2分35秒
- `./gradlew check` 全绿（spotless + 单测 + 集成测试 + shadowJar）