### PR TITLE
feat(bot): $e 命令输出完整捕获（同步代理 + Log4J 日志窗口兜底）

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,10 @@ dependencies {
     implementation(project(":orzmc-api"))
 
     compileOnly("io.papermc.paper:paper-api:${property("paper_api_version") as String}")
+    // Log4J（Paper 运行时自带；compileOnly 不打进 jar）——$e 命令日志窗口收集 Appender
+    compileOnly("org.apache.logging.log4j:log4j-api:2.26.0")
+    compileOnly("org.apache.logging.log4j:log4j-core:2.26.0")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.26.0")
     // LuckPerms API（软依赖：LP 插件在运行时提供 API 类——compileOnly 不打进 jar，
     // shadowJar 排除 net/luckperms 避免类加载器冲突；paper-plugin.yml dependencies 新格式声明软依赖）
     compileOnly("net.luckperms:api:5.5")

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandAndEventIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandAndEventIntegrationTest.java
@@ -68,7 +68,10 @@ public class CommandAndEventIntegrationTest {
         AtomicReference<MessageEnvelope> got = new AtomicReference<>();
 
         Assertions.assertDoesNotThrow(() -> handler.handleMessage("$e bot", true, got::set));
-        server.getScheduler().performOneTick();
+        // $e 走「同步执行 + 日志窗口延迟回包」（40 tick 收集窗口），需推进足够 tick
+        for (int i = 0; i < 60; i++) {
+            server.getScheduler().performOneTick();
+        }
 
         MessageEnvelope envelope = got.get();
         Assertions.assertNotNull(envelope, "missing bot command response");

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandAndEventIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandAndEventIntegrationTest.java
@@ -68,8 +68,12 @@ public class CommandAndEventIntegrationTest {
         AtomicReference<MessageEnvelope> got = new AtomicReference<>();
 
         Assertions.assertDoesNotThrow(() -> handler.handleMessage("$e bot", true, got::set));
-        // $e 走「同步执行 + 日志窗口延迟回包」（40 tick 收集窗口），需推进足够 tick
-        for (int i = 0; i < 60; i++) {
+        // $e 走「同步执行 + 日志窗口延迟回包」（40 tick 收集窗口）：窗口前不回包，窗口后回包
+        for (int i = 0; i < 39; i++) {
+            server.getScheduler().performOneTick();
+        }
+        Assertions.assertNull(got.get(), "$e 回包不应早于收集窗口");
+        for (int i = 39; i < 60; i++) {
             server.getScheduler().performOneTick();
         }
 

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandIntegrationTest.java
@@ -129,8 +129,12 @@ public class CommandIntegrationTest {
         BotModule botModule = plugin.services().botModule();
         AtomicReference<MessageEnvelope> got = new AtomicReference<>();
         Assertions.assertDoesNotThrow(() -> botModule.botInboundHandler().handleMessage("$e bot", true, got::set));
-        // $e 走「同步执行 + 日志窗口延迟回包」（40 tick 收集窗口），需推进足够 tick
-        for (int i = 0; i < 60; i++) {
+        // $e 走「同步执行 + 日志窗口延迟回包」（40 tick 收集窗口）：窗口前不回包，窗口后回包
+        for (int i = 0; i < 39; i++) {
+            server.getScheduler().performOneTick();
+        }
+        Assertions.assertNull(got.get(), "$e 回包不应早于收集窗口");
+        for (int i = 39; i < 60; i++) {
             server.getScheduler().performOneTick();
         }
         MessageEnvelope envelope = got.get();

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandIntegrationTest.java
@@ -129,7 +129,10 @@ public class CommandIntegrationTest {
         BotModule botModule = plugin.services().botModule();
         AtomicReference<MessageEnvelope> got = new AtomicReference<>();
         Assertions.assertDoesNotThrow(() -> botModule.botInboundHandler().handleMessage("$e bot", true, got::set));
-        server.getScheduler().performOneTick();
+        // $e 走「同步执行 + 日志窗口延迟回包」（40 tick 收集窗口），需推进足够 tick
+        for (int i = 0; i < 60; i++) {
+            server.getScheduler().performOneTick();
+        }
         MessageEnvelope envelope = got.get();
         Assertions.assertNotNull(envelope, "Bot command should produce response");
         Assertions.assertTrue(envelope.message().contains("ws"), "Status should show ws state");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/BotModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/BotModule.java
@@ -28,6 +28,8 @@ public final class BotModule implements ServiceModule, Initializable {
         this.healthRegistry = new HealthRegistry();
         // Phase A: 先创建 BotCommandService（核心依赖来自 PlatformModule）
         this.botCommandService = new BotCommandService(platform.serverFacade(), platform.configs());
+        // $e 命令输出兜底：注入日志窗口收集服务
+        this.botCommandService.setLogCaptureService(platform.logCaptureService());
 
         // Phase C: 创建 BotMessageService（以 BotCommandService 作为 BotInboundHandler）
         this.botMessageService = BotMessageServiceProvider.create(

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/PlatformModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/PlatformModule.java
@@ -8,10 +8,14 @@ import com.jokerhub.paper.plugin.orzmc.core.ports.server.ServerScheduler;
 import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
 import com.jokerhub.paper.plugin.orzmc.infra.config.DefaultTypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.health.HealthRegistry;
+import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
+import com.jokerhub.paper.plugin.orzmc.infra.logging.OrzLog4JCaptureAppender;
 import com.jokerhub.paper.plugin.orzmc.infra.logging.ThrottledLogger;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.ThrottledNotifier;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 
 /**
  * 平台基础设施模块。
@@ -28,6 +32,8 @@ public final class PlatformModule implements ServiceModule {
     private final ThrottledLogger throttledLogger;
     private final ThrottledNotifier throttledNotifier;
     private final HealthRegistry healthRegistry;
+    private final LogCaptureService logCaptureService;
+    private OrzLog4JCaptureAppender logCaptureAppender;
 
     public PlatformModule(OrzMC plugin) {
         this.serverFacade = new ServerFacade(plugin);
@@ -37,16 +43,55 @@ public final class PlatformModule implements ServiceModule {
         this.throttledLogger = new ThrottledLogger(configService, plugin.getLogger());
         this.throttledNotifier = new ThrottledNotifier(configService);
         this.healthRegistry = new HealthRegistry();
+        this.logCaptureService = new LogCaptureService(LOG_CAPTURE_CAPACITY);
     }
+
+    /** 日志环形缓冲容量（$e 命令输出窗口收集）。 */
+    private static final int LOG_CAPTURE_CAPACITY = 500;
 
     @Override
     public void setup() {
         configService.setup();
+        attachLogCaptureAppender();
     }
 
     @Override
     public void tearDown() {
+        detachLogCaptureAppender();
         configService.tearDown();
+    }
+
+    /**
+     * 注册 Log4J root Appender，把服务器日志喂给 {@link LogCaptureService}。
+     * 环境异常（如测试容器无 Log4J）时降级为仅警告，不影响插件启动。
+     */
+    private void attachLogCaptureAppender() {
+        try {
+            LoggerContext context = (LoggerContext) LogManager.getContext(false);
+            OrzLog4JCaptureAppender appender = new OrzLog4JCaptureAppender(logCaptureService);
+            appender.start();
+            context.getRootLogger().addAppender(appender);
+            logCaptureAppender = appender;
+        } catch (Exception e) {
+            logCaptureAppender = null;
+            serverFacade.logger().warning("Log4J 日志捕获 Appender 注册失败，$e 输出兜底不可用: " + e.getMessage());
+        }
+    }
+
+    /** 注销 Log4J Appender（插件卸载时）。 */
+    private void detachLogCaptureAppender() {
+        if (logCaptureAppender == null) {
+            return;
+        }
+        try {
+            LoggerContext context = (LoggerContext) LogManager.getContext(false);
+            context.getRootLogger().removeAppender(logCaptureAppender);
+            logCaptureAppender.stop();
+        } catch (Exception e) {
+            serverFacade.logger().warning("Log4J 日志捕获 Appender 注销失败: " + e.getMessage());
+        } finally {
+            logCaptureAppender = null;
+        }
     }
 
     // --- Getters ---
@@ -89,5 +134,9 @@ public final class PlatformModule implements ServiceModule {
 
     public HealthRegistry healthRegistry() {
         return healthRegistry;
+    }
+
+    public LogCaptureService logCaptureService() {
+        return logCaptureService;
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -36,7 +36,7 @@ public final class BotCommandService implements BotInboundHandler {
     private com.jokerhub.paper.plugin.orzmc.features.rank.RankService rankService;
     private LogCaptureService logCaptureService;
 
-    /** $e 日志收集窗口：40 tick = 2 秒（覆盖大多数插件异步命令输出）。 */
+    /** $e 日志收集窗口：40 tick ≈ 2 秒（按 20 TPS 推算，覆盖大多数插件异步命令输出）。 */
     private static final long CONSOLE_OUTPUT_COLLECT_TICKS = 40L;
 
     /** $e 输出最大行数，超过截断防刷群。 */
@@ -304,12 +304,17 @@ public final class BotCommandService implements BotInboundHandler {
             // 先取水位再执行，命令执行期间的日志行才能落入窗口
             long watermark = logCaptureService.watermark();
             ServerFacade.ConsoleCommandResult result = server.executeConsoleCommand(rawArgs);
-            // 延迟一个收集窗口后取日志增量：覆盖异步命令输出（LuckPerms 等回调式输出）
+            // 延迟一个收集窗口后取日志增量：覆盖异步命令输出（LuckPerms 等回调式输出）。
+            // 日志窗口是「尽力而为」兜底：窗口内可能混入服务器其他活动日志（已过滤
+            // 命令回显/玩家聊天），缓冲溢出时输出头部提示可能缺失
             server.runLater(
                     () -> {
                         List<String> windowLogLines = logCaptureService.drainSince(watermark);
                         String assembled = CommandOutputAssembler.assemble(
                                 result.outputLines(), windowLogLines, CONSOLE_OUTPUT_MAX_LINES);
+                        if (!assembled.isEmpty() && logCaptureService.hasGapSince(watermark)) {
+                            assembled = "⚠️ 日志缓冲溢出，输出可能不完整\n" + assembled;
+                        }
                         String message = assembled.isEmpty() ? result.message() : assembled;
                         emit(callback, "command_output", Map.of("message", message), message);
                     },

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -312,10 +312,13 @@ public final class BotCommandService implements BotInboundHandler {
                         List<String> windowLogLines = logCaptureService.drainSince(watermark);
                         String assembled = CommandOutputAssembler.assemble(
                                 result.outputLines(), windowLogLines, CONSOLE_OUTPUT_MAX_LINES);
-                        if (!assembled.isEmpty() && logCaptureService.hasGapSince(watermark)) {
-                            assembled = "⚠️ 日志缓冲溢出，输出可能不完整\n" + assembled;
+                        // 缺口检测独立于输出内容：即使窗口内有效行全被驱逐/过滤也要提示
+                        String message;
+                        if (logCaptureService.hasGapSince(watermark)) {
+                            message = assembled.isEmpty() ? "⚠️ 日志缓冲溢出，输出可能不完整" : "⚠️ 日志缓冲溢出，输出可能不完整\n" + assembled;
+                        } else {
+                            message = assembled.isEmpty() ? result.message() : assembled;
                         }
-                        String message = assembled.isEmpty() ? result.message() : assembled;
                         emit(callback, "command_output", Map.of("message", message), message);
                     },
                     CONSOLE_OUTPUT_COLLECT_TICKS);

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -11,6 +11,7 @@ import com.jokerhub.paper.plugin.orzmc.features.whitelist.WhitelistService;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.WhitelistConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
 import com.jokerhub.paper.plugin.orzmc.infra.paging.Paginator;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import java.util.ArrayList;
@@ -33,6 +34,13 @@ public final class BotCommandService implements BotInboundHandler {
     private BlacklistService blacklistService;
     private com.jokerhub.paper.plugin.orzmc.features.review.ReviewService reviewService;
     private com.jokerhub.paper.plugin.orzmc.features.rank.RankService rankService;
+    private LogCaptureService logCaptureService;
+
+    /** $e 日志收集窗口：40 tick = 2 秒（覆盖大多数插件异步命令输出）。 */
+    private static final long CONSOLE_OUTPUT_COLLECT_TICKS = 40L;
+
+    /** $e 输出最大行数，超过截断防刷群。 */
+    private static final int CONSOLE_OUTPUT_MAX_LINES = 30;
 
     @FunctionalInterface
     private interface CmdHandler {
@@ -87,6 +95,11 @@ public final class BotCommandService implements BotInboundHandler {
                 new com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter();
         formatter.setRankService(rankService);
         this.listFeedbackService = new BotCommandListFeedbackService(server, configs, formatter);
+    }
+
+    /** 注入日志窗口收集服务（$e 命令输出兜底）。未注入时 $e 退化为仅返回执行状态。 */
+    public void setLogCaptureService(LogCaptureService logCaptureService) {
+        this.logCaptureService = logCaptureService;
     }
 
     @Override
@@ -282,8 +295,25 @@ public final class BotCommandService implements BotInboundHandler {
             return;
         }
         server.runSync(() -> {
+            if (logCaptureService == null) {
+                // 未注入日志窗口服务：退化为仅返回执行状态
+                ServerFacade.ConsoleCommandResult result = server.executeConsoleCommand(rawArgs);
+                emit(callback, "command_output", Map.of("message", result.message()), result.message());
+                return;
+            }
+            // 先取水位再执行，命令执行期间的日志行才能落入窗口
+            long watermark = logCaptureService.watermark();
             ServerFacade.ConsoleCommandResult result = server.executeConsoleCommand(rawArgs);
-            emit(callback, "command_output", Map.of("message", result.message()), result.message());
+            // 延迟一个收集窗口后取日志增量：覆盖异步命令输出（LuckPerms 等回调式输出）
+            server.runLater(
+                    () -> {
+                        List<String> windowLogLines = logCaptureService.drainSince(watermark);
+                        String assembled = CommandOutputAssembler.assemble(
+                                result.outputLines(), windowLogLines, CONSOLE_OUTPUT_MAX_LINES);
+                        String message = assembled.isEmpty() ? result.message() : assembled;
+                        emit(callback, "command_output", Map.of("message", message), message);
+                    },
+                    CONSOLE_OUTPUT_COLLECT_TICKS);
         });
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssembler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssembler.java
@@ -25,6 +25,9 @@ public final class CommandOutputAssembler {
      * @return 组装后的多行文本；全部被过滤时返回空字符串
      */
     public static String assemble(List<String> syncLines, List<String> windowLogLines, int maxLines) {
+        if (maxLines <= 0) {
+            maxLines = 1;
+        }
         List<String> merged = new ArrayList<>();
         Set<String> seen = new LinkedHashSet<>();
         if (syncLines != null) {
@@ -58,8 +61,20 @@ public final class CommandOutputAssembler {
         }
     }
 
-    /** 噪音行判定：命令回显（{@code <sender> issued server command: /xxx}）。 */
+    /**
+     * 噪音行判定：
+     * <ul>
+     *   <li>命令回显（{@code <sender> issued server command: /xxx}）</li>
+     *   <li>玩家聊天行（{@code <Steve> 大家好}）——$e 日志窗口是全局兜底，活跃服务器
+     *       上窗口内混入玩家聊天属已知限制，尽力过滤</li>
+     * </ul>
+     * 定位为「尽力而为」：无法做到命令级隔离（异步输出无法区分来源），
+     * 不能保证窗口内 100% 无无关日志。
+     */
     static boolean isNoise(String line) {
-        return line.contains("issued server command");
+        if (line.contains("issued server command")) {
+            return true;
+        }
+        return line.startsWith("<") && line.contains("> ");
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssembler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssembler.java
@@ -1,0 +1,65 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * {@code $e} 命令输出组装：把「同步捕获行」与「日志时间窗行」合并为最终群消息文本。
+ *
+ * <p>规则：先同步行、后日志行（保序）；跳过空行与噪音行（命令回显
+ * {@code issued server command}）；同步行与日志行可能重复（代理转发后仍写日志），
+ * 用 {@link LinkedHashSet} 保序去重；超过 {@code maxLines} 截断并追加提示。
+ */
+public final class CommandOutputAssembler {
+
+    private CommandOutputAssembler() {}
+
+    /**
+     * 组装输出文本。
+     *
+     * @param syncLines 同步捕获的命令输出行（可能为空）
+     * @param windowLogLines 日志时间窗内新增的行（可能为空）
+     * @param maxLines 最大行数，超过则截断
+     * @return 组装后的多行文本；全部被过滤时返回空字符串
+     */
+    public static String assemble(List<String> syncLines, List<String> windowLogLines, int maxLines) {
+        List<String> merged = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        if (syncLines != null) {
+            for (String line : syncLines) {
+                addFiltered(merged, seen, line);
+            }
+        }
+        if (windowLogLines != null) {
+            for (String line : windowLogLines) {
+                addFiltered(merged, seen, line);
+            }
+        }
+        if (merged.isEmpty()) {
+            return "";
+        }
+        if (merged.size() <= maxLines) {
+            return String.join("\n", merged);
+        }
+        List<String> head = new ArrayList<>(merged.subList(0, maxLines));
+        head.add("…（输出过长，已截断，共 " + merged.size() + " 行）");
+        return String.join("\n", head);
+    }
+
+    private static void addFiltered(List<String> out, Set<String> seen, String rawLine) {
+        if (rawLine == null || rawLine.isBlank() || isNoise(rawLine)) {
+            return;
+        }
+        String line = rawLine.trim();
+        if (seen.add(line)) {
+            out.add(line);
+        }
+    }
+
+    /** 噪音行判定：命令回显（{@code <sender> issued server command: /xxx}）。 */
+    static boolean isNoise(String line) {
+        return line.contains("issued server command");
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureService.java
@@ -48,14 +48,17 @@ public final class LogCaptureService {
             if (line.isBlank()) {
                 continue;
             }
-            String clean = ANSI_ESCAPE.matcher(line).replaceAll("");
-            if (clean.isBlank()) {
-                continue;
+            // 快速路径：无 ANSI 码与 CR 时跳过正则/替换（服务器每条日志都会经过这里）
+            if (line.indexOf('\u001B') >= 0) {
+                line = ANSI_ESCAPE.matcher(line).replaceAll("");
+                if (line.isBlank()) {
+                    continue;
+                }
             }
             if (buffer.size() == capacity) {
                 buffer.removeFirst();
             }
-            buffer.addLast(new CapturedLine(++sequence, clean));
+            buffer.addLast(new CapturedLine(++sequence, line));
         }
     }
 
@@ -69,7 +72,7 @@ public final class LogCaptureService {
     }
 
     /**
-     * 取 {@code fromSeq} 之后新增的日志行文本（保序）。
+     * 取 {@code fromSeq} 之后新增的日志行文本（保序、幂等：不消费缓冲）。
      *
      * @param fromSeq 窗口起点序号（执行命令前取到的 {@link #watermark()}）
      * @return 新增行文本列表；无新增返回空列表
@@ -82,6 +85,21 @@ public final class LogCaptureService {
             }
         }
         return lines;
+    }
+
+    /**
+     * 窗口是否发生容量驱逐（水位到缓冲起点之间存在缺口）。
+     *
+     * <p>{@code $e} 窗口内服务器日志流量大时（如备份任务刷日志），缓冲满会把
+     * 水位之后的行驱逐，{@link #drainSince(long)} 会静默丢行。调用方检测到缺口
+     * 应在输出头部提示「可能不完整」。
+     *
+     * @param fromSeq 执行命令前取到的水位
+     * @return true 表示 {@code fromSeq} 之后有行已被驱逐
+     */
+    public synchronized boolean hasGapSince(long fromSeq) {
+        CapturedLine oldest = buffer.peekFirst();
+        return oldest != null && oldest.seq() > fromSeq + 1;
     }
 
     /** 缓冲行数（测试与诊断用）。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureService.java
@@ -1,0 +1,94 @@
+package com.jokerhub.paper.plugin.orzmc.infra.logging;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * 全局日志环形缓冲，供 {@code $e} 控制台命令输出窗口收集使用。
+ *
+ * <p>设计为纯 Java、零 Log4J 依赖：日志系统（Log4J Appender）通过 {@link #capture(String)}
+ * 把每一行日志喂进来，主线程通过 {@link #watermark()} + {@link #drainSince(long)} 取
+ * 「执行命令后新增的日志行」。环形缓冲容量固定，超容量丢弃最老的行，内存占用有界。
+ *
+ * <p>线程安全：{@code capture} 由日志线程并发调用，{@code watermark}/{@code drainSince}
+ * 由服务器主线程调用，全部方法 {@code synchronized} 串行化（容量 500 时开销可忽略）。
+ */
+public final class LogCaptureService {
+
+    /** 缓冲容量。 */
+    private final int capacity;
+
+    /** ANSI 颜色码（{@code ESC[33m} 等）：插件命令输出常带色，发群前剥离。 */
+    private static final Pattern ANSI_ESCAPE = Pattern.compile("\u001B\\[[;\\d]*[A-Za-z]");
+
+    /** 环形缓冲：尾部是最新的行。 */
+    private final Deque<CapturedLine> buffer;
+
+    /** 单调递增序号：既当水位，也用于窗口过滤。 */
+    private long sequence;
+
+    public LogCaptureService(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("capacity must be positive: " + capacity);
+        }
+        this.capacity = capacity;
+        this.buffer = new ArrayDeque<>(capacity);
+    }
+
+    /** 捕获一行（或多行，内部按 {@code \n} 拆分、剥 ANSI 色码、丢弃空行）。 */
+    public synchronized void capture(String rawText) {
+        if (rawText == null) {
+            return;
+        }
+        String normalized = rawText.replace("\r\n", "\n").replace('\r', '\n');
+        for (String line : normalized.split("\n", -1)) {
+            if (line.isBlank()) {
+                continue;
+            }
+            String clean = ANSI_ESCAPE.matcher(line).replaceAll("");
+            if (clean.isBlank()) {
+                continue;
+            }
+            if (buffer.size() == capacity) {
+                buffer.removeFirst();
+            }
+            buffer.addLast(new CapturedLine(++sequence, clean));
+        }
+    }
+
+    /**
+     * 当前水位：执行命令前调用，作为窗口起点。
+     *
+     * @return 当前已捕获的最大行序号
+     */
+    public synchronized long watermark() {
+        return sequence;
+    }
+
+    /**
+     * 取 {@code fromSeq} 之后新增的日志行文本（保序）。
+     *
+     * @param fromSeq 窗口起点序号（执行命令前取到的 {@link #watermark()}）
+     * @return 新增行文本列表；无新增返回空列表
+     */
+    public synchronized List<String> drainSince(long fromSeq) {
+        List<String> lines = new ArrayList<>();
+        for (CapturedLine captured : buffer) {
+            if (captured.seq() > fromSeq) {
+                lines.add(captured.text());
+            }
+        }
+        return lines;
+    }
+
+    /** 缓冲行数（测试与诊断用）。 */
+    public synchronized int size() {
+        return buffer.size();
+    }
+
+    /** 单条捕获行：序号 + 文本。 */
+    public record CapturedLine(long seq, String text) {}
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/logging/OrzLog4JCaptureAppender.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/logging/OrzLog4JCaptureAppender.java
@@ -17,7 +17,8 @@ public final class OrzLog4JCaptureAppender extends AbstractAppender {
     private final LogCaptureService captureService;
 
     public OrzLog4JCaptureAppender(LogCaptureService captureService) {
-        super("OrzMC-LogCapture", null, null, false, Property.EMPTY_ARRAY);
+        // ignoreExceptions=true：append 异常不回流日志系统（避免递归/污染），捕获失败仅丢行
+        super("OrzMC-LogCapture", null, null, true, Property.EMPTY_ARRAY);
         this.captureService = captureService;
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/logging/OrzLog4JCaptureAppender.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/logging/OrzLog4JCaptureAppender.java
@@ -1,0 +1,31 @@
+package com.jokerhub.paper.plugin.orzmc.infra.logging;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+
+/**
+ * Log4J Appender：把服务器日志行（含插件 logger 与命令输出）喂给 {@link LogCaptureService}。
+ *
+ * <p>在 Paper 上 ConsoleCommandSender 的 sendMessage 最终都会进入日志系统，因此挂一个
+ * root Appender 即可覆盖同步 + 异步命令输出（比只包装 ConsoleCommandSender 的同步捕获
+ * 覆盖面广得多）。Appender 常驻，由 {@code $e} 命令用时间窗取增量，注册/注销见
+ * {@code PlatformModule}。
+ */
+public final class OrzLog4JCaptureAppender extends AbstractAppender {
+
+    private final LogCaptureService captureService;
+
+    public OrzLog4JCaptureAppender(LogCaptureService captureService) {
+        super("OrzMC-LogCapture", null, null, false, Property.EMPTY_ARRAY);
+        this.captureService = captureService;
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (event == null || event.getMessage() == null) {
+            return;
+        }
+        captureService.capture(event.getMessage().getFormattedMessage());
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandServiceTest.java
@@ -243,6 +243,24 @@ class BotCommandServiceTest {
     }
 
     @Test
+    void parse_executeConsole_withLogCapture_bufferOverflow_prependsWarning() {
+        LogCaptureService capture = mock(LogCaptureService.class);
+        when(capture.watermark()).thenReturn(3L);
+        when(capture.drainSince(3L)).thenReturn(java.util.List.of("survived line"));
+        when(capture.hasGapSince(3L)).thenReturn(true);
+        service.setLogCaptureService(capture);
+
+        when(serverFacade.executeConsoleCommand("say hi"))
+                .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of()));
+
+        service.parse("$e say hi", true, callback);
+
+        org.mockito.ArgumentCaptor<MessageEnvelope> captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);
+        verify(callback).accept(captor.capture());
+        assertEquals("⚠️ 日志缓冲溢出，输出可能不完整\nsurvived line", captor.getValue().message());
+    }
+
+    @Test
     void parse_botConfigException_usesDefaults() {
         when(configs.bot()).thenThrow(new RuntimeException("config error"));
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandServiceTest.java
@@ -11,6 +11,7 @@ import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.features.rank.RankService;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.WhitelistConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
@@ -60,6 +61,14 @@ class BotCommandServiceTest {
                 })
                 .when(serverFacade)
                 .runSync(any(Runnable.class));
+
+        doAnswer(invocation -> {
+                    Runnable r = invocation.getArgument(0);
+                    r.run();
+                    return null;
+                })
+                .when(serverFacade)
+                .runLater(any(Runnable.class), anyLong());
 
         service = new BotCommandService(serverFacade, configs);
     }
@@ -158,6 +167,79 @@ class BotCommandServiceTest {
 
         service.parse("$e say hello", true, callback);
         verify(callback, atLeastOnce()).accept(any(MessageEnvelope.class));
+    }
+
+    // ---- $e 日志窗口收集（setLogCaptureService 注入后） ----
+
+    @Test
+    void parse_executeConsole_withLogCapture_emitsAssembledOutput() {
+        LogCaptureService capture = mock(LogCaptureService.class);
+        when(capture.watermark()).thenReturn(42L);
+        when(capture.drainSince(42L)).thenReturn(java.util.List.of("async log line"));
+        service.setLogCaptureService(capture);
+
+        when(serverFacade.executeConsoleCommand("say hello"))
+                .thenReturn(new ServerFacade.ConsoleCommandResult("say hello", true, java.util.List.of("sync line")));
+
+        service.parse("$e say hello", true, callback);
+
+        org.mockito.ArgumentCaptor<MessageEnvelope> captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);
+        verify(callback).accept(captor.capture());
+        // 同步捕获行在前，日志窗口行在后（合并去重）
+        assertEquals("sync line\nasync log line", captor.getValue().message());
+    }
+
+    @Test
+    void parse_executeConsole_withLogCapture_watermarkTakenBeforeDispatch() {
+        LogCaptureService capture = mock(LogCaptureService.class);
+        when(capture.watermark()).thenReturn(1L);
+        when(capture.drainSince(anyLong())).thenReturn(java.util.List.of());
+        service.setLogCaptureService(capture);
+
+        when(serverFacade.executeConsoleCommand("say hi"))
+                .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of()));
+
+        service.parse("$e say hi", true, callback);
+
+        // 水位必须在执行命令前取，否则命令自身的日志行会漏出窗口
+        org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(capture, serverFacade);
+        inOrder.verify(capture).watermark();
+        inOrder.verify(serverFacade).executeConsoleCommand("say hi");
+    }
+
+    @Test
+    void parse_executeConsole_withLogCapture_noOutputFallsBackToStatus() {
+        LogCaptureService capture = mock(LogCaptureService.class);
+        when(capture.watermark()).thenReturn(7L);
+        when(capture.drainSince(7L)).thenReturn(java.util.List.of());
+        service.setLogCaptureService(capture);
+
+        when(serverFacade.executeConsoleCommand("say hi"))
+                .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of()));
+
+        service.parse("$e say hi", true, callback);
+
+        org.mockito.ArgumentCaptor<MessageEnvelope> captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);
+        verify(callback).accept(captor.capture());
+        assertEquals("命令已执行: say hi", captor.getValue().message());
+    }
+
+    @Test
+    void parse_executeConsole_withLogCapture_filtersIssuedServerCommandNoise() {
+        LogCaptureService capture = mock(LogCaptureService.class);
+        when(capture.watermark()).thenReturn(9L);
+        when(capture.drainSince(9L))
+                .thenReturn(java.util.List.of("Rcon issued server command: /say hi", "real async output"));
+        service.setLogCaptureService(capture);
+
+        when(serverFacade.executeConsoleCommand("say hi"))
+                .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of()));
+
+        service.parse("$e say hi", true, callback);
+
+        org.mockito.ArgumentCaptor<MessageEnvelope> captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);
+        verify(callback).accept(captor.capture());
+        assertEquals("real async output", captor.getValue().message());
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssemblerTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssemblerTest.java
@@ -33,8 +33,8 @@ class CommandOutputAssemblerTest {
     }
 
     @Test
-    void assemble_keepsCommandOutputStartingWithBracketAngle() {
-        // 命令输出可能以 <xxx> 开头（如 LP 的占位提示），但不能是 "<名字> 聊天" 结构
+    void assemble_keepsCommandOutputWithInlineBracketAngle() {
+        // 行内含 <xxx>（如 LP 占位提示）但不是 "<名字> 聊天" 结构，不应误杀
         String result = CommandOutputAssembler.assemble(List.of("> /luckperms user <user>"), List.of(), 30);
         assertEquals("> /luckperms user <user>", result);
     }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssemblerTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssemblerTest.java
@@ -1,0 +1,91 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CommandOutputAssemblerTest {
+
+    @Test
+    void assemble_syncLinesOnly_joinsWithNewline() {
+        String result = CommandOutputAssembler.assemble(List.of("a", "b"), List.of(), 30);
+        assertEquals("a\nb", result);
+    }
+
+    @Test
+    void assemble_logLinesAppendedAfterSyncLines() {
+        String result = CommandOutputAssembler.assemble(List.of("sync1"), List.of("log1", "log2"), 30);
+        assertEquals("sync1\nlog1\nlog2", result);
+    }
+
+    @Test
+    void assemble_filtersIssuedServerCommandNoise() {
+        String result = CommandOutputAssembler.assemble(
+                List.of(), List.of("Rcon issued server command: /list", "real output"), 30);
+        assertEquals("real output", result);
+    }
+
+    @Test
+    void assemble_filtersBlankLines() {
+        String result = CommandOutputAssembler.assemble(List.of("a", " ", ""), List.of(), 30);
+        assertEquals("a", result);
+    }
+
+    @Test
+    void assemble_deduplicatesSyncAndLogOverlap() {
+        String result = CommandOutputAssembler.assemble(List.of("same", "unique"), List.of("same", "extra"), 30);
+        assertEquals("same\nunique\nextra", result);
+    }
+
+    @Test
+    void assemble_trimsLines() {
+        String result = CommandOutputAssembler.assemble(List.of("  padded  "), List.of(), 30);
+        assertEquals("padded", result);
+    }
+
+    @Test
+    void assemble_allNoise_returnsEmpty() {
+        String result = CommandOutputAssembler.assemble(List.of("issued server command: /x"), List.of(), 30);
+        assertEquals("", result);
+    }
+
+    @Test
+    void assemble_nullInputs_returnsEmpty() {
+        assertEquals("", CommandOutputAssembler.assemble(null, null, 30));
+    }
+
+    @Test
+    void assemble_underMaxLines_returnsAll() {
+        String result = CommandOutputAssembler.assemble(List.of("a", "b", "c"), List.of(), 5);
+        assertEquals("a\nb\nc", result);
+    }
+
+    @Test
+    void assemble_overMaxLines_truncatesWithNotice() {
+        List<String> lines = List.of("1", "2", "3", "4", "5");
+        String result = CommandOutputAssembler.assemble(lines, List.of(), 3);
+        assertEquals("1\n2\n3\n…（输出过长，已截断，共 5 行）", result);
+    }
+
+    @Test
+    void assemble_exactlyMaxLines_noTruncation() {
+        List<String> lines = List.of("1", "2", "3");
+        String result = CommandOutputAssembler.assemble(lines, List.of(), 3);
+        assertEquals("1\n2\n3", result);
+    }
+
+    @Test
+    void isNoise_issuedServerCommand_returnsTrue() {
+        assertTrue(CommandOutputAssembler.isNoise("Bot issued server command: /say hi"));
+        assertTrue(CommandOutputAssembler.isNoise("Rcon issued server command: /list"));
+    }
+
+    @Test
+    void isNoise_regularOutput_returnsFalse() {
+        assertFalse(CommandOutputAssembler.isNoise("There are 5 of a max of 20 players online"));
+        assertFalse(CommandOutputAssembler.isNoise("玩家 x 已上线"));
+        // 含关键词的任意文本都视为噪音（保守过滤，宁可漏过不可放过回显）
+        assertTrue(CommandOutputAssembler.isNoise("issued server command"));
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssemblerTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/CommandOutputAssemblerTest.java
@@ -27,6 +27,25 @@ class CommandOutputAssemblerTest {
     }
 
     @Test
+    void assemble_filtersPlayerChatLines() {
+        String result = CommandOutputAssembler.assemble(List.of(), List.of("<Steve> 大家好", "real output"), 30);
+        assertEquals("real output", result);
+    }
+
+    @Test
+    void assemble_keepsCommandOutputStartingWithBracketAngle() {
+        // 命令输出可能以 <xxx> 开头（如 LP 的占位提示），但不能是 "<名字> 聊天" 结构
+        String result = CommandOutputAssembler.assemble(List.of("> /luckperms user <user>"), List.of(), 30);
+        assertEquals("> /luckperms user <user>", result);
+    }
+
+    @Test
+    void assemble_nonPositiveMaxLines_clampedToOne() {
+        String result = CommandOutputAssembler.assemble(List.of("a", "b"), List.of(), 0);
+        assertEquals("a\n…（输出过长，已截断，共 2 行）", result);
+    }
+
+    @Test
     void assemble_filtersBlankLines() {
         String result = CommandOutputAssembler.assemble(List.of("a", " ", ""), List.of(), 30);
         assertEquals("a", result);

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureServiceTest.java
@@ -143,6 +143,20 @@ class LogCaptureServiceTest {
     }
 
     @Test
+    void hasGapSince_exactBoundaryNoEviction_returnsFalse() {
+        // 边界：缓冲恰好从水位之后的首行开始（oldest == fromSeq + 1），无丢失
+        LogCaptureService service = new LogCaptureService(3);
+        service.capture("a"); // seq=1
+        service.capture("b"); // seq=2
+
+        long watermark = service.watermark(); // 2
+        service.capture("c"); // seq=3 —— 驱逐尚未发生
+
+        assertFalse(service.hasGapSince(watermark));
+        assertEquals(List.of("c"), service.drainSince(watermark));
+    }
+
+    @Test
     void constructor_negativeCapacity_throws() {
         assertThrows(IllegalArgumentException.class, () -> new LogCaptureService(0));
         assertThrows(IllegalArgumentException.class, () -> new LogCaptureService(-1));

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureServiceTest.java
@@ -1,0 +1,135 @@
+package com.jokerhub.paper.plugin.orzmc.infra.logging;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LogCaptureServiceTest {
+
+    @Test
+    void capture_singleLine_watermarkAndDrain() {
+        LogCaptureService service = new LogCaptureService(10);
+        long watermark = service.watermark();
+        assertEquals(0, watermark);
+
+        service.capture("hello");
+
+        assertEquals(1, service.watermark());
+        assertEquals(List.of("hello"), service.drainSince(watermark));
+    }
+
+    @Test
+    void capture_multilineText_splitsIntoLines() {
+        LogCaptureService service = new LogCaptureService(10);
+        long watermark = service.watermark();
+
+        service.capture("line1\nline2\nline3");
+
+        assertEquals(List.of("line1", "line2", "line3"), service.drainSince(watermark));
+    }
+
+    @Test
+    void capture_nullAndBlankLines_ignored() {
+        LogCaptureService service = new LogCaptureService(10);
+        long watermark = service.watermark();
+
+        service.capture(null);
+        service.capture("");
+        service.capture("   ");
+        service.capture("\n\n");
+
+        assertEquals(List.of(), service.drainSince(watermark));
+        assertEquals(0, service.watermark());
+    }
+
+    @Test
+    void capture_crlfNormalized() {
+        LogCaptureService service = new LogCaptureService(10);
+        long watermark = service.watermark();
+
+        service.capture("a\r\nb\rc");
+
+        assertEquals(List.of("a", "b", "c"), service.drainSince(watermark));
+    }
+
+    @Test
+    void capture_stripsAnsiColorCodes() {
+        LogCaptureService service = new LogCaptureService(10);
+        long watermark = service.watermark();
+
+        service.capture("\u001B[33m黄色输出\u001B[0m plain");
+
+        assertEquals(List.of("黄色输出 plain"), service.drainSince(watermark));
+    }
+
+    @Test
+    void drainSince_onlyReturnsNewerThanWatermark() {
+        LogCaptureService service = new LogCaptureService(10);
+        service.capture("before");
+
+        long watermark = service.watermark();
+        service.capture("after1");
+        service.capture("after2");
+
+        assertEquals(List.of("after1", "after2"), service.drainSince(watermark));
+    }
+
+    @Test
+    void drainSince_noNewLinesSinceNewWatermark_returnsEmpty() {
+        LogCaptureService service = new LogCaptureService(10);
+        service.capture("before");
+
+        long watermark = service.watermark();
+        service.capture("after");
+
+        // drainSince 是幂等查询（按水位），取走后缓冲仍在；用新水位查询才为空
+        assertEquals(List.of("after"), service.drainSince(watermark));
+        assertEquals(List.of(), service.drainSince(service.watermark()));
+    }
+
+    @Test
+    void capture_beyondCapacity_evictsOldest() {
+        LogCaptureService service = new LogCaptureService(3);
+        service.capture("a");
+        service.capture("b");
+        service.capture("c");
+        service.capture("d");
+
+        assertEquals(3, service.size());
+        long watermark = service.watermark();
+        // 最老的 a 已被挤出缓冲，drainSince(0) 只能拿到仍在缓冲里的行
+        assertEquals(List.of("b", "c", "d"), service.drainSince(0));
+        assertEquals(4, watermark);
+    }
+
+    @Test
+    void constructor_negativeCapacity_throws() {
+        assertThrows(IllegalArgumentException.class, () -> new LogCaptureService(0));
+        assertThrows(IllegalArgumentException.class, () -> new LogCaptureService(-1));
+    }
+
+    @Test
+    void capture_fromMultipleThreads_noDataLoss() throws Exception {
+        LogCaptureService service = new LogCaptureService(1000);
+        int threads = 4;
+        int linesPerThread = 200;
+        Thread[] workers = new Thread[threads];
+        for (int t = 0; t < threads; t++) {
+            final int threadId = t;
+            workers[t] = new Thread(() -> {
+                for (int i = 0; i < linesPerThread; i++) {
+                    service.capture("t" + threadId + "-" + i);
+                }
+            });
+            workers[t].start();
+        }
+        for (Thread worker : workers) {
+            worker.join();
+        }
+
+        assertEquals(threads * linesPerThread, service.size());
+        assertEquals(threads * linesPerThread, service.watermark());
+        assertEquals(threads * linesPerThread, service.drainSince(0).size());
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/logging/LogCaptureServiceTest.java
@@ -104,6 +104,45 @@ class LogCaptureServiceTest {
     }
 
     @Test
+    void hasGapSince_noEviction_returnsFalse() {
+        LogCaptureService service = new LogCaptureService(10);
+        service.capture("a");
+        service.capture("b");
+
+        long watermark = service.watermark();
+        service.capture("c");
+
+        assertFalse(service.hasGapSince(watermark));
+    }
+
+    @Test
+    void hasGapSince_evictionBetweenWatermarkAndBufferStart_returnsTrue() {
+        LogCaptureService service = new LogCaptureService(3);
+        service.capture("a"); // seq=1
+        service.capture("b"); // seq=2
+
+        long watermark = service.watermark(); // 2
+        service.capture("c"); // 3
+        service.capture("d"); // 4（驱逐 a）
+        service.capture("e"); // 5（驱逐 b）
+        service.capture("f"); // 6（驱逐 c —— 水位 2 之后的行开始丢失）
+
+        // 水位 2 之后的行 c(3) 已被驱逐，缓冲起点 seq=4
+        assertTrue(service.hasGapSince(watermark));
+        assertEquals(List.of("d", "e", "f"), service.drainSince(watermark));
+    }
+
+    @Test
+    void hasGapSince_noNewLines_returnsFalse() {
+        LogCaptureService service = new LogCaptureService(3);
+        service.capture("a");
+        service.capture("b");
+
+        long watermark = service.watermark();
+        assertFalse(service.hasGapSince(watermark));
+    }
+
+    @Test
     void constructor_negativeCapacity_throws() {
         assertThrows(IllegalArgumentException.class, () -> new LogCaptureService(0));
         assertThrows(IllegalArgumentException.class, () -> new LogCaptureService(-1));

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/logging/OrzLog4JCaptureAppenderTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/logging/OrzLog4JCaptureAppenderTest.java
@@ -1,0 +1,75 @@
+package com.jokerhub.paper.plugin.orzmc.infra.logging;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.Test;
+
+class OrzLog4JCaptureAppenderTest {
+
+    @Test
+    void append_capturesLoggerOutput() {
+        LogCaptureService service = new LogCaptureService(100);
+        OrzLog4JCaptureAppender appender = new OrzLog4JCaptureAppender(service);
+        // 独立 LoggerContext，不污染全局；root level 设 ALL，直接经 root 记录
+        LoggerContext ctx = new LoggerContext("OrzCaptureTest");
+        ctx.getRootLogger().setLevel(Level.ALL);
+        appender.start();
+        ctx.getRootLogger().addAppender(appender);
+        try {
+            ctx.getRootLogger().info("hello from log4j");
+            ctx.getRootLogger().warn("warning line");
+
+            long watermark = service.watermark();
+            List<String> lines = service.drainSince(0);
+            assertTrue(lines.contains("hello from log4j"), "info 行应被捕获");
+            assertTrue(lines.contains("warning line"), "warn 行应被捕获");
+            assertTrue(watermark >= 2, "水位应前进");
+        } finally {
+            ctx.getRootLogger().removeAppender(appender);
+            appender.stop();
+            ctx.stop();
+        }
+    }
+
+    @Test
+    void append_formattedMessageUsesPlaceholders() {
+        LogCaptureService service = new LogCaptureService(100);
+        OrzLog4JCaptureAppender appender = new OrzLog4JCaptureAppender(service);
+        LoggerContext ctx = new LoggerContext("OrzCaptureTest2");
+        ctx.getRootLogger().setLevel(Level.ALL);
+        appender.start();
+        ctx.getRootLogger().addAppender(appender);
+        try {
+            ctx.getRootLogger().info("players: {} / {}", 5, 20);
+
+            List<String> lines = service.drainSince(0);
+            assertTrue(lines.contains("players: 5 / 20"), "占位符应被格式化: " + lines);
+        } finally {
+            ctx.getRootLogger().removeAppender(appender);
+            appender.stop();
+            ctx.stop();
+        }
+    }
+
+    @Test
+    void append_multilineMessage_splitsPerLine() {
+        LogCaptureService service = new LogCaptureService(100);
+        OrzLog4JCaptureAppender appender = new OrzLog4JCaptureAppender(service);
+        LoggerContext ctx = new LoggerContext("OrzCaptureTest3");
+        ctx.getRootLogger().setLevel(Level.ALL);
+        appender.start();
+        ctx.getRootLogger().addAppender(appender);
+        try {
+            ctx.getRootLogger().info("line1\nline2");
+
+            assertEquals(List.of("line1", "line2"), service.drainSince(0));
+        } finally {
+            ctx.getRootLogger().removeAppender(appender);
+            appender.stop();
+            ctx.stop();
+        }
+    }
+}


### PR DESCRIPTION
## 背景

`$e <控制台命令>` 执行后台指令后，群里只返回「命令已执行/命令不存在或执行失败」状态文本——现有实现用动态代理包装 ConsoleCommandSender **同步捕获** sendMessage，但绝大多数插件命令输出是**异步回调/直接写日志**，捕获不到。

## 方案（已与老板确认）

同步代理捕获（保留）+ **Log4J root Appender 日志时间窗兜底**：
1. 新增 `LogCaptureService`（纯 Java 环形缓冲 500 行）：capture 时拆分多行/剥离 ANSI 色码/丢弃空行；`watermark()` + `drainSince()` 时间窗增量查询
2. 新增 `OrzLog4JCaptureAppender`：Log4J root Appender 把服务器日志行喂给缓冲（**Paper 26.2 已移除 ServerLogEvent**，日志监听只能走 Log4J Appender 路线）
3. `$e` 流程：先取水位 → dispatch → 延迟 40 tick（2s）取窗口增量 → `CommandOutputAssembler` 合并同步行+日志行（保序去重、过滤 `issued server command` 回显噪音、30 行截断防刷群）→ 发群
4. 未注入 LogCaptureService 时退化为原逻辑；Appender 注册失败降级仅警告，不阻塞启动

## 验证

| 项 | 结果 |
|:--|:--|
| 单测 | 全绿（新增 25 个：LogCaptureService 多线程/容量/ANSI、Appender 真实 Log4J、Assembler 噪音/去重/截断、$e 窗口流程） |
| integrationTest | 全绿（2 个 $e 测试适配 60 tick 延迟回包） |
| spotless + jacoco | 通过 |
| 本地测试服实测 | `$e list`（Essentials 异步✅）/ `$e tps`（同步✅）/ `$e luckperms groups list`（LP 异步多行✅）/ `$e plugins`（✅），回显噪音过滤 + ANSI 剥离正常 |

## 改动

13 文件 +667/-3：3 个新主类 + 3 个新测试类 + BotCommandService/$e 流程 + PlatformModule Appender 生命周期 + BotModule 装配 + log4j compileOnly 依赖