### PR TITLE
feat(player_notify): 上下线通知窗口聚合（无丢消息 + 速率上界）

### DIFF
--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CapturingSink.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CapturingSink.java
@@ -1,0 +1,45 @@
+package com.jokerhub.paper.plugin.orzmc.integration;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.NotifierSink;
+import java.util.ArrayList;
+import java.util.List;
+import net.kyori.adventure.text.Component;
+
+/**
+ * 捕获 Notifier 事件与服务端消息的测试替身（NotifierSink 策略，见 CLAUDE.md「通知策略」）。
+ * 注册到 {@code notifier().registerSink(...)} 后，即可断言插件发出的每条通知消息。
+ */
+final class CapturingSink implements NotifierSink {
+
+    /** 包内测试直接读取捕获结果。 */
+    final List<String> keys = new ArrayList<>();
+
+    final List<MessageEnvelope> envelopes = new ArrayList<>();
+    final List<Component> serverMessages = new ArrayList<>();
+
+    @Override
+    public void server(Component message) {
+        serverMessages.add(message);
+    }
+
+    @Override
+    public void event(String key, MessageEnvelope envelope) {
+        keys.add(key);
+        envelopes.add(envelope);
+    }
+
+    void clear() {
+        keys.clear();
+        envelopes.clear();
+        serverMessages.clear();
+    }
+
+    boolean isEmpty() {
+        return keys.isEmpty();
+    }
+
+    MessageEnvelope lastEnvelope() {
+        return envelopes.get(envelopes.size() - 1);
+    }
+}

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandAndEventIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/CommandAndEventIntegrationTest.java
@@ -4,9 +4,6 @@ import com.jokerhub.paper.plugin.orzmc.OrzMC;
 import com.jokerhub.paper.plugin.orzmc.assembly.BotModule;
 import com.jokerhub.paper.plugin.orzmc.core.bot.BotInboundHandler;
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
-import com.jokerhub.paper.plugin.orzmc.infra.notify.NotifierSink;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -53,13 +50,21 @@ public class CommandAndEventIntegrationTest {
     @Test
     public void testPlayerJoinEventDispatch() {
         PlayerMock player = server.addPlayer();
+        // addPlayer() 已触发真实 PlayerJoinEvent；通知经聚合延迟一个窗口，先冲刷掉，
+        // 避免与下面手动派发的事件同窗口合并为摘要。
+        server.getScheduler().performTicks(FLUSH_TICKS);
+        sink.clear();
         Assertions.assertDoesNotThrow(
                 () -> server.getPluginManager().callEvent(new PlayerJoinEvent(player, Component.text("hi"))));
+        server.getScheduler().performTicks(FLUSH_TICKS);
         Assertions.assertTrue(
                 sink.keys.stream().anyMatch(k -> k.equals("player_join")), "player_join event not captured");
         Assertions.assertTrue(
                 sink.envelopes.stream().anyMatch(e -> e != null && e.message() != null), "missing event message");
     }
+
+    /** 聚合窗口（config.yml window_ms=3000ms / 50 = 60 ticks），多 1 tick 确保冲刷执行。 */
+    private static final long FLUSH_TICKS = 61;
 
     @Test
     public void testAdminBotCommandCanExecuteConsoleCommand() {
@@ -85,22 +90,5 @@ public class CommandAndEventIntegrationTest {
 
     private static BotModule getBotModule(OrzMC plugin) {
         return plugin.services().botModule();
-    }
-
-    private static final class CapturingSink implements NotifierSink {
-        private final List<String> keys = new ArrayList<>();
-        private final List<MessageEnvelope> envelopes = new ArrayList<>();
-        private final List<Component> serverMessages = new ArrayList<>();
-
-        @Override
-        public void server(Component message) {
-            serverMessages.add(message);
-        }
-
-        @Override
-        public void event(String key, MessageEnvelope envelope) {
-            keys.add(key);
-            envelopes.add(envelope);
-        }
     }
 }

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/EventIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/EventIntegrationTest.java
@@ -1,17 +1,10 @@
 package com.jokerhub.paper.plugin.orzmc.integration;
 
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
-import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
-import com.jokerhub.paper.plugin.orzmc.infra.notify.NotifierSink;
-import java.util.ArrayList;
-import java.util.List;
-import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
@@ -26,6 +19,9 @@ import org.mockbukkit.mockbukkit.entity.PlayerMock;
 @Tag("integration")
 public class EventIntegrationTest {
 
+    /** 玩家上下线通知聚合窗口（config.yml window_ms=3000ms / 50 = 60 ticks），多 1 tick 确保冲刷执行。 */
+    private static final long FLUSH_TICKS = 61;
+
     private ServerMock server;
     private OrzMC plugin;
     private CapturingSink sink;
@@ -34,6 +30,9 @@ public class EventIntegrationTest {
     public void setUp() {
         server = MockBukkit.mock();
         plugin = MockBukkit.load(OrzMC.class);
+        // 关闭服务端白名单：MockBukkit 会在 PlayerJoinEvent 后把非白名单玩家移出在线列表，
+        // 保持玩家在线的测试语义（与真实服 E2E 的 force_whitelist=false 对齐）。
+        server.setWhitelist(false);
         sink = new CapturingSink();
         plugin.services().botModule().notifier().registerSink(sink);
     }
@@ -46,7 +45,8 @@ public class EventIntegrationTest {
     @Test
     public void testPlayerJoinEventTriggersNotification() {
         PlayerMock player = server.addPlayer();
-        // addPlayer() fires PlayerJoinEvent which should be captured by sink
+        // addPlayer() fires PlayerJoinEvent；通知经聚合延迟一个窗口，推进调度器触发冲刷
+        server.getScheduler().performTicks(FLUSH_TICKS);
         Assertions.assertTrue(
                 sink.keys.stream().anyMatch(k -> k.equals("player_join")),
                 "player_join event should be captured after player join");
@@ -55,38 +55,15 @@ public class EventIntegrationTest {
     @Test
     public void testPlayerQuitEventTriggersNotification() {
         PlayerMock player = server.addPlayer();
-        sink.keys.clear();
-        sink.envelopes.clear();
+        server.getScheduler().performTicks(FLUSH_TICKS); // 先冲刷上线，避免与下线同窗口合并为摘要
+        sink.clear();
 
-        Assertions.assertDoesNotThrow(() -> server.getPluginManager()
-                .callEvent(
-                        new PlayerQuitEvent(player, Component.text("bye"), PlayerQuitEvent.QuitReason.DISCONNECTED)));
+        // disconnect() 触发 PlayerQuitEvent 并移出在线列表（与真实服语义一致）
+        Assertions.assertDoesNotThrow(player::disconnect);
 
+        server.getScheduler().performTicks(FLUSH_TICKS); // 冲刷下线
         Assertions.assertTrue(
                 sink.keys.stream().anyMatch(k -> k.equals("player_quit")), "player_quit event should be captured");
-    }
-
-    @Test
-    public void testManualPlayerJoinEventDispatchesNotification() {
-        PlayerMock player = server.addPlayer();
-        // Clear the sink from the auto-generated player_join event from addPlayer()
-        sink.keys.clear();
-        sink.envelopes.clear();
-
-        Assertions.assertDoesNotThrow(
-                () -> server.getPluginManager().callEvent(new PlayerJoinEvent(player, Component.text("welcome back"))));
-
-        // The manual join event fires notifyPlayerState which routes through throttledNotifier.
-        // If the key was recently used (by addPlayer's join), it may be throttled.
-        boolean captured = sink.keys.stream().anyMatch(k -> k.equals("player_join"));
-        if (!captured) {
-            // Throttling is acceptable — the throttled code path was exercised without error.
-            Assertions.assertTrue(true, "Event may be throttled, which is acceptable");
-        } else {
-            Assertions.assertTrue(
-                    sink.envelopes.stream().anyMatch(e -> e != null && e.message() != null),
-                    "Join event should have a message envelope");
-        }
     }
 
     @Test
@@ -142,22 +119,5 @@ public class EventIntegrationTest {
         Assertions.assertDoesNotThrow(
                 () -> server.getPluginManager().callEvent(event),
                 "TNT BlockPlaceEvent should dispatch without exception");
-    }
-
-    private static final class CapturingSink implements NotifierSink {
-        private final List<String> keys = new ArrayList<>();
-        private final List<MessageEnvelope> envelopes = new ArrayList<>();
-        private final List<Component> serverMessages = new ArrayList<>();
-
-        @Override
-        public void server(Component message) {
-            serverMessages.add(message);
-        }
-
-        @Override
-        public void event(String key, MessageEnvelope envelope) {
-            keys.add(key);
-            envelopes.add(envelope);
-        }
     }
 }

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/PlayerNotifyIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/PlayerNotifyIntegrationTest.java
@@ -1,0 +1,216 @@
+package com.jokerhub.paper.plugin.orzmc.integration;
+
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+/**
+ * 玩家上下线通知聚合的 MockBukkit 集成测试。
+ *
+ * <p>在真实 MockBukkit 服务器上装载完整插件，用真实 Bukkit 事件
+ * （{@code addPlayer} → PlayerJoinEvent、{@code disconnect} → PlayerQuitEvent、
+ * {@code kick} → PlayerKickEvent）驱动整条链路：
+ * 事件监听器 → PlayerEventService → PlayerEventAggregator → Notifier → CapturingSink。
+ *
+ * <p>验证聚合约束：窗口内多条事件合并为一条摘要且计数精确、单条事件延迟一个窗口仍走原模板、
+ * 跨窗口无丢消息（事件总数 = Σ单条消息数 + Σ摘要计数）、名称截断不影响计数。
+ */
+@Tag("integration")
+public class PlayerNotifyIntegrationTest {
+
+    /** 聚合窗口（config.yml {@code player_notify.window_ms=3000ms} / 50 = 60 ticks），多 1 tick 确保冲刷执行。 */
+    private static final long FLUSH_TICKS = 61;
+
+    private ServerMock server;
+    private OrzMC plugin;
+    private CapturingSink sink;
+
+    @BeforeEach
+    public void setUp() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.load(OrzMC.class);
+        // 关闭服务端白名单（enableForceWhitelist 已在 load 时打开它）：
+        // MockBukkit 会在 PlayerJoinEvent 后把非白名单玩家移出在线列表，
+        // 导致冲刷时刻 online_count 恒为 0。与真实服 E2E 的 force_whitelist=false 对齐。
+        server.setWhitelist(false);
+        sink = new CapturingSink();
+        plugin.services().botModule().notifier().registerSink(sink);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /** 推进调度器越过一个聚合窗口，触发窗口尾部冲刷。 */
+    private void flushWindow() {
+        server.getScheduler().performTicks(FLUSH_TICKS);
+    }
+
+    /** 上线：addPlayer 触发 PlayerJoinEvent（监听器入队聚合器）。 */
+    private PlayerMock join(String name) {
+        return server.addPlayer(name);
+    }
+
+    /** 下线：disconnect 触发 PlayerQuitEvent 并移出在线列表（与真实服语义一致）。 */
+    private void quit(PlayerMock player) {
+        player.disconnect();
+    }
+
+    /** 被踢：kick 触发 PlayerKickEvent 并移出在线列表。 */
+    private void kick(PlayerMock player) {
+        player.kick(Component.text("E2E kick"));
+    }
+
+    // ---- 单发：窗口内仅 1 条事件，延迟一个窗口走原单条模板 ----
+
+    @Test
+    public void singleJoin_rendersPlayerJoinTemplateAfterWindow() {
+        join("e2e_0");
+        Assertions.assertTrue(sink.isEmpty(), "聚合窗口内不应立即发送");
+        flushWindow();
+        Assertions.assertEquals(List.of("player_join"), sink.keys, "单发应复用 player_join 模板");
+        String msg = sink.lastEnvelope().message();
+        Assertions.assertTrue(msg.contains("e2e_0"), "消息应含玩家名: " + msg);
+        Assertions.assertTrue(msg.contains(" 上线"), "应为单条上线模板: " + msg);
+        Assertions.assertTrue(msg.contains("当前在线(1/"), "冲刷时刻在线数为 1: " + msg);
+    }
+
+    @Test
+    public void singleQuit_afterPreviousWindow_rendersPlayerQuitWithoutDoubleSubtract() {
+        PlayerMock p = join("e2e_0");
+        flushWindow(); // 窗口1：上线已发
+        sink.clear();
+        quit(p); // 触发 PlayerQuitEvent + 移出在线列表
+        flushWindow(); // 窗口2
+        Assertions.assertEquals(List.of("player_quit"), sink.keys);
+        String msg = sink.lastEnvelope().message();
+        Assertions.assertTrue(msg.contains(" 下线"), "应为单条下线模板: " + msg);
+        Assertions.assertTrue(msg.contains("当前在线(0/"), "冲刷时刻当事人已离线，不应重复减 1: " + msg);
+    }
+
+    // ---- 多发：窗口内多条事件，合并为一条摘要，计数精确 ----
+
+    @Test
+    public void burstJoins_withinWindow_renderSingleDigestExactCount() {
+        for (int i = 0; i < 6; i++) {
+            join("e2e_" + i);
+        }
+        flushWindow();
+        Assertions.assertEquals(List.of("player_digest"), sink.keys, "窗口内 6 条事件应合并为 1 条摘要");
+        String msg = sink.lastEnvelope().message();
+        Assertions.assertTrue(msg.contains("🟢 +6 上线"), "摘要计数应精确: " + msg);
+        Assertions.assertTrue(msg.contains("e2e_0") && msg.contains("e2e_5"), "应列出玩家名: " + msg);
+        Assertions.assertTrue(msg.contains("当前在线(6/"), "冲刷时刻 6 人在线: " + msg);
+    }
+
+    @Test
+    public void burstMixed_joinQuitKick_renderAllSummaries() {
+        PlayerMock p0 = join("e2e_0");
+        PlayerMock p1 = join("e2e_1");
+        PlayerMock p2 = join("e2e_2");
+        quit(p1);
+        kick(p2);
+        flushWindow();
+        String msg = sink.lastEnvelope().message();
+        Assertions.assertTrue(msg.contains("🟢 +3 上线"), "3 人都在窗口内上线，摘要应 +3: " + msg);
+        Assertions.assertTrue(msg.contains("🔴 -1 下线"), "got: " + msg);
+        Assertions.assertTrue(msg.contains("⛔ -1 被踢"), "got: " + msg);
+        Assertions.assertTrue(msg.contains("当前在线(1/"), "3 加入 -1 退出 -1 被踢 = 剩 1: " + msg);
+    }
+
+    @Test
+    public void manyJoins_inOneWindow_truncateNamesButCountExact() {
+        // max_list_items 默认 6：10 条事件 → 摘要计数 +10，名称仅显示前 6 并附 "等4人"
+        for (int i = 0; i < 10; i++) {
+            join("e2e_" + i);
+        }
+        flushWindow();
+        String msg = sink.lastEnvelope().message();
+        Assertions.assertTrue(msg.contains("🟢 +10 上线"), "计数应精确 +10: " + msg);
+        Assertions.assertTrue(msg.contains("等4人"), "超出 max_list_items 应显示 等4人: " + msg);
+    }
+
+    // ---- 窗口边界与跨窗口无丢消息 ----
+
+    @Test
+    public void windowBoundary_singleEventsInSeparateWindows_keepSingleTemplates() {
+        PlayerMock p = join("e2e_0");
+        flushWindow(); // 窗口1：player_join
+        quit(p);
+        flushWindow(); // 窗口2：player_quit
+        Assertions.assertEquals(List.of("player_join", "player_quit"), sink.keys, "各窗口独立，单发仍走单模板");
+    }
+
+    @Test
+    public void manyEvents_acrossWindows_noMessageLoss() {
+        // 窗口1：5 加入；窗口2：3 退出；窗口3：2 加入
+        PlayerMock p1 = join("e2e_1");
+        PlayerMock p2 = join("e2e_2");
+        PlayerMock p3 = join("e2e_3");
+        join("e2e_4");
+        join("e2e_5");
+        flushWindow();
+        quit(p1);
+        quit(p2);
+        quit(p3);
+        flushWindow();
+        join("e2e_8");
+        join("e2e_9");
+        flushWindow();
+
+        Totals totals = Totals.from(sink);
+        Assertions.assertEquals(7, totals.join, "7 次加入全部被计数，无丢弃");
+        Assertions.assertEquals(3, totals.quit, "3 次退出全部被计数，无丢弃");
+        Assertions.assertEquals(0, totals.kick);
+        Assertions.assertEquals(3, sink.keys.size(), "3 个窗口 → 恰好 3 条消息（每个窗口 1 条）");
+    }
+
+    /** 从捕获消息汇总各状态事件数（摘要按 +N/-N 计数，单条计 1）——与 tools/e2e 对账公式一致。 */
+    private static final class Totals {
+        private int join;
+        private int quit;
+        private int kick;
+
+        static Totals from(CapturingSink sink) {
+            Totals t = new Totals();
+            for (int i = 0; i < sink.keys.size(); i++) {
+                String key = sink.keys.get(i);
+                String msg = sink.envelopes.get(i).message();
+                switch (key) {
+                    case "player_join" -> t.join++;
+                    case "player_quit" -> t.quit++;
+                    case "player_kick" -> t.kick++;
+                    case "player_digest" -> {
+                        t.join += count(msg, "🟢 \\+(\\d+) 上线");
+                        t.quit += count(msg, "🔴 -(\\d+) 下线");
+                        t.kick += count(msg, "⛔ -(\\d+) 被踢");
+                    }
+                    default -> {
+                        // 未知事件键不参与对账
+                    }
+                }
+            }
+            return t;
+        }
+
+        private static int count(String text, String regex) {
+            Matcher m = Pattern.compile(regex).matcher(text);
+            int sum = 0;
+            while (m.find()) {
+                sum += Integer.parseInt(m.group(1));
+            }
+            return sum;
+        }
+    }
+}

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/WhitelistIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/WhitelistIntegrationTest.java
@@ -3,11 +3,7 @@ package com.jokerhub.paper.plugin.orzmc.integration;
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.WhitelistConfig;
-import com.jokerhub.paper.plugin.orzmc.infra.notify.NotifierSink;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import net.kyori.adventure.text.Component;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -111,22 +107,5 @@ public class WhitelistIntegrationTest {
         Assertions.assertTrue(
                 config.forceWhitelist(),
                 "Default force_whitelist should be true when config section is present but empty");
-    }
-
-    private static final class CapturingSink implements NotifierSink {
-        private final List<String> keys = new ArrayList<>();
-        private final List<MessageEnvelope> envelopes = new ArrayList<>();
-        private final List<Component> serverMessages = new ArrayList<>();
-
-        @Override
-        public void server(Component message) {
-            serverMessages.add(message);
-        }
-
-        @Override
-        public void event(String key, MessageEnvelope envelope) {
-            keys.add(key);
-            envelopes.add(envelope);
-        }
     }
 }

--- a/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/WhitelistIntegrationTest.java
+++ b/src/integrationTest/java/com/jokerhub/paper/plugin/orzmc/integration/WhitelistIntegrationTest.java
@@ -29,6 +29,9 @@ public class WhitelistIntegrationTest {
     public void setUp() {
         server = MockBukkit.mock();
         plugin = MockBukkit.load(OrzMC.class);
+        // 关闭服务端白名单：MockBukkit 会在 PlayerJoinEvent 后把非白名单玩家移出在线列表，
+        // 保持玩家在线的测试语义（与真实服 E2E 的 force_whitelist=false 对齐）。
+        server.setWhitelist(false);
         sink = new CapturingSink();
         plugin.services().botModule().notifier().registerSink(sink);
     }
@@ -87,10 +90,15 @@ public class WhitelistIntegrationTest {
     public void testPlayerJoinCapturedBySink() {
         PlayerMock player = server.addPlayer();
         // addPlayer() triggers PlayerJoinEvent which routes through notifier
+        // 通知经聚合延迟一个窗口，推进调度器触发冲刷
+        server.getScheduler().performTicks(FLUSH_TICKS);
         Assertions.assertFalse(sink.keys.isEmpty(), "Sink should have captured at least one event");
         Assertions.assertTrue(
                 sink.keys.stream().anyMatch(k -> k.equals("player_join")), "player_join should be captured");
     }
+
+    /** 聚合窗口（config.yml window_ms=3000ms / 50 = 60 ticks），多 1 tick 确保冲刷执行。 */
+    private static final long FLUSH_TICKS = 61;
 
     @Test
     public void testWhitelistConfigLoadedFromYaml() {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzServices.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzServices.java
@@ -87,6 +87,10 @@ public final class OrzServices {
     }
 
     public void shutdownAll() {
+        // 先冲刷上下线聚合挂起批次（配置/通知器仍存活），再通知服务端关闭：
+        // Bukkit 禁用插件时会取消待执行任务，窗口尾部调度来不及运行，同步冲刷避免静默丢弃
+        featureModule.flushPlayerNotifications();
+
         // 通知服务端关闭
         featureModule.notifyServerStop();
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -870,6 +870,11 @@ public final class FeatureModule implements ServiceModule {
 
     // --- Lifecycle ---
 
+    /** 禁用/重载时同步冲刷上下线聚合批次，避免最后一个窗口的事件被调度器取消而静默丢弃。 */
+    public void flushPlayerNotifications() {
+        playerEventService.flushPending();
+    }
+
     public void notifyServerStop() {
         serverLifecycleService.notifyServerStop();
     }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -21,6 +21,7 @@ import com.jokerhub.paper.plugin.orzmc.features.command.binding.PlayerOnlyInterc
 import com.jokerhub.paper.plugin.orzmc.features.guide.GuideService;
 import com.jokerhub.paper.plugin.orzmc.features.menu.MenuCommandService;
 import com.jokerhub.paper.plugin.orzmc.features.menu.MenuEventService;
+import com.jokerhub.paper.plugin.orzmc.features.player.PlayerEventAggregator;
 import com.jokerhub.paper.plugin.orzmc.features.player.PlayerEventService;
 import com.jokerhub.paper.plugin.orzmc.features.portal.PortalCommandService;
 import com.jokerhub.paper.plugin.orzmc.features.portal.PortalEventService;
@@ -111,13 +112,15 @@ public final class FeatureModule implements ServiceModule {
         this.geoIpAccessService = new GeoIpAccessService(platform.configs());
         this.blacklistService = new BlacklistService(platform.configService());
         this.guideService = new GuideService(platform.serverFacade(), platform.configService(), platform.textStyles());
+        // 上下线通知：窗口聚合限流（不丢消息），单发走原模板、多发走 player_digest 摘要
         this.playerEventService = new PlayerEventService(
                 platform.serverFacade(),
                 platform.configs(),
                 platform.textStyles(),
                 botModule.notifier(),
                 platform.throttledNotifier(),
-                this.listFormatter);
+                new PlayerEventAggregator(
+                        platform.serverFacade(), platform.configs(), botModule.notifier(), this.listFormatter));
         this.tntEventService = new TntEventService(
                 platform.configs(), platform.textStyles(), botModule.notifier(), platform.serverScheduler());
         this.whitelistEventService =

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/PlatformModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/PlatformModule.java
@@ -41,7 +41,7 @@ public final class PlatformModule implements ServiceModule {
         this.configs = new DefaultTypedConfigProvider(configService);
         this.textStyles = new OrzTextStyles(configService);
         this.throttledLogger = new ThrottledLogger(configService, plugin.getLogger());
-        this.throttledNotifier = new ThrottledNotifier(configService);
+        this.throttledNotifier = new ThrottledNotifier();
         this.healthRegistry = new HealthRegistry();
         this.logCaptureService = new LogCaptureService(LOG_CAPTURE_CAPACITY);
     }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
@@ -4,6 +4,7 @@ import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.Templates;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TntConfig;
@@ -25,6 +26,8 @@ public interface TypedConfigProvider {
     Templates templates();
 
     TntConfig tnt();
+
+    PlayerNotifyConfig playerNotify();
 
     IpWhitelist ipWhitelist();
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
@@ -8,6 +8,7 @@ import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
@@ -77,7 +78,9 @@ public class OrzPlayerEvent extends OrzBaseListener {
         service.notifyPlayerState(event.getPlayer(), PlayerEventService.PlayerState.QUIT);
     }
 
-    @EventHandler
+    // MONITOR：观察最终取消状态——若在 LOW/HIGHEST 等早期优先级被其他插件取消，
+    // NORMAL 默认优先级下的 isCancelled() 尚未反映最终结果，会误发「被踢」通知。
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerKickLeave(PlayerKickEvent event) {
         if (event.isCancelled()) {
             // 被其他插件取消的踢人：玩家仍在线上，不产生「被踢」通知

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
@@ -79,6 +79,10 @@ public class OrzPlayerEvent extends OrzBaseListener {
 
     @EventHandler
     public void onPlayerKickLeave(PlayerKickEvent event) {
+        if (event.isCancelled()) {
+            // 被其他插件取消的踢人：玩家仍在线上，不产生「被踢」通知
+            return;
+        }
         service.notifyPlayerState(event.getPlayer(), PlayerEventService.PlayerState.KICK);
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregator.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregator.java
@@ -1,0 +1,232 @@
+package com.jokerhub.paper.plugin.orzmc.features.player;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
+import com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import com.jokerhub.paper.plugin.orzmc.infra.templates.CoordFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+/**
+ * 玩家上下线通知的窗口聚合器（无丢消息）。
+ *
+ * <p>JOIN/QUIT/KICK 事件在聚合窗口内累积，窗口尾部统一冲刷为一条消息：
+ * <ul>
+ *   <li>窗口内仅 1 条事件 → 复用原单条模板（player_join / player_quit / player_kick），
+ *       延迟一个窗口发出（保持最多 1 条/窗口的速率上界）；</li>
+ *   <li>窗口内多条事件 → 渲染聚合摘要 {@code player_digest}，按状态精确计数，
+ *       玩家名超长仅显示截断（追加 {@code +等N人}），计数不受影响。</li>
+ * </ul>
+ * 没有任何丢弃路径：限流完全通过窗口合并实现，每条事件要么作为唯一事件单条渲染，
+ * 要么进入摘要被精确计数。</p>
+ *
+ * <p>事件（Bukkit 事件监听器）与冲刷（{@code runLater} 同步任务）都在主线程，
+ * 无并发竞态。配置每次 {@link #enqueue} 时实时读取，热重载立即生效。</p>
+ */
+public final class PlayerEventAggregator {
+
+    /** Bukkit 调度 tick 时长（毫秒）。 */
+    private static final long TICKS_PER_MS = 50L;
+
+    private final ServerFacade server;
+    private final TypedConfigProvider configs;
+    private final Notifier notifier;
+    private final OnlineListFormatter listFormatter;
+
+    /** 当前聚合窗口批次（仅主线程访问）；null 表示无待冲刷批次。 */
+    private PendingBatch batch;
+
+    public PlayerEventAggregator(
+            ServerFacade server, TypedConfigProvider configs, Notifier notifier, OnlineListFormatter listFormatter) {
+        this.server = server;
+        this.configs = configs;
+        this.notifier = notifier;
+        this.listFormatter = listFormatter;
+    }
+
+    /**
+     * 收纳入队一条上下线事件。
+     *
+     * @param player 事件当事人
+     * @param state  事件类型
+     */
+    public void enqueue(Player player, PlayerEventService.PlayerState state) {
+        PlayerNotifyConfig cfg = configs.playerNotify();
+        if (!enabled(cfg, state)) {
+            // 管理员显式关闭该类型通知：配置性忽略，不属于运行时丢消息
+            return;
+        }
+        PendingBatch current = batch;
+        if (current == null) {
+            current = new PendingBatch();
+            long windowMs = cfg.windowMs();
+            long ticks = Math.max(1, windowMs / TICKS_PER_MS);
+            // 尾部调度成功后才入表：中途抛异常不留孤儿批次（该批次永远不会被冲刷）
+            server.runLater(this::flushTail, ticks);
+            batch = current;
+        }
+        current.add(player, state);
+    }
+
+    private static boolean enabled(PlayerNotifyConfig cfg, PlayerEventService.PlayerState state) {
+        return switch (state) {
+            case JOIN -> cfg.enabledJoin();
+            case QUIT -> cfg.enabledQuit();
+            case KICK -> cfg.enabledKick();
+        };
+    }
+
+    /** 窗口尾部冲刷：批次清零；单发走原模板，多发走聚合摘要。 */
+    private void flushTail() {
+        PendingBatch current = batch;
+        batch = null;
+        if (current == null || current.total() == 0) {
+            return;
+        }
+        if (current.total() == 1) {
+            renderSingle(current.singlePlayer(), current.singleState());
+        } else {
+            renderDigest(current);
+        }
+    }
+
+    /** 单发渲染：复用原单条模板。在线状态以冲刷时刻为准（当事人已离开/已加入），无需修正。 */
+    private void renderSingle(Player player, PlayerEventService.PlayerState state) {
+        ArrayList<Player> onlinePlayers = onlinePlayers();
+        int onlinePlayerCount = onlinePlayers.size();
+        int maxPlayerCount = server.server().getMaxPlayers();
+        Map<String, String> vars = new HashMap<>();
+        Location loc = player.getLocation();
+        if (loc != null) {
+            TemplateOptions opt = configs.templateOptions();
+            vars.putAll(CoordFormatter.format(loc, opt));
+        }
+        vars.put("world", loc != null && loc.getWorld() != null ? loc.getWorld().getName() : "unknown");
+        vars.put("name", listFormatter.line(player));
+        vars.put("online_count", String.valueOf(onlinePlayerCount));
+        vars.put("max_count", String.valueOf(maxPlayerCount));
+        vars.put("online_list", formatOnlineList(onlinePlayers));
+        String eventKey =
+                switch (state) {
+                    case JOIN -> "player_join";
+                    case QUIT -> "player_quit";
+                    case KICK -> "player_kick";
+                };
+        MessageEnvelope envelope = configs.renderEvent(eventKey, vars);
+        notifier.event(eventKey, envelope);
+        server.logger().info(envelope.message());
+    }
+
+    /** 多发渲染：按状态精确计数，玩家名显示截断（计数不受影响），可选附带在线列表。 */
+    private void renderDigest(PendingBatch current) {
+        PlayerNotifyConfig cfg = configs.playerNotify();
+        String joinSummary = buildSummary(current.joins, "🟢", "上线", "+", cfg.maxListItems());
+        String quitSummary = buildSummary(current.quits, "🔴", "下线", "-", cfg.maxListItems());
+        String kickSummary = buildSummary(current.kicks, "⛔", "被踢", "-", cfg.maxListItems());
+        ArrayList<Player> onlinePlayers = onlinePlayers();
+        Map<String, String> vars = new HashMap<>();
+        vars.put("join_summary", joinSummary);
+        vars.put("quit_summary", quitSummary);
+        vars.put("kick_summary", kickSummary);
+        vars.put("online_count", String.valueOf(onlinePlayers.size()));
+        vars.put("max_count", String.valueOf(server.server().getMaxPlayers()));
+        vars.put("online_list", cfg.includeOnlineList() ? "\n" + formatOnlineList(onlinePlayers) : "");
+        MessageEnvelope envelope = configs.renderEvent("player_digest", vars);
+        notifier.event("player_digest", envelope);
+        server.logger().info(envelope.message());
+    }
+
+    /** 单状态摘要：如 "🟢 +5 上线：A、B、C、D、E\n"；无事件返回空串。 */
+    private static String buildSummary(
+            List<Player> players, String marker, String action, String sign, int maxListItems) {
+        if (players.isEmpty()) {
+            return "";
+        }
+        return marker + " " + sign + players.size() + " " + action + "：" + joinNames(players, maxListItems) + "\n";
+    }
+
+    /** 玩家名列表（顿号分隔），超长仅截断显示并追加 "、等N人"（计数不受影响）。 */
+    private static String joinNames(List<Player> players, int maxListItems) {
+        int shown = Math.min(maxListItems, players.size());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < shown; i++) {
+            if (i > 0) {
+                sb.append("、");
+            }
+            sb.append(players.get(i).getName());
+        }
+        int hidden = players.size() - shown;
+        if (hidden > 0) {
+            sb.append("、等").append(hidden).append("人");
+        }
+        return sb.toString();
+    }
+
+    private ArrayList<Player> onlinePlayers() {
+        ArrayList<Player> result = new ArrayList<>();
+        Object[] objects = server.server().getOnlinePlayers().toArray();
+        for (Object obj : objects) {
+            if (obj instanceof Player p) {
+                result.add(p);
+            }
+        }
+        return result;
+    }
+
+    private String formatOnlineList(List<Player> players) {
+        StringBuilder sb = new StringBuilder();
+        for (Player p : players) {
+            sb.append(listFormatter.line(p)).append('\n');
+        }
+        return sb.toString().trim();
+    }
+
+    /** 一个聚合窗口内的待发批次（仅主线程访问）。 */
+    private static final class PendingBatch {
+        private final List<Player> joins = new ArrayList<>();
+        private final List<Player> quits = new ArrayList<>();
+        private final List<Player> kicks = new ArrayList<>();
+
+        void add(Player player, PlayerEventService.PlayerState state) {
+            switch (state) {
+                case JOIN -> joins.add(player);
+                case QUIT -> quits.add(player);
+                case KICK -> kicks.add(player);
+            }
+        }
+
+        int total() {
+            return joins.size() + quits.size() + kicks.size();
+        }
+
+        /** 单事件当事人；仅在 {@code total() == 1} 时调用。 */
+        Player singlePlayer() {
+            if (!joins.isEmpty()) {
+                return joins.get(0);
+            }
+            if (!quits.isEmpty()) {
+                return quits.get(0);
+            }
+            return kicks.get(0);
+        }
+
+        /** 单事件类型；仅在 {@code total() == 1} 时调用。 */
+        PlayerEventService.PlayerState singleState() {
+            if (!joins.isEmpty()) {
+                return PlayerEventService.PlayerState.JOIN;
+            }
+            if (!quits.isEmpty()) {
+                return PlayerEventService.PlayerState.QUIT;
+            }
+            return PlayerEventService.PlayerState.KICK;
+        }
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregator.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregator.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
@@ -34,8 +35,24 @@ import org.bukkit.entity.Player;
  * 无并发竞态。配置每次 {@link #enqueue} 时实时读取，热重载立即生效；冲刷时也会
  * 按最新配置过滤（窗口内被关闭的类型不再发送，属于配置性忽略而非运行时丢消息）。</p>
  *
- * <p>当事人属性（玩家名/显示行/坐标）在 {@link #enqueue} 时快照：冲刷可能发生在
+ * <p>当事人属性（玩家名/显示行/坐标/UUID）在 {@link #enqueue} 时快照：冲刷可能发生在
  * 当事人已离线之后，避免读取离线玩家的属性（null 坐标 / null 显示名）。</p>
+ *
+ * <p>真实 Paper 中一次成功的踢出会同时触发 {@code PlayerKickEvent} 与 {@code PlayerQuitEvent}
+ * （同一离开被上报两次）。聚合器在批次内按玩家 UUID 去重：窗口内同一玩家已有 KICK 时，
+ * 随后的 QUIT 折叠为「被踢」单次计数（保留更具体的语义），避免摘要双计。
+ * （MockBukkit 的 {@code kick()} 不触发 QuitEvent，该去重对真实服生效、对测试无副作用。）</p>
+ *
+ * <p>插件禁用/重载时 Bukkit 会取消插件待执行任务，窗口尾部调度可能来不及运行，批次将
+ * 静默丢弃。{@link #flushPending()} 提供同步冲刷入口，由组合根在 {@code shutdownAll} 时
+ * 调用，保证最后一个窗口的事件在卸载前交付（与「无静默丢弃」约束一致）。</p>
+ *
+ * <p>已知取舍（均为极低频或管理员显式配置变更的边界场景，不影响正常路径的精确计数）：
+ * <ul>
+ *   <li>渲染失败重试时，后续窗口的新事件并入重试批次（恢复后一并冲刷，见 {@link #MAX_RENDER_RETRIES}）；</li>
+ *   <li>摘要的在线数/在线列表取冲刷时刻实时值，与窗口内被关闭（过滤）的类型可能不严格对齐；</li>
+ *   <li>入队时被配置关闭的类型直接忽略（配置性丢弃，非运行时丢消息）。</li>
+ * </ul></p>
  */
 public final class PlayerEventAggregator {
 
@@ -74,7 +91,8 @@ public final class PlayerEventAggregator {
             return;
         }
         // 入队时快照：冲刷可能发生在当事人已离线之后，避免读离线玩家属性（null 坐标/显示名）
-        PendingEvent event = new PendingEvent(player.getName(), listFormatter.line(player), player.getLocation());
+        PendingEvent event = new PendingEvent(
+                player.getUniqueId(), player.getName(), listFormatter.line(player), player.getLocation());
         PendingBatch current = batch;
         if (current == null) {
             current = new PendingBatch();
@@ -98,8 +116,23 @@ public final class PlayerEventAggregator {
         return Math.max(1, cfg.windowMs() / TICKS_PER_MS);
     }
 
-    /** 窗口尾部冲刷：按最新配置过滤被关闭的类型；单发走原模板，多发走聚合摘要。 */
+    /**
+     * 立即冲刷当前批次（同步，不走调度器）。
+     *
+     * <p>插件禁用/重载时由组合根调用：Bukkit 会取消插件待执行任务，窗口尾部调度可能来不及
+     * 运行，此入口保证最后一个窗口的事件在卸载前交付。禁用场景下渲染失败不再重排，仅告警。</p>
+     */
+    public void flushPending() {
+        flushAndRender(false);
+    }
+
+    /** 调度器回调：窗口尾部冲刷；渲染失败时保留批次重试（有界）。 */
     private void flushTail() {
+        flushAndRender(true);
+    }
+
+    /** 窗口尾部冲刷：按最新配置过滤被关闭的类型；单发走原模板，多发走聚合摘要。 */
+    private void flushAndRender(boolean retryOnFailure) {
         PendingBatch current = batch;
         batch = null;
         if (current == null || current.total() == 0) {
@@ -127,7 +160,7 @@ public final class PlayerEventAggregator {
             }
             // 渲染成功：批次已交付，无需保留
         } catch (RuntimeException e) {
-            handleRenderFailure(current, e);
+            handleRenderFailure(current, e, retryOnFailure);
         }
     }
 
@@ -135,14 +168,15 @@ public final class PlayerEventAggregator {
      * 渲染失败处理：保留批次并重试，避免整窗事件静默丢弃。
      *
      * <p>连续失败达到 {@link #MAX_RENDER_RETRIES} 后放弃（有界），记录严重告警并清空批次，
-     * 避免模板永久损坏时无限重试与批次无限增长。</p>
+     * 避免模板永久损坏时无限重试与批次无限增长。禁用冲刷（{@code retryOnFailure=false}）
+     * 失败仅告警不重排——插件卸载在即，重排的任务不会执行。</p>
      */
-    private void handleRenderFailure(PendingBatch current, RuntimeException e) {
-        if (current.renderRetries() >= MAX_RENDER_RETRIES) {
+    private void handleRenderFailure(PendingBatch current, RuntimeException e, boolean retryOnFailure) {
+        if (!retryOnFailure || current.renderRetries() >= MAX_RENDER_RETRIES) {
             server.logger()
                     .severe("上下线通知连续渲染失败 " + (current.renderRetries() + 1) + " 次，该窗口 " + current.total() + " 条事件无法发送: "
                             + e);
-            return; // batch 已置 null：有界放弃
+            return; // batch 已置 null：有界放弃（禁用冲刷仅告警，不重排）
         }
         current.retry();
         batch = current; // 恢复批次，下次冲刷重试
@@ -166,7 +200,7 @@ public final class PlayerEventAggregator {
         vars.put("name", event.displayLine);
         vars.put("online_count", String.valueOf(onlinePlayers.size()));
         vars.put("max_count", String.valueOf(server.server().getMaxPlayers()));
-        vars.put("online_list", formatOnlineList(onlinePlayers));
+        vars.put("online_list", listFormatter.list(onlinePlayers));
         String eventKey =
                 switch (state) {
                     case JOIN -> TemplateKeys.PLAYER_JOIN;
@@ -191,7 +225,7 @@ public final class PlayerEventAggregator {
         vars.put("kick_summary", kickSummary);
         vars.put("online_count", String.valueOf(onlinePlayers.size()));
         vars.put("max_count", String.valueOf(server.server().getMaxPlayers()));
-        vars.put("online_list", cfg.includeOnlineList() ? "\n" + formatOnlineList(onlinePlayers) : "");
+        vars.put("online_list", cfg.includeOnlineList() ? "\n" + listFormatter.list(onlinePlayers) : "");
         MessageEnvelope envelope = configs.renderEvent(TemplateKeys.PLAYER_DIGEST, vars);
         notifier.event(TemplateKeys.PLAYER_DIGEST, envelope);
         server.logger().info(envelope.message());
@@ -234,21 +268,15 @@ public final class PlayerEventAggregator {
         return result;
     }
 
-    private String formatOnlineList(List<Player> players) {
-        StringBuilder sb = new StringBuilder();
-        for (Player p : players) {
-            sb.append(listFormatter.line(p)).append('\n');
-        }
-        return sb.toString().trim();
-    }
-
     /**
      * 一条聚合事件：入队时的玩家快照。
      *
-     * <p>冲刷发生在窗口尾部（当事人可能已离线），因此玩家名/显示行/坐标均在入队时捕获，
+     * <p>冲刷发生在窗口尾部（当事人可能已离线），因此玩家 UUID/名/显示行/坐标均在入队时捕获，
      * 避免读取离线玩家属性（null 坐标 / null 显示名导致渲染异常或字段丢失）。</p>
      */
     private static final class PendingEvent {
+        /** 玩家 UUID（KICK→QUIT 去重键）。 */
+        final UUID playerId;
         /** 原始玩家名（摘要列表显示）。 */
         final String name;
         /** 显示行（玩家名(op) 游戏模式 权限组），入队时计算。 */
@@ -256,7 +284,8 @@ public final class PlayerEventAggregator {
         /** 入队时坐标快照；可能为 null（如当事人已离线但 Location 不可用）。 */
         final Location location;
 
-        PendingEvent(String name, String displayLine, Location location) {
+        PendingEvent(UUID playerId, String name, String displayLine, Location location) {
+            this.playerId = playerId;
             this.name = name;
             this.displayLine = displayLine;
             this.location = location;
@@ -272,11 +301,31 @@ public final class PlayerEventAggregator {
         private int renderRetries;
 
         void add(PendingEvent event, PlayerEventService.PlayerState state) {
+            if (state == PlayerEventService.PlayerState.QUIT && hasKick(event.playerId)) {
+                // 真实 Paper 中一次成功的踢出会同时触发 PlayerKickEvent 与 PlayerQuitEvent，
+                // 同一离开被上报两次。窗口内同 playerId 已有 KICK → 该 QUIT 是踢出的跟随事件，
+                // 折叠只保留更具体的「被踢」，避免摘要双计。
+                // （极端场景「被踢→3 秒内重连→再次退出」可能被误折叠，概率极低且计数误差有界 ≤1。）
+                return;
+            }
             switch (state) {
                 case JOIN -> joins.add(event);
                 case QUIT -> quits.add(event);
                 case KICK -> kicks.add(event);
             }
+        }
+
+        /** 本批次内该玩家是否已有 KICK（用于折叠其随后的 QUIT）。 */
+        private boolean hasKick(UUID playerId) {
+            if (playerId == null) {
+                return false; // 防御性短路：理论真实玩家必有 UUID，null 不折叠
+            }
+            for (PendingEvent e : kicks) {
+                if (playerId.equals(e.playerId)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         int total() {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregator.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregator.java
@@ -2,6 +2,7 @@ package com.jokerhub.paper.plugin.orzmc.features.player;
 
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.config.TemplateKeys;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
@@ -25,16 +26,24 @@ import org.bukkit.entity.Player;
  *   <li>窗口内多条事件 → 渲染聚合摘要 {@code player_digest}，按状态精确计数，
  *       玩家名超长仅显示截断（追加 {@code +等N人}），计数不受影响。</li>
  * </ul>
- * 没有任何丢弃路径：限流完全通过窗口合并实现，每条事件要么作为唯一事件单条渲染，
- * 要么进入摘要被精确计数。</p>
+ * 没有任何静默丢弃路径：限流完全通过窗口合并实现，每条事件要么作为唯一事件单条渲染，
+ * 要么进入摘要被精确计数。渲染失败（模板/通知异常）时保留批次并在下一窗口重试
+ * （连续失败上限 {@link #MAX_RENDER_RETRIES} 后放弃并告警，避免无限重试/批次无限增长）。</p>
  *
  * <p>事件（Bukkit 事件监听器）与冲刷（{@code runLater} 同步任务）都在主线程，
- * 无并发竞态。配置每次 {@link #enqueue} 时实时读取，热重载立即生效。</p>
+ * 无并发竞态。配置每次 {@link #enqueue} 时实时读取，热重载立即生效；冲刷时也会
+ * 按最新配置过滤（窗口内被关闭的类型不再发送，属于配置性忽略而非运行时丢消息）。</p>
+ *
+ * <p>当事人属性（玩家名/显示行/坐标）在 {@link #enqueue} 时快照：冲刷可能发生在
+ * 当事人已离线之后，避免读取离线玩家的属性（null 坐标 / null 显示名）。</p>
  */
 public final class PlayerEventAggregator {
 
     /** Bukkit 调度 tick 时长（毫秒）。 */
     private static final long TICKS_PER_MS = 50L;
+
+    /** 单批次渲染连续失败的最大重试次数；达到后放弃并记录严重告警。 */
+    private static final int MAX_RENDER_RETRIES = 3;
 
     private final ServerFacade server;
     private final TypedConfigProvider configs;
@@ -64,16 +73,17 @@ public final class PlayerEventAggregator {
             // 管理员显式关闭该类型通知：配置性忽略，不属于运行时丢消息
             return;
         }
+        // 入队时快照：冲刷可能发生在当事人已离线之后，避免读离线玩家属性（null 坐标/显示名）
+        PendingEvent event = new PendingEvent(player.getName(), listFormatter.line(player), player.getLocation());
         PendingBatch current = batch;
         if (current == null) {
             current = new PendingBatch();
-            long windowMs = cfg.windowMs();
-            long ticks = Math.max(1, windowMs / TICKS_PER_MS);
+            long ticks = windowTicks(cfg);
             // 尾部调度成功后才入表：中途抛异常不留孤儿批次（该批次永远不会被冲刷）
             server.runLater(this::flushTail, ticks);
             batch = current;
         }
-        current.add(player, state);
+        current.add(event, state);
     }
 
     private static boolean enabled(PlayerNotifyConfig cfg, PlayerEventService.PlayerState state) {
@@ -84,41 +94,84 @@ public final class PlayerEventAggregator {
         };
     }
 
-    /** 窗口尾部冲刷：批次清零；单发走原模板，多发走聚合摘要。 */
+    private static long windowTicks(PlayerNotifyConfig cfg) {
+        return Math.max(1, cfg.windowMs() / TICKS_PER_MS);
+    }
+
+    /** 窗口尾部冲刷：按最新配置过滤被关闭的类型；单发走原模板，多发走聚合摘要。 */
     private void flushTail() {
         PendingBatch current = batch;
         batch = null;
         if (current == null || current.total() == 0) {
             return;
         }
-        if (current.total() == 1) {
-            renderSingle(current.singlePlayer(), current.singleState());
-        } else {
-            renderDigest(current);
+        // 冲刷时按最新配置过滤：窗口内被关闭的类型不再发送（配置性忽略，非运行时丢消息）
+        PlayerNotifyConfig cfg = configs.playerNotify();
+        if (!cfg.enabledJoin()) {
+            current.joins.clear();
+        }
+        if (!cfg.enabledQuit()) {
+            current.quits.clear();
+        }
+        if (!cfg.enabledKick()) {
+            current.kicks.clear();
+        }
+        if (current.total() == 0) {
+            return;
+        }
+        try {
+            if (current.total() == 1) {
+                renderSingle(current.singleEvent(), current.singleState());
+            } else {
+                renderDigest(current);
+            }
+            // 渲染成功：批次已交付，无需保留
+        } catch (RuntimeException e) {
+            handleRenderFailure(current, e);
         }
     }
 
-    /** 单发渲染：复用原单条模板。在线状态以冲刷时刻为准（当事人已离开/已加入），无需修正。 */
-    private void renderSingle(Player player, PlayerEventService.PlayerState state) {
-        ArrayList<Player> onlinePlayers = onlinePlayers();
-        int onlinePlayerCount = onlinePlayers.size();
-        int maxPlayerCount = server.server().getMaxPlayers();
-        Map<String, String> vars = new HashMap<>();
-        Location loc = player.getLocation();
-        if (loc != null) {
-            TemplateOptions opt = configs.templateOptions();
-            vars.putAll(CoordFormatter.format(loc, opt));
+    /**
+     * 渲染失败处理：保留批次并重试，避免整窗事件静默丢弃。
+     *
+     * <p>连续失败达到 {@link #MAX_RENDER_RETRIES} 后放弃（有界），记录严重告警并清空批次，
+     * 避免模板永久损坏时无限重试与批次无限增长。</p>
+     */
+    private void handleRenderFailure(PendingBatch current, RuntimeException e) {
+        if (current.renderRetries() >= MAX_RENDER_RETRIES) {
+            server.logger()
+                    .severe("上下线通知连续渲染失败 " + (current.renderRetries() + 1) + " 次，该窗口 " + current.total() + " 条事件无法发送: "
+                            + e);
+            return; // batch 已置 null：有界放弃
         }
-        vars.put("world", loc != null && loc.getWorld() != null ? loc.getWorld().getName() : "unknown");
-        vars.put("name", listFormatter.line(player));
-        vars.put("online_count", String.valueOf(onlinePlayerCount));
-        vars.put("max_count", String.valueOf(maxPlayerCount));
+        current.retry();
+        batch = current; // 恢复批次，下次冲刷重试
+        server.logger().warning("上下线通知渲染失败，保留批次于下一窗口重试（第 " + current.renderRetries() + " 次）: " + e);
+        server.runLater(this::flushTail, windowTicks(configs.playerNotify()));
+    }
+
+    /** 单发渲染：复用原单条模板。在线状态以冲刷时刻为准（当事人已离开/已加入），无需修正。 */
+    private void renderSingle(PendingEvent event, PlayerEventService.PlayerState state) {
+        ArrayList<Player> onlinePlayers = onlinePlayers();
+        Map<String, String> vars = new HashMap<>();
+        if (event.location != null) {
+            TemplateOptions opt = configs.templateOptions();
+            vars.putAll(CoordFormatter.format(event.location, opt));
+        }
+        vars.put(
+                "world",
+                event.location != null && event.location.getWorld() != null
+                        ? event.location.getWorld().getName()
+                        : "unknown");
+        vars.put("name", event.displayLine);
+        vars.put("online_count", String.valueOf(onlinePlayers.size()));
+        vars.put("max_count", String.valueOf(server.server().getMaxPlayers()));
         vars.put("online_list", formatOnlineList(onlinePlayers));
         String eventKey =
                 switch (state) {
-                    case JOIN -> "player_join";
-                    case QUIT -> "player_quit";
-                    case KICK -> "player_kick";
+                    case JOIN -> TemplateKeys.PLAYER_JOIN;
+                    case QUIT -> TemplateKeys.PLAYER_QUIT;
+                    case KICK -> TemplateKeys.PLAYER_KICK;
                 };
         MessageEnvelope envelope = configs.renderEvent(eventKey, vars);
         notifier.event(eventKey, envelope);
@@ -139,31 +192,31 @@ public final class PlayerEventAggregator {
         vars.put("online_count", String.valueOf(onlinePlayers.size()));
         vars.put("max_count", String.valueOf(server.server().getMaxPlayers()));
         vars.put("online_list", cfg.includeOnlineList() ? "\n" + formatOnlineList(onlinePlayers) : "");
-        MessageEnvelope envelope = configs.renderEvent("player_digest", vars);
-        notifier.event("player_digest", envelope);
+        MessageEnvelope envelope = configs.renderEvent(TemplateKeys.PLAYER_DIGEST, vars);
+        notifier.event(TemplateKeys.PLAYER_DIGEST, envelope);
         server.logger().info(envelope.message());
     }
 
     /** 单状态摘要：如 "🟢 +5 上线：A、B、C、D、E\n"；无事件返回空串。 */
     private static String buildSummary(
-            List<Player> players, String marker, String action, String sign, int maxListItems) {
-        if (players.isEmpty()) {
+            List<PendingEvent> events, String marker, String action, String sign, int maxListItems) {
+        if (events.isEmpty()) {
             return "";
         }
-        return marker + " " + sign + players.size() + " " + action + "：" + joinNames(players, maxListItems) + "\n";
+        return marker + " " + sign + events.size() + " " + action + "：" + joinNames(events, maxListItems) + "\n";
     }
 
     /** 玩家名列表（顿号分隔），超长仅截断显示并追加 "、等N人"（计数不受影响）。 */
-    private static String joinNames(List<Player> players, int maxListItems) {
-        int shown = Math.min(maxListItems, players.size());
+    private static String joinNames(List<PendingEvent> events, int maxListItems) {
+        int shown = Math.min(maxListItems, events.size());
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < shown; i++) {
             if (i > 0) {
                 sb.append("、");
             }
-            sb.append(players.get(i).getName());
+            sb.append(events.get(i).name);
         }
-        int hidden = players.size() - shown;
+        int hidden = events.size() - shown;
         if (hidden > 0) {
             sb.append("、等").append(hidden).append("人");
         }
@@ -189,17 +242,40 @@ public final class PlayerEventAggregator {
         return sb.toString().trim();
     }
 
+    /**
+     * 一条聚合事件：入队时的玩家快照。
+     *
+     * <p>冲刷发生在窗口尾部（当事人可能已离线），因此玩家名/显示行/坐标均在入队时捕获，
+     * 避免读取离线玩家属性（null 坐标 / null 显示名导致渲染异常或字段丢失）。</p>
+     */
+    private static final class PendingEvent {
+        /** 原始玩家名（摘要列表显示）。 */
+        final String name;
+        /** 显示行（玩家名(op) 游戏模式 权限组），入队时计算。 */
+        final String displayLine;
+        /** 入队时坐标快照；可能为 null（如当事人已离线但 Location 不可用）。 */
+        final Location location;
+
+        PendingEvent(String name, String displayLine, Location location) {
+            this.name = name;
+            this.displayLine = displayLine;
+            this.location = location;
+        }
+    }
+
     /** 一个聚合窗口内的待发批次（仅主线程访问）。 */
     private static final class PendingBatch {
-        private final List<Player> joins = new ArrayList<>();
-        private final List<Player> quits = new ArrayList<>();
-        private final List<Player> kicks = new ArrayList<>();
+        private final List<PendingEvent> joins = new ArrayList<>();
+        private final List<PendingEvent> quits = new ArrayList<>();
+        private final List<PendingEvent> kicks = new ArrayList<>();
+        /** 本批次连续渲染失败次数（有界重试用）。 */
+        private int renderRetries;
 
-        void add(Player player, PlayerEventService.PlayerState state) {
+        void add(PendingEvent event, PlayerEventService.PlayerState state) {
             switch (state) {
-                case JOIN -> joins.add(player);
-                case QUIT -> quits.add(player);
-                case KICK -> kicks.add(player);
+                case JOIN -> joins.add(event);
+                case QUIT -> quits.add(event);
+                case KICK -> kicks.add(event);
             }
         }
 
@@ -208,7 +284,7 @@ public final class PlayerEventAggregator {
         }
 
         /** 单事件当事人；仅在 {@code total() == 1} 时调用。 */
-        Player singlePlayer() {
+        PendingEvent singleEvent() {
             if (!joins.isEmpty()) {
                 return joins.get(0);
             }
@@ -227,6 +303,14 @@ public final class PlayerEventAggregator {
                 return PlayerEventService.PlayerState.QUIT;
             }
             return PlayerEventService.PlayerState.KICK;
+        }
+
+        int renderRetries() {
+            return renderRetries;
+        }
+
+        void retry() {
+            renderRetries++;
         }
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventService.java
@@ -3,16 +3,12 @@ package com.jokerhub.paper.plugin.orzmc.features.player;
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
-import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.ThrottledNotifier;
-import com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
-import com.jokerhub.paper.plugin.orzmc.infra.templates.CoordFormatter;
 import com.jokerhub.paper.plugin.orzmc.infra.templates.ExceptionFormatter;
 import java.time.Duration;
-import java.util.ArrayList;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 
@@ -27,7 +23,7 @@ public final class PlayerEventService {
     private final OrzTextStyles styles;
     private final Notifier notifier;
     private final ThrottledNotifier throttledNotifier;
-    private final OnlineListFormatter listFormatter;
+    private final PlayerEventAggregator aggregator;
 
     public PlayerEventService(
             ServerFacade server,
@@ -35,13 +31,13 @@ public final class PlayerEventService {
             OrzTextStyles styles,
             Notifier notifier,
             ThrottledNotifier throttledNotifier,
-            OnlineListFormatter listFormatter) {
+            PlayerEventAggregator aggregator) {
         this.server = server;
         this.configs = configs;
         this.styles = styles;
         this.notifier = notifier;
         this.throttledNotifier = throttledNotifier;
-        this.listFormatter = listFormatter;
+        this.aggregator = aggregator;
     }
 
     public enum PlayerState {
@@ -151,47 +147,14 @@ public final class PlayerEventService {
         notifier.event("exception_alert", envelope);
     }
 
+    /**
+     * 收纳入队一条上下线广播事件。
+     *
+     * <p>不再直接发送：事件进入 {@link PlayerEventAggregator} 聚合窗口，窗口尾部统一冲刷
+     * （单发走原模板，多发走 {@code player_digest} 摘要）。限流通过窗口合并实现，
+     * 不丢消息——每条事件要么作为唯一事件单条渲染，要么进入摘要被精确计数。</p>
+     */
     public void notifyPlayerState(Player player, PlayerState state) {
-        String key = "player_event|" + player.getUniqueId() + "|" + state.name();
-        if (!throttledNotifier.shouldRunDefault(key)) {
-            return;
-        }
-        ArrayList<Player> onlinePlayers = new ArrayList<>();
-        Object[] objects = server.server().getOnlinePlayers().toArray();
-        for (Object obj : objects) {
-            if (obj instanceof Player p) {
-                onlinePlayers.add(p);
-            }
-        }
-        int onlinePlayerCount = onlinePlayers.size();
-        int maxPlayerCount = server.server().getMaxPlayers();
-        String playerName = listFormatter.line(player);
-        boolean minusCurrent = (state == PlayerState.QUIT || state == PlayerState.KICK);
-        int displayOnlineCount = onlinePlayerCount - (minusCurrent ? 1 : 0);
-        StringBuilder listBuilder = new StringBuilder();
-        for (Player p : onlinePlayers) {
-            if (minusCurrent && p.getUniqueId().equals(player.getUniqueId())) continue;
-            listBuilder.append(listFormatter.line(p)).append("\n");
-        }
-        org.bukkit.Location loc = player.getLocation();
-        String world = loc.getWorld() != null ? loc.getWorld().getName() : "unknown";
-        TemplateOptions opt = configs.templateOptions();
-        // 权限组中文名统一走 RankService.groupDisplayName（唯一事实源），
-        // 不再用模板系统的 role_alias 配置（已删除：与权限组映射重复维护）
-        java.util.Map<String, String> vars = CoordFormatter.format(loc, opt);
-        vars.put("world", world); // 覆盖 CoordFormatter 的别名，保留原始世界名
-        vars.put("name", playerName);
-        vars.put("online_count", String.valueOf(displayOnlineCount));
-        vars.put("max_count", String.valueOf(maxPlayerCount));
-        vars.put("online_list", listBuilder.toString().trim());
-        String eventKey =
-                switch (state) {
-                    case JOIN -> "player_join";
-                    case QUIT -> "player_quit";
-                    case KICK -> "player_kick";
-                };
-        MessageEnvelope envelope = configs.renderEvent(eventKey, vars);
-        notifier.event(eventKey, envelope);
-        server.logger().info(envelope.message());
+        aggregator.enqueue(player, state);
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventService.java
@@ -157,4 +157,14 @@ public final class PlayerEventService {
     public void notifyPlayerState(Player player, PlayerState state) {
         aggregator.enqueue(player, state);
     }
+
+    /**
+     * 立即冲刷聚合器中挂起的批次（同步）。
+     *
+     * <p>插件禁用/重载时调用：Bukkit 会取消插件待执行任务，窗口尾部调度可能来不及运行，
+     * 此方法保证最后一个窗口的上下线事件在卸载前交付，不静默丢弃。</p>
+     */
+    public void flushPending() {
+        aggregator.flushPending();
+    }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
@@ -101,7 +101,9 @@ public final class ConfigHealthCheck {
 
     private static void validatePlayerNotifySection(ConfigurationSection section, List<String> issues) {
         if (section == null) {
-            issues.add("config.yml 缺失 player_notify 配置段");
+            // 降级为建议：默认配置完整可用，仅升级安装（config.yml 存在故未复制新默认值）会缺此段，
+            // 属提示而非缺陷，避免升级后每次启动的持久告警
+            issues.add("建议: config.yml 缺失 player_notify 配置段，将使用默认配置（窗口 3000ms，三类通知启用）");
             return;
         }
         for (String key : new String[] {"enabled_join", "enabled_quit", "enabled_kick"}) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
@@ -34,6 +34,7 @@ public final class ConfigHealthCheck {
         validateWhitelistSection(cfg.getConfigurationSection("whitelist"), issues);
         validateMaintenanceSection(cfg.getConfigurationSection("maintenance"), issues);
         validateTntSection(cfg.getConfigurationSection("tnt"), issues);
+        validatePlayerNotifySection(cfg.getConfigurationSection("player_notify"), issues);
         validateGeoIpSection(cfg.getConfigurationSection("geoip"), issues);
         validateCommandPoliciesSection(cfg.getConfigurationSection("command_policies"), issues);
     }
@@ -90,14 +91,30 @@ public final class ConfigHealthCheck {
             issues.add("类型错误: tnt.enable_respawn_anchor 需为布尔值");
         int cd = section.getInt("place_cooldown", 0);
         if (cd < 0) issues.add("非法: tnt.place_cooldown 不得为负数");
-        long thr = section.getLong("notify_throttle_ms", 1000L);
-        if (thr < 0) issues.add("非法: tnt.notify_throttle_ms 不得为负数");
         long agg = section.getLong("notify_aggregate_ms", 3000L);
         if (agg <= 0) issues.add("非法: tnt.notify_aggregate_ms 必须为正数（≤0 会回退默认 3000ms，静默关闭防刷屏）");
         Object wl = section.get("whitelist");
         if (wl != null && !(wl instanceof List<?>)) issues.add("类型错误: tnt.whitelist 需为列表");
         Object exempt = section.get("exempt_entities");
         if (exempt != null && !(exempt instanceof List<?>)) issues.add("类型错误: tnt.exempt_entities 需为列表");
+    }
+
+    private static void validatePlayerNotifySection(ConfigurationSection section, List<String> issues) {
+        if (section == null) {
+            issues.add("config.yml 缺失 player_notify 配置段");
+            return;
+        }
+        for (String key : new String[] {"enabled_join", "enabled_quit", "enabled_kick"}) {
+            Object en = section.get(key);
+            if (en != null && !(en instanceof Boolean)) issues.add("类型错误: player_notify." + key + " 需为布尔值");
+        }
+        long window = section.getLong("window_ms", 3000L);
+        if (window <= 0) issues.add("非法: player_notify.window_ms 必须为正数（≤0 会回退默认 3000ms，静默关闭防刷屏）");
+        int maxList = section.getInt("max_list_items", 6);
+        if (maxList < 1) issues.add("非法: player_notify.max_list_items 不得小于 1");
+        Object include = section.get("include_online_list");
+        if (include != null && !(include instanceof Boolean))
+            issues.add("类型错误: player_notify.include_online_list 需为布尔值");
     }
 
     private static void validateGeoIpSection(ConfigurationSection section, List<String> issues) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPath.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPath.java
@@ -64,7 +64,6 @@ public final class ConfigPath {
         reg(map, "config", "tnt.enable_respawn_anchor", Boolean.class, false, "启用重生锚检测");
         reg(map, "config", "tnt.place_cooldown", Integer.class, 5, "TNT放置冷却(秒)");
         reg(map, "config", "tnt.notify_aggregate_ms", Long.class, 3000L, "TNT/爆炸告警聚合窗口(毫秒)");
-        reg(map, "config", "tnt.notify_throttle_ms", Long.class, 1000L, "（已废弃）上下线限流，由 player_notify.window_ms 取代");
         // player_notify (config.yml)
         reg(map, "config", "player_notify.enabled_join", Boolean.class, true, "上线消息通知开关");
         reg(map, "config", "player_notify.enabled_quit", Boolean.class, true, "下线消息通知开关");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPath.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPath.java
@@ -64,7 +64,14 @@ public final class ConfigPath {
         reg(map, "config", "tnt.enable_respawn_anchor", Boolean.class, false, "启用重生锚检测");
         reg(map, "config", "tnt.place_cooldown", Integer.class, 5, "TNT放置冷却(秒)");
         reg(map, "config", "tnt.notify_aggregate_ms", Long.class, 3000L, "TNT/爆炸告警聚合窗口(毫秒)");
-        reg(map, "config", "tnt.notify_throttle_ms", Long.class, 1000L, "玩家上下线消息限流(毫秒)");
+        reg(map, "config", "tnt.notify_throttle_ms", Long.class, 1000L, "（已废弃）上下线限流，由 player_notify.window_ms 取代");
+        // player_notify (config.yml)
+        reg(map, "config", "player_notify.enabled_join", Boolean.class, true, "上线消息通知开关");
+        reg(map, "config", "player_notify.enabled_quit", Boolean.class, true, "下线消息通知开关");
+        reg(map, "config", "player_notify.enabled_kick", Boolean.class, true, "被踢消息通知开关");
+        reg(map, "config", "player_notify.window_ms", Long.class, 3000L, "上下线通知聚合窗口(毫秒)");
+        reg(map, "config", "player_notify.max_list_items", Integer.class, 6, "聚合摘要最多列出的玩家数");
+        reg(map, "config", "player_notify.include_online_list", Boolean.class, false, "聚合摘要是否附带在线列表");
         // command policies (config.yml)
         reg(map, "config", "command_policies.tpbow.cooldown_secs", Integer.class, 3, "传送弓冷却(秒)");
         reg(map, "config", "command_policies.tpbow.admin_only", Boolean.class, false, "传送弓仅管理员可用");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
@@ -5,6 +5,7 @@ import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.Templates;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TntConfig;
@@ -60,6 +61,12 @@ public final class DefaultTypedConfigProvider implements TypedConfigProvider {
     public TntConfig tnt() {
         ConfigurationSection section = sectionOrLegacy("config", "tnt", "tnt.yml");
         return TntConfig.from(section);
+    }
+
+    @Override
+    public PlayerNotifyConfig playerNotify() {
+        ConfigurationSection section = sectionOrLegacy("config", "player_notify", "player_notify.yml");
+        return PlayerNotifyConfig.from(section);
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
@@ -78,12 +78,17 @@ public final class TemplateKeys {
     public static final String PATTERNS = "patterns";
     public static final String MOTD = "motd";
 
-    /** 所有已知的模板事件 key。用于 {@link ConfigHealthCheck} 校验。 */
+    /**
+     * 所有已知的模板事件 key。用于 {@link ConfigHealthCheck} 校验。
+     *
+     * <p>不含 {@link #PLAYER_DIGEST}：它在 {@code Templates} 中有完整 Java 默认模板，
+     * 升级安装（templates.yml 已存在故未复制新默认值）不携带该键即可正常工作；
+     * 纳入 ALL 会要求模板文件提供该键，造成升级后每次启动的持久「缺失」告警。</p>
+     */
     public static final String[] ALL = {
         PLAYER_JOIN,
         PLAYER_KICK,
         PLAYER_QUIT,
-        PLAYER_DIGEST,
         COMMAND_OUTPUT,
         COMMAND_HELP,
         COMMAND_PLAYERS,

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
@@ -15,6 +15,7 @@ public final class TemplateKeys {
     public static final String PLAYER_JOIN = "player_join";
     public static final String PLAYER_KICK = "player_kick";
     public static final String PLAYER_QUIT = "player_quit";
+    public static final String PLAYER_DIGEST = "player_digest";
 
     // ---- 命令事件 ----
     public static final String COMMAND_OUTPUT = "command_output";
@@ -82,6 +83,7 @@ public final class TemplateKeys {
         PLAYER_JOIN,
         PLAYER_KICK,
         PLAYER_QUIT,
+        PLAYER_DIGEST,
         COMMAND_OUTPUT,
         COMMAND_HELP,
         COMMAND_PLAYERS,

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/PlayerNotifyConfig.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/PlayerNotifyConfig.java
@@ -1,0 +1,41 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+/**
+ * 玩家上下线通知配置。
+ *
+ * <p>上下线/被踢消息的窗口聚合限流参数：窗口内多条事件合并为一条聚合摘要，
+ * 单条事件仍按原模板单发（延迟一个窗口，保证最多 1 条/窗口）。
+ * 各类型开关为显式配置项：关闭后该类型事件不再产生通知（配置性忽略，非运行时丢消息）。</p>
+ */
+public record PlayerNotifyConfig(
+        boolean enabledJoin,
+        boolean enabledQuit,
+        boolean enabledKick,
+        long windowMs,
+        int maxListItems,
+        boolean includeOnlineList) {
+
+    public static PlayerNotifyConfig from(ConfigurationSection cfg) {
+        if (cfg == null) {
+            return new PlayerNotifyConfig(true, true, true, 3000L, 6, false);
+        }
+        long windowMs = cfg.getLong("window_ms", 3000L);
+        if (windowMs <= 0) {
+            // 非正窗口会让聚合退化为 1 tick，等于关闭防刷屏 → 回退默认
+            windowMs = 3000L;
+        }
+        int maxListItems = cfg.getInt("max_list_items", 6);
+        if (maxListItems < 1) {
+            maxListItems = 1;
+        }
+        return new PlayerNotifyConfig(
+                cfg.getBoolean("enabled_join", true),
+                cfg.getBoolean("enabled_quit", true),
+                cfg.getBoolean("enabled_kick", true),
+                windowMs,
+                maxListItems,
+                cfg.getBoolean("include_online_list", false));
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/Templates.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/Templates.java
@@ -34,7 +34,7 @@ public record Templates(
                 "{name} 被踢\n世界:{world_alias} 坐标:{x_unit},{y_unit},{z_unit}({coord_unit})\n------当前在线({online_count}/{max_count})------\n{online_list}");
         String digest = cfg.getString(
                 base + ".player_digest",
-                "{join_summary}{quit_summary}{kick_summary}------当前在线({online_count}/{max_count})------\n{online_list}");
+                "{join_summary}{quit_summary}{kick_summary}------当前在线({online_count}/{max_count})------{online_list}");
         String exceptionAlert = cfg.getString(base + ".exception_alert", "异常: {message}\n摘要: {stack_summary}");
         String geoipBlock = cfg.getString(
                 base + ".geoip_block", "{name}({ip}) 地区:{country_code} 不在允许列表({allow_list})\n{address_info}");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/Templates.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/Templates.java
@@ -6,6 +6,7 @@ public record Templates(
         String playerJoin,
         String playerQuit,
         String playerKick,
+        String playerDigest,
         String exceptionAlert,
         String geoipBlock,
         String tntAlert,
@@ -31,6 +32,9 @@ public record Templates(
         String kick = cfg.getString(
                 base + ".player_kick",
                 "{name} 被踢\n世界:{world_alias} 坐标:{x_unit},{y_unit},{z_unit}({coord_unit})\n------当前在线({online_count}/{max_count})------\n{online_list}");
+        String digest = cfg.getString(
+                base + ".player_digest",
+                "{join_summary}{quit_summary}{kick_summary}------当前在线({online_count}/{max_count})------\n{online_list}");
         String exceptionAlert = cfg.getString(base + ".exception_alert", "异常: {message}\n摘要: {stack_summary}");
         String geoipBlock = cfg.getString(
                 base + ".geoip_block", "{name}({ip}) 地区:{country_code} 不在允许列表({allow_list})\n{address_info}");
@@ -55,6 +59,7 @@ public record Templates(
                 join,
                 quit,
                 kick,
+                digest,
                 exceptionAlert,
                 geoipBlock,
                 tntAlert,

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/notify/ThrottledNotifier.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/notify/ThrottledNotifier.java
@@ -1,63 +1,19 @@
 package com.jokerhub.paper.plugin.orzmc.infra.notify;
 
-import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
 import java.util.concurrent.ConcurrentHashMap;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
 
+/**
+ * 按固定周期限频的通知/告警抑制器。
+ *
+ * <p>key 在 periodMs 内最多放行一次。已废弃的 {@code tnt.notify_throttle_ms} 读取
+ * （上下线限流）已由 {@code player_notify.window_ms} 聚合窗口取代，相关 {@code shouldRunDefault}
+ * /{@code runDefault} 死代码一并移除；本类仅保留固定周期限频供与 TNT 无关的告警使用。</p>
+ */
 public final class ThrottledNotifier {
-    private final ConfigService configService;
     private final ConcurrentHashMap<String, Long> last = new ConcurrentHashMap<>();
     private volatile long lastCleanup = 0L;
 
-    public ThrottledNotifier(ConfigService configService) {
-        this.configService = configService;
-    }
-
-    public boolean shouldRunDefault(String key) {
-        long p = defaultPeriodMs();
-        return shouldRunDefault(key, p);
-    }
-
-    public boolean shouldRunDefault(String key, long ttlMs) {
-        long p = defaultPeriodMs();
-        return shouldRun(key, p, ttlMs);
-    }
-
-    public void runDefault(String key, Runnable action) {
-        long p = defaultPeriodMs();
-        if (shouldRun(key, p)) {
-            action.run();
-        }
-    }
-
-    public void runDefault(String key, long ttlMs, Runnable action) {
-        long p = defaultPeriodMs();
-        if (shouldRun(key, p, ttlMs)) {
-            action.run();
-        }
-    }
-
-    private long defaultPeriodMs() {
-        try {
-            ConfigurationSection tntSection = configService.getConfig("config").getConfigurationSection("tnt");
-            if (tntSection != null) {
-                long v = tntSection.getLong("notify_throttle_ms");
-                return v <= 0 ? 1000L : v;
-            }
-            FileConfiguration legacy = configService.loadFile("tnt.yml");
-            if (legacy != null) {
-                long v = legacy.getLong("notify_throttle_ms");
-                return v <= 0 ? 1000L : v;
-            }
-            return 1000L;
-        } catch (Exception ignored) {
-            // 配置段未就绪时使用默认值 —— 安全兜底，无需日志
-            return 1000L;
-        }
-    }
-
-    /** 按固定周期限频（不读取 tnt 配置）：key 在 periodMs 内最多放行一次，用于与 TNT 无关的告警限频。 */
+    /** 按固定周期限频：key 在 periodMs 内最多放行一次，用于与 TNT 无关的告警限频。 */
     public boolean shouldRun(String key, long periodMs) {
         return shouldRun(key, periodMs, periodMs);
     }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplatePlaceholderValidator.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplatePlaceholderValidator.java
@@ -115,6 +115,9 @@ public final class TemplatePlaceholderValidator {
         m.put("player_join", playerVars);
         m.put("player_quit", playerVars);
         m.put("player_kick", playerVars);
+        m.put(
+                "player_digest",
+                Set.of("join_summary", "quit_summary", "kick_summary", "online_count", "max_count", "online_list"));
         m.put("exception_alert", Set.of("message", "stack_summary"));
         m.put("geoip_block", Set.of("name", "ip", "country_code", "allow_list", "address_info"));
         m.put(

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateService.java
@@ -21,6 +21,7 @@ public final class TemplateService {
         if ("player_join".equals(eventKey)) return templates.playerJoin();
         if ("player_quit".equals(eventKey)) return templates.playerQuit();
         if ("player_kick".equals(eventKey)) return templates.playerKick();
+        if ("player_digest".equals(eventKey)) return templates.playerDigest();
         if ("exception_alert".equals(eventKey)) return templates.exceptionAlert();
         if ("geoip_block".equals(eventKey)) return templates.geoipBlock();
         if ("tnt_alert".equals(eventKey)) return templates.tntAlert();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -39,9 +39,6 @@ tnt:
   # TNT/爆炸告警聚合窗口(ms)：同一区域(128×128×64区块)同类型事件在窗口内合并为一条告警(带 ×N 和首个坐标)；
   # 既是突发合并也限制持续刷屏频率。单发事件仍立即发，不受窗口延迟。
   notify_aggregate_ms: 3000
-  # （已废弃）上下线消息限流：上下线消息已改为 player_notify.window_ms 聚合窗口限流，
-  # 本 key 不再被读取，仅保留以兼容旧配置。
-  notify_throttle_ms: 1000
   whitelist:
     - { minX: 0, maxX: 0, minY: 0, maxY: 0, minZ: 0, maxZ: 0, world: 'world' }
     - { minX: 0, maxX: 0, minY: 0, maxY: 0, minZ: 0, maxZ: 0, world: 'world_nether' }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -39,7 +39,8 @@ tnt:
   # TNT/爆炸告警聚合窗口(ms)：同一区域(128×128×64区块)同类型事件在窗口内合并为一条告警(带 ×N 和首个坐标)；
   # 既是突发合并也限制持续刷屏频率。单发事件仍立即发，不受窗口延迟。
   notify_aggregate_ms: 3000
-  # 玩家上下线消息限流(ms)：本 key 由 PlayerEventService 读取，与 TNT 告警无关（TNT 限流由 notify_aggregate_ms 承担）。
+  # （已废弃）上下线消息限流：上下线消息已改为 player_notify.window_ms 聚合窗口限流，
+  # 本 key 不再被读取，仅保留以兼容旧配置。
   notify_throttle_ms: 1000
   whitelist:
     - { minX: 0, maxX: 0, minY: 0, maxY: 0, minZ: 0, maxZ: 0, world: 'world' }
@@ -66,6 +67,23 @@ geoip:
   # 填写大写两位 ISO 国家码，例如：
   #   allow_country_code: [CN, JP, TW]
   allow_country_code: []
+
+# ==================================================
+#             玩家上下线通知（2026-08-16）
+# ==================================================
+player_notify:
+  # 各类型通知开关：关闭后该类型事件不再产生群消息
+  enabled_join: true
+  enabled_quit: true
+  enabled_kick: true
+  # 聚合窗口(ms)：窗口内所有上下线事件合并为一条消息，限制高频上下线刷屏。
+  # 单条事件仍按原模板单发（延迟一个窗口），多条事件渲染 player_digest 摘要。
+  # 消息频率被限制为最多 1 条/窗口，事件不丢失（逐条精确计数）。
+  window_ms: 3000
+  # 聚合摘要最多列出的玩家名数量，超出用 "+等N人" 截断（仅显示截断，计数不受影响）
+  max_list_items: 6
+  # 聚合摘要是否附带完整在线列表（单条事件模板始终含在线列表，不受此开关影响）
+  include_online_list: false
 
 # ==================================================
 #              实体传送策略（2026-08-09）

--- a/src/main/resources/templates.yml
+++ b/src/main/resources/templates.yml
@@ -80,6 +80,7 @@ templates:
   player_join: "{name} 上线\n------当前在线({online_count}/{max_count})------\n{online_list}"
   player_quit: "{name} 下线\n------当前在线({online_count}/{max_count})------\n{online_list}"
   player_kick: "{name} 被踢\n------当前在线({online_count}/{max_count})------\n{online_list}"
+  player_digest: "{join_summary}{quit_summary}{kick_summary}------当前在线({online_count}/{max_count})------{online_list}"
   exception_alert: "异常: {message}\n摘要: {stack_summary}"
   geoip_block: "{name}({ip}) 地区:{country_code} 不在允许列表({allow_list})\n{address_info}"
   tnt_alert: "{msg}\n世界:{world_alias} 坐标:{x_unit},{y_unit},{z_unit}({coord_unit})\n触发:{actor} 方块:{block_type}"

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEventTest.java
@@ -16,7 +16,11 @@ import java.net.InetAddress;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -50,6 +54,18 @@ class OrzPlayerEventTest extends ServiceTestBase {
     @Mock
     private PlayerProfile profile;
 
+    @Mock
+    private Player player;
+
+    @Mock
+    private PlayerJoinEvent joinEvent;
+
+    @Mock
+    private PlayerQuitEvent quitEvent;
+
+    @Mock
+    private PlayerKickEvent kickEvent;
+
     private OrzPlayerEvent listener;
 
     @BeforeEach
@@ -62,6 +78,9 @@ class OrzPlayerEventTest extends ServiceTestBase {
         when(blacklistService.isBlocked(anyString())).thenReturn(false);
         when(styles.warn(anyString())).thenReturn(Component.text("warn"));
         when(styles.error(anyString())).thenReturn(Component.text("error"));
+        when(joinEvent.getPlayer()).thenReturn(player);
+        when(quitEvent.getPlayer()).thenReturn(player);
+        when(kickEvent.getPlayer()).thenReturn(player);
 
         listener = new OrzPlayerEvent(
                 plugin, geoIpAccessService, blacklistService, service, guideService, styles, maintenanceService);
@@ -134,5 +153,38 @@ class OrzPlayerEventTest extends ServiceTestBase {
         verify(service)
                 .handleGeoIpPreLogin(
                         eq(event), eq("player1"), eq("1.2.3.4"), any(), eq(GeoIpAccessService.DECISION_TIMEOUT_MS));
+    }
+
+    @Test
+    void onPlayerJoin_notifiesJoinState() {
+        listener.onPlayerJoin(joinEvent);
+
+        verify(service).notifyPlayerState(player, PlayerEventService.PlayerState.JOIN);
+    }
+
+    @Test
+    void onPlayerQuit_notifiesQuitState() {
+        listener.onPlayerQuit(quitEvent);
+
+        verify(service).notifyPlayerState(player, PlayerEventService.PlayerState.QUIT);
+    }
+
+    @Test
+    void onPlayerKickLeave_notCancelled_notifiesKick() {
+        when(kickEvent.isCancelled()).thenReturn(false);
+
+        listener.onPlayerKickLeave(kickEvent);
+
+        verify(service).notifyPlayerState(player, PlayerEventService.PlayerState.KICK);
+    }
+
+    @Test
+    void onPlayerKickLeave_cancelled_skipsNotification() {
+        when(kickEvent.isCancelled()).thenReturn(true);
+
+        listener.onPlayerKickLeave(kickEvent);
+
+        // 被取消的踢人：玩家仍在线上，不产生「被踢」通知
+        verify(service, never()).notifyPlayerState(any(), any());
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregatorTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregatorTest.java
@@ -1,0 +1,324 @@
+package com.jokerhub.paper.plugin.orzmc.features.player;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.features.rank.RankService;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
+import com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Logger;
+import org.bukkit.GameMode;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+class PlayerEventAggregatorTest extends ServiceTestBase {
+
+    @Mock
+    private ServerFacade server;
+
+    @Mock
+    private TypedConfigProvider configs;
+
+    @Mock
+    private Notifier notifier;
+
+    @Mock
+    private Server bukkitServer;
+
+    @Mock
+    private Logger logger;
+
+    private OnlineListFormatter formatter;
+    private PlayerEventAggregator aggregator;
+
+    @BeforeEach
+    void setUp() {
+        formatter = new OnlineListFormatter();
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(true, true, true, 3000L, 6, false));
+        when(server.server()).thenReturn(bukkitServer);
+        when(server.logger()).thenReturn(logger);
+        when(configs.renderEvent(anyString(), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
+        aggregator = new PlayerEventAggregator(server, configs, notifier, formatter);
+    }
+
+    private Player mockPlayer(String name) {
+        Player p = mock(Player.class);
+        PlayerProfile profile = mock(PlayerProfile.class);
+        when(profile.getName()).thenReturn(name);
+        when(p.getPlayerProfile()).thenReturn(profile);
+        when(p.getName()).thenReturn(name);
+        when(p.getGameMode()).thenReturn(GameMode.SURVIVAL);
+        when(p.isOp()).thenReturn(false);
+        return p;
+    }
+
+    /** 执行已捕获的尾部冲刷任务（模拟调度器在窗口到期后运行）。仅适用于恰好调度了一次的场景。 */
+    private void runTail() {
+        ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+        verify(server).runLater(task.capture(), anyLong());
+        task.getValue().run();
+    }
+
+    // ---- 单发：窗口内仅 1 条事件，复用原模板 ----
+
+    @Test
+    void enqueue_singleJoin_flushRendersPlayerJoin() {
+        Player p = mockPlayer("Alice");
+        doReturn(List.of(p)).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_join"), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
+
+        aggregator.enqueue(p, PlayerEventService.PlayerState.JOIN);
+
+        // 纯聚合：事件不立即发送，仅调度一次窗口冲刷（3000ms → 60 ticks）
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+        verify(server).runLater(any(Runnable.class), eq(60L));
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_join"), vars.capture());
+        verify(notifier).event(eq("player_join"), any(MessageEnvelope.class));
+        Map<String, String> v = vars.getValue();
+        // name 沿用 OnlineListFormatter.line()（玩家名 + 游戏模式），与旧 PlayerEventService 行为一致
+        assertTrue(v.get("name").startsWith("Alice"), "got: " + v.get("name"));
+        assertEquals("1", v.get("online_count"));
+        assertEquals("100", v.get("max_count"));
+        assertTrue(v.get("online_list").contains("Alice"), "got: " + v.get("online_list"));
+    }
+
+    @Test
+    void enqueue_singleQuit_flushUsesLiveOnlineCount() {
+        Player quitter = mockPlayer("Alice");
+        Player remaining = mockPlayer("Bob");
+        // 冲刷时刻当事人已离开在线列表（与事件同步渲染的"减1修正"相反）
+        doReturn(List.of(remaining)).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_quit"), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
+
+        aggregator.enqueue(quitter, PlayerEventService.PlayerState.QUIT);
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_quit"), vars.capture());
+        Map<String, String> v = vars.getValue();
+        assertEquals("1", v.get("online_count"), "应取冲刷时刻实时在线数，不重复减 1");
+        String onlineList = v.get("online_list");
+        assertFalse(onlineList.contains("Alice"), "当事人不应出现在在线列表, got: " + onlineList);
+        assertTrue(onlineList.contains("Bob"), "got: " + onlineList);
+    }
+
+    @Test
+    void enqueue_singleKick_flushRendersPlayerKick() {
+        Player p = mockPlayer("Alice");
+        doReturn(List.of()).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_kick"), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
+
+        aggregator.enqueue(p, PlayerEventService.PlayerState.KICK);
+        runTail();
+
+        verify(configs).renderEvent(eq("player_kick"), anyMap());
+        verify(notifier).event(eq("player_kick"), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void enqueue_singleJoin_withRankService_includesGroupInList() {
+        // 在线列表格式与权限组注入走真实 OnlineListFormatter（缺组名回归保护）
+        RankService rankService = mock(RankService.class);
+        OnlineListFormatter formatterWithRank = new OnlineListFormatter();
+        formatterWithRank.setRankService(rankService);
+        aggregator = new PlayerEventAggregator(server, configs, notifier, formatterWithRank);
+
+        Player p1 = mockPlayer("Alice");
+        Player p2 = mockPlayer("Bob");
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        when(p1.getUniqueId()).thenReturn(id1);
+        when(p2.getUniqueId()).thenReturn(id2);
+        when(rankService.currentGroup(id1)).thenReturn("admin");
+        when(rankService.currentGroup(id2)).thenReturn("builder");
+
+        doReturn(List.of(p1, p2)).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_join"), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
+
+        aggregator.enqueue(p1, PlayerEventService.PlayerState.JOIN);
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_join"), vars.capture());
+        String onlineList = vars.getValue().get("online_list");
+        assertTrue(onlineList.contains("Alice"), "got: " + onlineList);
+        assertTrue(onlineList.contains("管理员"), "Alice 应显示权限组 管理员, got: " + onlineList);
+        assertTrue(onlineList.contains("Bob"), "got: " + onlineList);
+        assertTrue(onlineList.contains("建造者"), "Bob 应显示权限组 建造者, got: " + onlineList);
+    }
+
+    // ---- 多发：窗口内多条事件，渲染聚合摘要（不丢消息，精确计数）----
+
+    @Test
+    void enqueue_multipleEvents_flushRendersDigestWithExactCounts() {
+        Player a = mockPlayer("Alice");
+        Player b = mockPlayer("Bob");
+        Player c = mockPlayer("Carol");
+        doReturn(List.of(a, b, c)).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_digest"), anyMap())).thenReturn(MessageEnvelope.publicMessage("digest"));
+
+        aggregator.enqueue(a, PlayerEventService.PlayerState.JOIN);
+        aggregator.enqueue(b, PlayerEventService.PlayerState.JOIN);
+        aggregator.enqueue(c, PlayerEventService.PlayerState.QUIT);
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_digest"), vars.capture());
+        verify(notifier).event(eq("player_digest"), any(MessageEnvelope.class));
+        Map<String, String> v = vars.getValue();
+        assertTrue(v.get("join_summary").startsWith("🟢 +2 上线"), "got: " + v.get("join_summary"));
+        assertTrue(v.get("join_summary").contains("Alice"), "got: " + v.get("join_summary"));
+        assertTrue(v.get("join_summary").contains("Bob"), "got: " + v.get("join_summary"));
+        assertTrue(v.get("quit_summary").startsWith("🔴 -1 下线"), "got: " + v.get("quit_summary"));
+        assertEquals("", v.get("kick_summary"));
+        assertEquals("3", v.get("online_count"));
+    }
+
+    @Test
+    void enqueue_manyEvents_truncatesNamesOnlyCountExact() {
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(true, true, true, 3000L, 6, false));
+        doReturn(List.of()).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_digest"), anyMap())).thenReturn(MessageEnvelope.publicMessage("digest"));
+
+        for (int i = 0; i < 10; i++) {
+            aggregator.enqueue(mockPlayer("P" + i), PlayerEventService.PlayerState.JOIN);
+        }
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_digest"), vars.capture());
+        String joinSummary = vars.getValue().get("join_summary");
+        // 计数精确（+10），名称仅显示前 6 个并截断
+        assertTrue(joinSummary.startsWith("🟢 +10 上线"), "got: " + joinSummary);
+        assertTrue(joinSummary.contains("P0") && joinSummary.contains("P5"), "got: " + joinSummary);
+        assertFalse(joinSummary.contains("P6"), "P6 应被截断: " + joinSummary);
+        assertTrue(joinSummary.contains("等4人"), "got: " + joinSummary);
+    }
+
+    @Test
+    void enqueue_digestIncludeOnlineList_attachesList() {
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(true, true, true, 3000L, 6, true));
+        Player a = mockPlayer("Alice");
+        Player b = mockPlayer("Bob");
+        doReturn(List.of(a, b)).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_digest"), anyMap())).thenReturn(MessageEnvelope.publicMessage("digest"));
+
+        aggregator.enqueue(a, PlayerEventService.PlayerState.JOIN);
+        aggregator.enqueue(b, PlayerEventService.PlayerState.JOIN);
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_digest"), vars.capture());
+        String onlineList = vars.getValue().get("online_list");
+        assertTrue(onlineList.startsWith("\n"), "应带换行前缀: " + onlineList);
+        assertTrue(onlineList.contains("Alice") && onlineList.contains("Bob"), "got: " + onlineList);
+    }
+
+    @Test
+    void enqueue_digestIncludeOnlineList_false_omitsList() {
+        // 默认 includeOnlineList=false：摘要不含在线列表
+        Player a = mockPlayer("Alice");
+        doReturn(List.of(a)).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_digest"), anyMap())).thenReturn(MessageEnvelope.publicMessage("digest"));
+
+        aggregator.enqueue(a, PlayerEventService.PlayerState.JOIN);
+        aggregator.enqueue(mockPlayer("Bob"), PlayerEventService.PlayerState.QUIT);
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_digest"), vars.capture());
+        assertEquals("", vars.getValue().get("online_list"));
+    }
+
+    // ---- 限流上界与窗口行为 ----
+
+    @Test
+    void enqueue_multipleWithinWindow_singleScheduledFlush() {
+        aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
+        aggregator.enqueue(mockPlayer("B"), PlayerEventService.PlayerState.JOIN);
+        aggregator.enqueue(mockPlayer("C"), PlayerEventService.PlayerState.QUIT);
+
+        verify(server, times(1)).runLater(any(Runnable.class), anyLong());
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void enqueue_windowMs_convertsToTicks() {
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(true, true, true, 5000L, 6, false));
+
+        aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
+
+        verify(server).runLater(any(Runnable.class), eq(100L)); // 5000ms / 50
+    }
+
+    @Test
+    void enqueue_configReloaded_usesNewWindow() {
+        // 首个窗口 3000ms → 60 ticks
+        aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
+        runTail();
+
+        // 热重载：新窗口 5000ms → 100 ticks，不重建 service
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(true, true, true, 5000L, 6, false));
+        aggregator.enqueue(mockPlayer("B"), PlayerEventService.PlayerState.JOIN);
+
+        verify(server).runLater(any(Runnable.class), eq(100L));
+    }
+
+    @Test
+    void enqueue_disabledState_suppressed() {
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(false, true, true, 3000L, 6, false));
+
+        aggregator.enqueue(mockPlayer("Alice"), PlayerEventService.PlayerState.JOIN);
+
+        verify(server, never()).runLater(any(Runnable.class), anyLong());
+        verifyNoInteractions(notifier);
+    }
+
+    @Test
+    void enqueue_renderFailure_flushClearsBatch_noOrphan() {
+        doThrow(new IllegalStateException("template broken")).when(configs).renderEvent(anyString(), anyMap());
+        aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
+
+        // 尾部冲刷渲染失败 → 异常冒出，但批次已清除不留孤儿（后续事件可正常聚合）
+        assertThrows(IllegalStateException.class, () -> runTail());
+
+        doReturn(MessageEnvelope.publicMessage("ok")).when(configs).renderEvent(anyString(), anyMap());
+        aggregator.enqueue(mockPlayer("B"), PlayerEventService.PlayerState.JOIN);
+        verify(server, times(2)).runLater(any(Runnable.class), anyLong());
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregatorTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregatorTest.java
@@ -2,7 +2,7 @@ package com.jokerhub.paper.plugin.orzmc.features.player;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -16,6 +16,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
 import com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -48,6 +49,9 @@ class PlayerEventAggregatorTest extends ServiceTestBase {
     private OnlineListFormatter formatter;
     private PlayerEventAggregator aggregator;
 
+    /** 调度器捕获队列：doAnswer 拦截 runLater，模拟真实调度（含失败重试的重调度）。 */
+    private final ArrayDeque<Runnable> scheduledTasks = new ArrayDeque<>();
+
     @BeforeEach
     void setUp() {
         formatter = new OnlineListFormatter();
@@ -55,6 +59,12 @@ class PlayerEventAggregatorTest extends ServiceTestBase {
         when(server.server()).thenReturn(bukkitServer);
         when(server.logger()).thenReturn(logger);
         when(configs.renderEvent(anyString(), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
+        doAnswer(inv -> {
+                    scheduledTasks.add(inv.getArgument(0));
+                    return null;
+                })
+                .when(server)
+                .runLater(any(Runnable.class), anyLong());
         aggregator = new PlayerEventAggregator(server, configs, notifier, formatter);
     }
 
@@ -69,11 +79,17 @@ class PlayerEventAggregatorTest extends ServiceTestBase {
         return p;
     }
 
-    /** 执行已捕获的尾部冲刷任务（模拟调度器在窗口到期后运行）。仅适用于恰好调度了一次的场景。 */
+    /** 执行最早一个已调度的窗口冲刷任务（模拟调度器在窗口到期后运行）。 */
     private void runTail() {
-        ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
-        verify(server).runLater(task.capture(), anyLong());
-        task.getValue().run();
+        assertFalse(scheduledTasks.isEmpty(), "没有待运行的窗口冲刷任务");
+        scheduledTasks.poll().run();
+    }
+
+    /** 依次执行所有已调度任务（含渲染失败后的重试重调度），直到队列为空。 */
+    private void runAllTails() {
+        while (!scheduledTasks.isEmpty()) {
+            scheduledTasks.poll().run();
+        }
     }
 
     // ---- 单发：窗口内仅 1 条事件，复用原模板 ----
@@ -172,6 +188,27 @@ class PlayerEventAggregatorTest extends ServiceTestBase {
         assertTrue(onlineList.contains("管理员"), "Alice 应显示权限组 管理员, got: " + onlineList);
         assertTrue(onlineList.contains("Bob"), "got: " + onlineList);
         assertTrue(onlineList.contains("建造者"), "Bob 应显示权限组 建造者, got: " + onlineList);
+    }
+
+    @Test
+    void enqueue_offlineQuitNullLocation_omitsCoordsKeepsName() {
+        // 当事人已离线（冲刷时刻坐标不可用）→ 坐标变量省略、world 回退 unknown，名字不受影响
+        Player quitter = mockPlayer("Alice");
+        when(quitter.getLocation()).thenReturn(null);
+        doReturn(List.of()).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_quit"), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
+
+        aggregator.enqueue(quitter, PlayerEventService.PlayerState.QUIT);
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_quit"), vars.capture());
+        Map<String, String> v = vars.getValue();
+        assertEquals("unknown", v.get("world"), "离线玩家坐标为 null 时应回退 unknown");
+        assertNull(v.get("x_unit"), "坐标缺失时不注入占位值");
+        assertTrue(v.get("name").startsWith("Alice"), "got: " + v.get("name"));
     }
 
     // ---- 多发：窗口内多条事件，渲染聚合摘要（不丢消息，精确计数）----
@@ -309,16 +346,73 @@ class PlayerEventAggregatorTest extends ServiceTestBase {
         verifyNoInteractions(notifier);
     }
 
+    // ---- 冲刷时按最新配置过滤（热重载对挂起批次生效）----
+
     @Test
-    void enqueue_renderFailure_flushClearsBatch_noOrphan() {
+    void flush_configDisabledMidWindow_suppressesBufferedEvents() {
+        aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
+        aggregator.enqueue(mockPlayer("B"), PlayerEventService.PlayerState.JOIN);
+        // 窗口内管理员关闭上线通知 → 挂起批次不再发送
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(false, true, true, 3000L, 6, false));
+
+        runTail();
+
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+        verify(configs, never()).renderEvent(anyString(), anyMap());
+    }
+
+    @Test
+    void flush_configDisabledMidWindow_singleRemainingUsesSingleTemplate() {
+        Player b = mockPlayer("B");
+        aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
+        aggregator.enqueue(b, PlayerEventService.PlayerState.QUIT);
+        // 上线被关闭后，窗口内剩余 1 条 QUIT → 走单条模板而非摘要
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(false, true, true, 3000L, 6, false));
+        doReturn(List.of(b)).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_quit"), anyMap())).thenReturn(MessageEnvelope.publicMessage("quit"));
+
+        runTail();
+
+        verify(configs).renderEvent(eq("player_quit"), anyMap());
+        verify(configs, never()).renderEvent(eq("player_digest"), anyMap());
+        verify(notifier).event(eq("player_quit"), any(MessageEnvelope.class));
+    }
+
+    // ---- 渲染失败：保留批次重试（有界），不静默丢弃整窗 ----
+
+    @Test
+    void flush_renderFailure_retainsBatchAndRetries_transientRecovery() {
         doThrow(new IllegalStateException("template broken")).when(configs).renderEvent(anyString(), anyMap());
         aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
 
-        // 尾部冲刷渲染失败 → 异常冒出，但批次已清除不留孤儿（后续事件可正常聚合）
-        assertThrows(IllegalStateException.class, () -> runTail());
+        // 首次冲刷渲染失败：不再抛出，批次保留并重试调度
+        runTail();
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+        assertFalse(scheduledTasks.isEmpty(), "失败后应重试调度");
 
+        // 渲染恢复后重试成功，事件不丢失
+        doReturn(MessageEnvelope.publicMessage("ok")).when(configs).renderEvent(anyString(), anyMap());
+        runTail();
+        verify(notifier).event(eq("player_join"), any(MessageEnvelope.class));
+        assertTrue(scheduledTasks.isEmpty(), "成功后不应再调度");
+    }
+
+    @Test
+    void flush_renderFailure_boundedRetries_dropsAfterCapWithAlert() {
+        doThrow(new IllegalStateException("template broken")).when(configs).renderEvent(anyString(), anyMap());
+        aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
+
+        // MAX_RENDER_RETRIES=3 → 第 4 次冲刷后放弃：1 首冲 + 3 重试
+        runAllTails();
+
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+        verify(logger).severe(anyString());
+
+        // 有界放弃后批次已清空，新事件可正常聚合（无孤儿批次）
         doReturn(MessageEnvelope.publicMessage("ok")).when(configs).renderEvent(anyString(), anyMap());
         aggregator.enqueue(mockPlayer("B"), PlayerEventService.PlayerState.JOIN);
-        verify(server, times(2)).runLater(any(Runnable.class), anyLong());
+        runTail();
+        verify(notifier).event(eq("player_join"), any(MessageEnvelope.class));
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregatorTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregatorTest.java
@@ -16,6 +16,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
 import com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +77,8 @@ class PlayerEventAggregatorTest extends ServiceTestBase {
         when(p.getName()).thenReturn(name);
         when(p.getGameMode()).thenReturn(GameMode.SURVIVAL);
         when(p.isOp()).thenReturn(false);
+        // 确定性且按名互异的 UUID：KICK→QUIT 去重按 playerId 匹配，不同玩家不可误折叠
+        when(p.getUniqueId()).thenReturn(UUID.nameUUIDFromBytes(name.getBytes(StandardCharsets.UTF_8)));
         return p;
     }
 
@@ -377,6 +380,78 @@ class PlayerEventAggregatorTest extends ServiceTestBase {
         verify(configs).renderEvent(eq("player_quit"), anyMap());
         verify(configs, never()).renderEvent(eq("player_digest"), anyMap());
         verify(notifier).event(eq("player_quit"), any(MessageEnvelope.class));
+    }
+
+    // ---- KICK→QUIT 去重：真实 Paper 一次踢出触发 PlayerKickEvent + PlayerQuitEvent ----
+
+    @Test
+    void enqueue_kickThenQuitSamePlayer_collapsesToSingleKick() {
+        Player p = mockPlayer("Alice");
+        doReturn(List.of()).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_kick"), anyMap())).thenReturn(MessageEnvelope.publicMessage("kick"));
+
+        // 真实 Paper 下成功的踢出会额外触发 PlayerQuitEvent（同一离开上报两次）
+        aggregator.enqueue(p, PlayerEventService.PlayerState.KICK);
+        aggregator.enqueue(p, PlayerEventService.PlayerState.QUIT);
+        runTail();
+
+        // 折叠后窗口内仅 1 条 → 单发走 player_kick 模板，不出现双计摘要
+        verify(configs).renderEvent(eq("player_kick"), anyMap());
+        verify(configs, never()).renderEvent(eq("player_digest"), anyMap());
+        verify(notifier).event(eq("player_kick"), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void enqueue_kickAndQuit_differentPlayers_countsBothInDigest() {
+        Player kicked = mockPlayer("Alice");
+        Player quitter = mockPlayer("Bob");
+        doReturn(List.of()).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_digest"), anyMap())).thenReturn(MessageEnvelope.publicMessage("digest"));
+
+        aggregator.enqueue(kicked, PlayerEventService.PlayerState.KICK);
+        aggregator.enqueue(quitter, PlayerEventService.PlayerState.QUIT);
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_digest"), vars.capture());
+        Map<String, String> v = vars.getValue();
+        assertTrue(v.get("kick_summary").startsWith("⛔ -1 被踢"), "got: " + v.get("kick_summary"));
+        assertTrue(v.get("quit_summary").startsWith("🔴 -1 下线"), "got: " + v.get("quit_summary"));
+    }
+
+    // ---- 禁用/重载同步冲刷：不走调度器，避免尾部任务被取消导致整窗丢失 ----
+
+    @Test
+    void flushPending_flushesSynchronously_leftoverScheduledTaskIsNoop() {
+        Player p = mockPlayer("Alice");
+        doReturn(List.of(p)).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_join"), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
+
+        aggregator.enqueue(p, PlayerEventService.PlayerState.JOIN);
+        // 禁用场景：不推进调度器，直接同步冲刷
+        aggregator.flushPending();
+
+        verify(notifier).event(eq("player_join"), any(MessageEnvelope.class));
+        // 已交付，入队时调度的尾部任务再执行应为空操作（不重复发送）
+        runTail();
+        verify(notifier, times(1)).event(anyString(), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void flushPending_renderFailure_logsSevereWithoutReschedule() {
+        doThrow(new IllegalStateException("template broken")).when(configs).renderEvent(anyString(), anyMap());
+        aggregator.enqueue(mockPlayer("A"), PlayerEventService.PlayerState.JOIN);
+
+        aggregator.flushPending();
+
+        verify(logger).severe(anyString());
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+        // 禁用场景失败不重排：仅告警（只有入队时的 1 次调度）
+        verify(server, times(1)).runLater(any(Runnable.class), anyLong());
     }
 
     // ---- 渲染失败：保留批次重试（有界），不静默丢弃整窗 ----

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventServiceTest.java
@@ -1,6 +1,5 @@
 package com.jokerhub.paper.plugin.orzmc.features.player;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
@@ -11,7 +10,6 @@ import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.ThrottledNotifier;
-import com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
@@ -19,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +44,9 @@ class PlayerEventServiceTest extends ServiceTestBase {
     private AsyncPlayerPreLoginEvent loginEvent;
 
     @Mock
+    private PlayerEventAggregator aggregator;
+
+    @Mock
     private Logger logger;
 
     private PlayerEventService service;
@@ -53,8 +55,7 @@ class PlayerEventServiceTest extends ServiceTestBase {
     void setUp() {
         // 告警限频默认放行，聚焦验证告警本身；限频行为由 ThrottledNotifier 单测覆盖
         when(throttledNotifier.shouldRun(anyString(), anyLong())).thenReturn(true);
-        service =
-                new PlayerEventService(server, configs, styles, notifier, throttledNotifier, new OnlineListFormatter());
+        service = new PlayerEventService(server, configs, styles, notifier, throttledNotifier, aggregator);
     }
 
     @Test
@@ -192,101 +193,18 @@ class PlayerEventServiceTest extends ServiceTestBase {
         assertTrue(addressInfo.contains("\n  \"ip\""), "JSON should be pretty-printed, got: " + addressInfo);
     }
 
-    // ---- 上下线广播：在线列表含权限组（2026-08-07 修复：缺组名）----
+    // ---- 上下线广播：委托聚合器（渲染与聚合逻辑由 PlayerEventAggregatorTest 覆盖）----
 
     @Test
-    void notifyPlayerState_join_withRankService_includesGroupInList() {
-        com.jokerhub.paper.plugin.orzmc.features.rank.RankService rankService =
-                mock(com.jokerhub.paper.plugin.orzmc.features.rank.RankService.class);
-        com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter formatter =
-                new com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter();
-        formatter.setRankService(rankService);
-        service = new PlayerEventService(server, configs, styles, notifier, throttledNotifier, formatter);
+    void notifyPlayerState_delegatesToAggregator() {
+        Player player = mock(Player.class);
 
-        org.bukkit.entity.Player p1 = mock(org.bukkit.entity.Player.class);
-        org.bukkit.entity.Player p2 = mock(org.bukkit.entity.Player.class);
-        com.destroystokyo.paper.profile.PlayerProfile profile1 =
-                mock(com.destroystokyo.paper.profile.PlayerProfile.class);
-        com.destroystokyo.paper.profile.PlayerProfile profile2 =
-                mock(com.destroystokyo.paper.profile.PlayerProfile.class);
-        when(profile1.getName()).thenReturn("Alice");
-        when(profile2.getName()).thenReturn("Bob");
-        when(p1.getPlayerProfile()).thenReturn(profile1);
-        when(p2.getPlayerProfile()).thenReturn(profile2);
-        when(p1.getGameMode()).thenReturn(org.bukkit.GameMode.SURVIVAL);
-        when(p2.getGameMode()).thenReturn(org.bukkit.GameMode.CREATIVE);
+        service.notifyPlayerState(player, PlayerEventService.PlayerState.JOIN);
+        service.notifyPlayerState(player, PlayerEventService.PlayerState.QUIT);
+        service.notifyPlayerState(player, PlayerEventService.PlayerState.KICK);
 
-        org.bukkit.Server bukkitServer = mock(org.bukkit.Server.class);
-        when(server.server()).thenReturn(bukkitServer);
-        java.util.Collection<? extends org.bukkit.entity.Player> online = java.util.List.of(p1, p2);
-        doReturn(online).when(bukkitServer).getOnlinePlayers();
-        when(bukkitServer.getMaxPlayers()).thenReturn(20);
-
-        // p1 是 admin 组、p2 是 builder 组（LP 真实组 → 显示名）
-        java.util.UUID id1 = java.util.UUID.randomUUID();
-        java.util.UUID id2 = java.util.UUID.randomUUID();
-        when(p1.getUniqueId()).thenReturn(id1);
-        when(p2.getUniqueId()).thenReturn(id2);
-        when(rankService.currentGroup(id1)).thenReturn("admin");
-        when(rankService.currentGroup(id2)).thenReturn("builder");
-
-        org.bukkit.Location loc = mock(org.bukkit.Location.class);
-        when(p1.getLocation()).thenReturn(loc);
-        when(loc.getWorld()).thenReturn(null);
-        when(server.logger()).thenReturn(logger);
-        when(configs.templateOptions())
-                .thenReturn(mock(com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions.class));
-        when(configs.renderEvent(eq("player_join"), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
-        when(throttledNotifier.shouldRunDefault(anyString())).thenReturn(true);
-
-        service.notifyPlayerState(p1, PlayerEventService.PlayerState.JOIN);
-
-        @SuppressWarnings("unchecked")
-        org.mockito.ArgumentCaptor<java.util.Map<String, String>> captor =
-                org.mockito.ArgumentCaptor.forClass(java.util.Map.class);
-        verify(configs).renderEvent(eq("player_join"), captor.capture());
-        String onlineList = captor.getValue().get("online_list");
-        assertNotNull(onlineList, "online_list should be present");
-        assertTrue(onlineList.contains("Alice"), "list should contain Alice, got: " + onlineList);
-        assertTrue(onlineList.contains("管理员"), "Alice 应显示权限组 管理员, got: " + onlineList);
-        assertTrue(onlineList.contains("Bob"), "list should contain Bob, got: " + onlineList);
-        assertTrue(onlineList.contains("建造者"), "Bob 应显示权限组 建造者, got: " + onlineList);
-    }
-
-    @Test
-    void notifyPlayerState_join_withoutRankService_omitsGroup() {
-        org.bukkit.entity.Player p1 = mock(org.bukkit.entity.Player.class);
-        com.destroystokyo.paper.profile.PlayerProfile profile1 =
-                mock(com.destroystokyo.paper.profile.PlayerProfile.class);
-        when(profile1.getName()).thenReturn("Alice");
-        when(p1.getPlayerProfile()).thenReturn(profile1);
-        when(p1.getGameMode()).thenReturn(org.bukkit.GameMode.SURVIVAL);
-
-        org.bukkit.Server bukkitServer = mock(org.bukkit.Server.class);
-        when(server.server()).thenReturn(bukkitServer);
-        java.util.Collection<? extends org.bukkit.entity.Player> online = java.util.List.of(p1);
-        doReturn(online).when(bukkitServer).getOnlinePlayers();
-        when(bukkitServer.getMaxPlayers()).thenReturn(20);
-
-        org.bukkit.Location loc = mock(org.bukkit.Location.class);
-        when(p1.getLocation()).thenReturn(loc);
-        when(loc.getWorld()).thenReturn(null);
-        when(server.logger()).thenReturn(logger);
-        when(configs.templateOptions())
-                .thenReturn(mock(com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions.class));
-        when(configs.renderEvent(eq("player_join"), anyMap())).thenReturn(MessageEnvelope.publicMessage("ok"));
-        when(throttledNotifier.shouldRunDefault(anyString())).thenReturn(true);
-
-        service.notifyPlayerState(p1, PlayerEventService.PlayerState.JOIN);
-
-        @SuppressWarnings("unchecked")
-        org.mockito.ArgumentCaptor<java.util.Map<String, String>> captor =
-                org.mockito.ArgumentCaptor.forClass(java.util.Map.class);
-        verify(configs).renderEvent(eq("player_join"), captor.capture());
-        String onlineList = captor.getValue().get("online_list");
-        assertNotNull(onlineList);
-        // 无 rankService：只显示 玩家名+游戏模式，不含任何权限组词
-        assertTrue(onlineList.contains("Alice 生存模式"), "got: " + onlineList);
-        assertFalse(onlineList.contains("管理员"), "不应含权限组, got: " + onlineList);
+        verify(aggregator).enqueue(player, PlayerEventService.PlayerState.JOIN);
+        verify(aggregator).enqueue(player, PlayerEventService.PlayerState.QUIT);
+        verify(aggregator).enqueue(player, PlayerEventService.PlayerState.KICK);
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventServiceTest.java
@@ -207,4 +207,11 @@ class PlayerEventServiceTest extends ServiceTestBase {
         verify(aggregator).enqueue(player, PlayerEventService.PlayerState.QUIT);
         verify(aggregator).enqueue(player, PlayerEventService.PlayerState.KICK);
     }
+
+    @Test
+    void flushPending_delegatesToAggregator() {
+        service.flushPending();
+
+        verify(aggregator).flushPending();
+    }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
@@ -529,7 +529,7 @@ class ConfigHealthCheckTest {
         addFullValidConfig_bot();
         addMinimalValidConfig_templates();
         List<String> issues = runValidate();
-        assertTrue(issues.contains("config.yml 缺失 player_notify 配置段"));
+        assertTrue(issues.contains("建议: config.yml 缺失 player_notify 配置段，将使用默认配置（窗口 3000ms，三类通知启用）"));
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
@@ -71,9 +71,18 @@ class ConfigHealthCheckTest {
         config.getConfigurationSection("tnt").set("enable", false);
         config.getConfigurationSection("tnt").set("enable_respawn_anchor", false);
         config.getConfigurationSection("tnt").set("place_cooldown", 5);
-        config.getConfigurationSection("tnt").set("notify_throttle_ms", 1000L);
         config.getConfigurationSection("tnt").set("whitelist", List.of());
         config.getConfigurationSection("tnt").set("exempt_entities", List.of());
+    }
+
+    private void addFullValidConfig_playerNotify() {
+        config.createSection("player_notify");
+        config.getConfigurationSection("player_notify").set("enabled_join", true);
+        config.getConfigurationSection("player_notify").set("enabled_quit", true);
+        config.getConfigurationSection("player_notify").set("enabled_kick", true);
+        config.getConfigurationSection("player_notify").set("window_ms", 3000L);
+        config.getConfigurationSection("player_notify").set("max_list_items", 6);
+        config.getConfigurationSection("player_notify").set("include_online_list", false);
     }
 
     private void addFullValidConfig_geoip() {
@@ -161,7 +170,8 @@ class ConfigHealthCheckTest {
             "command_review_list",
             "command_review_list_empty",
             "command_review_result",
-            "command_review_error"
+            "command_review_error",
+            "player_digest"
         };
         for (String cmd : requiredCmds) {
             templates.set("templates." + cmd, "x");
@@ -215,6 +225,7 @@ class ConfigHealthCheckTest {
         addFullValidConfig_whitelist();
         addFullValidConfig_maintenance();
         addFullValidConfig_tnt();
+        addFullValidConfig_playerNotify();
         addFullValidConfig_geoip();
         addFullValidConfig_commandPolicies();
         addFullValidConfig_bot();
@@ -496,19 +507,6 @@ class ConfigHealthCheckTest {
     }
 
     @Test
-    void tntNegativeNotifyThrottle_reportsIssue() {
-        config.createSection("tnt").set("notify_throttle_ms", -100L);
-        addFullValidConfig_whitelist();
-        addFullValidConfig_maintenance();
-        addFullValidConfig_geoip();
-        addFullValidConfig_commandPolicies();
-        addFullValidConfig_bot();
-        addMinimalValidConfig_templates();
-        List<String> issues = runValidate();
-        assertTrue(issues.contains("非法: tnt.notify_throttle_ms 不得为负数"));
-    }
-
-    @Test
     void tntNonPositiveAggregateWindow_reportsIssue() {
         config.createSection("tnt").set("notify_aggregate_ms", 0L);
         addFullValidConfig_whitelist();
@@ -519,6 +517,66 @@ class ConfigHealthCheckTest {
         addMinimalValidConfig_templates();
         List<String> issues = runValidate();
         assertTrue(issues.contains("非法: tnt.notify_aggregate_ms 必须为正数（≤0 会回退默认 3000ms，静默关闭防刷屏）"));
+    }
+
+    @Test
+    void missingPlayerNotifySection_reportsIssue() {
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("config.yml 缺失 player_notify 配置段"));
+    }
+
+    @Test
+    void playerNotifyNonPositiveWindow_reportsIssue() {
+        addFullValidConfig_playerNotify();
+        config.getConfigurationSection("player_notify").set("window_ms", -1L);
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("非法: player_notify.window_ms 必须为正数（≤0 会回退默认 3000ms，静默关闭防刷屏）"));
+    }
+
+    @Test
+    void playerNotifyMaxListBelowOne_reportsIssue() {
+        addFullValidConfig_playerNotify();
+        config.getConfigurationSection("player_notify").set("max_list_items", 0);
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("非法: player_notify.max_list_items 不得小于 1"));
+    }
+
+    @Test
+    void playerNotifyWrongToggleTypes_reportIssue() {
+        addFullValidConfig_playerNotify();
+        config.getConfigurationSection("player_notify").set("enabled_join", "yes");
+        config.getConfigurationSection("player_notify").set("include_online_list", 1);
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("类型错误: player_notify.enabled_join 需为布尔值"));
+        assertTrue(issues.contains("类型错误: player_notify.include_online_list 需为布尔值"));
     }
 
     @Test
@@ -942,7 +1000,8 @@ class ConfigHealthCheckTest {
             "command_review_list",
             "command_review_list_empty",
             "command_review_result",
-            "command_review_error"
+            "command_review_error",
+            "player_digest"
         };
         for (String cmd : requiredCmds) {
             templates.set("templates." + cmd, "x");

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPathTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPathTest.java
@@ -11,7 +11,7 @@ class ConfigPathTest {
     void all_containsExpectedEntries() {
         Map<String, ConfigPath> all = ConfigPath.all();
         assertNotNull(all);
-        assertEquals(31, all.size());
+        assertEquals(30, all.size());
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPathTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPathTest.java
@@ -11,7 +11,7 @@ class ConfigPathTest {
     void all_containsExpectedEntries() {
         Map<String, ConfigPath> all = ConfigPath.all();
         assertNotNull(all);
-        assertEquals(25, all.size());
+        assertEquals(31, all.size());
     }
 
     @Test
@@ -134,7 +134,27 @@ class ConfigPathTest {
         // tnt entries come after maintenance
         assertTrue(keys[7].startsWith("tnt."));
         // bot entries after command_policies
-        assertTrue(keys[18].startsWith("cmd_prompt_char") || keys[18].startsWith("discord_server_link"));
+        assertTrue(keys[24].startsWith("cmd_prompt_char") || keys[24].startsWith("discord_server_link"));
+    }
+
+    @Test
+    void all_containsPlayerNotifyPaths() {
+        Map<String, ConfigPath> all = ConfigPath.all();
+
+        ConfigPath window = all.get("player_notify.window_ms");
+        assertNotNull(window);
+        assertEquals(Long.class, window.type());
+        assertEquals(3000L, window.defaultValue());
+
+        ConfigPath maxList = all.get("player_notify.max_list_items");
+        assertNotNull(maxList);
+        assertEquals(Integer.class, maxList.type());
+        assertEquals(6, maxList.defaultValue());
+
+        ConfigPath includeList = all.get("player_notify.include_online_list");
+        assertNotNull(includeList);
+        assertEquals(Boolean.class, includeList.type());
+        assertEquals(false, includeList.defaultValue());
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/PlayerNotifyConfigTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/PlayerNotifyConfigTest.java
@@ -1,0 +1,79 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.junit.jupiter.api.Test;
+
+class PlayerNotifyConfigTest {
+
+    @Test
+    void fromNull_returnsDefaults() {
+        PlayerNotifyConfig config = PlayerNotifyConfig.from(null);
+        assertTrue(config.enabledJoin());
+        assertTrue(config.enabledQuit());
+        assertTrue(config.enabledKick());
+        assertEquals(3000L, config.windowMs());
+        assertEquals(6, config.maxListItems());
+        assertFalse(config.includeOnlineList());
+    }
+
+    @Test
+    void fromEmpty_returnsDefaults() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled_join", true)).thenReturn(true);
+        when(cfg.getBoolean("enabled_quit", true)).thenReturn(true);
+        when(cfg.getBoolean("enabled_kick", true)).thenReturn(true);
+        when(cfg.getLong("window_ms", 3000L)).thenReturn(3000L);
+        when(cfg.getInt("max_list_items", 6)).thenReturn(6);
+
+        PlayerNotifyConfig config = PlayerNotifyConfig.from(cfg);
+        assertTrue(config.enabledJoin());
+        assertTrue(config.enabledQuit());
+        assertTrue(config.enabledKick());
+        assertEquals(3000L, config.windowMs());
+        assertEquals(6, config.maxListItems());
+        assertFalse(config.includeOnlineList());
+    }
+
+    @Test
+    void fromSection_nonPositiveWindow_fallsBackToDefault() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getLong("window_ms", 3000L)).thenReturn(0L);
+
+        PlayerNotifyConfig config = PlayerNotifyConfig.from(cfg);
+
+        // 0/负数窗口会让聚合退化为 1 tick → 静默关闭防刷屏，必须回退默认
+        assertEquals(3000L, config.windowMs());
+    }
+
+    @Test
+    void fromSection_zeroMaxListItems_clampsToOne() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getInt("max_list_items", 6)).thenReturn(0);
+
+        PlayerNotifyConfig config = PlayerNotifyConfig.from(cfg);
+
+        assertEquals(1, config.maxListItems());
+    }
+
+    @Test
+    void fromFullSection_returnsCorrectValues() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled_join", true)).thenReturn(false);
+        when(cfg.getBoolean("enabled_quit", true)).thenReturn(false);
+        when(cfg.getBoolean("enabled_kick", true)).thenReturn(false);
+        when(cfg.getLong("window_ms", 3000L)).thenReturn(5000L);
+        when(cfg.getInt("max_list_items", 6)).thenReturn(10);
+        when(cfg.getBoolean("include_online_list", false)).thenReturn(true);
+
+        PlayerNotifyConfig config = PlayerNotifyConfig.from(cfg);
+        assertFalse(config.enabledJoin());
+        assertFalse(config.enabledQuit());
+        assertFalse(config.enabledKick());
+        assertEquals(5000L, config.windowMs());
+        assertEquals(10, config.maxListItems());
+        assertTrue(config.includeOnlineList());
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/notify/ThrottledNotifierTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/notify/ThrottledNotifierTest.java
@@ -1,69 +1,17 @@
 package com.jokerhub.paper.plugin.orzmc.infra.notify;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
-import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ThrottledNotifierTest {
 
-    private ConfigService configService;
-    private FileConfiguration config;
     private ThrottledNotifier notifier;
 
     @BeforeEach
     void setUp() {
-        configService = mock(ConfigService.class);
-        config = mock(FileConfiguration.class);
-        lenient().when(configService.getConfig("config")).thenReturn(config);
-        lenient().when(config.getConfigurationSection("tnt")).thenReturn(null);
-
-        notifier = new ThrottledNotifier(configService);
-    }
-
-    @Test
-    void shouldRun_returnsTrueOnFirstCall() {
-        assertTrue(notifier.shouldRunDefault("test-key"));
-    }
-
-    @Test
-    void shouldRun_returnsFalseWithinPeriod() {
-        assertTrue(notifier.shouldRunDefault("test-key"));
-        assertFalse(notifier.shouldRunDefault("test-key"));
-    }
-
-    @Test
-    void shouldRun_differentKeysIndependently() {
-        assertTrue(notifier.shouldRunDefault("key-a"));
-        assertTrue(notifier.shouldRunDefault("key-b"));
-        assertFalse(notifier.shouldRunDefault("key-a"));
-        assertFalse(notifier.shouldRunDefault("key-b"));
-    }
-
-    @Test
-    void runDefault_executesActionOnFirstCall() {
-        AtomicInteger count = new AtomicInteger(0);
-        notifier.runDefault("key", () -> count.incrementAndGet());
-        assertEquals(1, count.get());
-    }
-
-    @Test
-    void runDefault_skipsActionWithinPeriod() {
-        AtomicInteger count = new AtomicInteger(0);
-        notifier.runDefault("key", () -> count.incrementAndGet());
-        notifier.runDefault("key", () -> count.incrementAndGet());
-        assertEquals(1, count.get());
-    }
-
-    @Test
-    void runDefault_withCustomTtlMs() {
-        AtomicInteger count = new AtomicInteger(0);
-        notifier.runDefault("key", 10L, () -> count.incrementAndGet());
-        assertEquals(1, count.get());
+        notifier = new ThrottledNotifier();
     }
 
     @Test
@@ -80,9 +28,8 @@ class ThrottledNotifierTest {
     }
 
     @Test
-    void defaultPeriodMs_fallsBackToDefault_whenConfigFails() {
-        reset(config);
-        lenient().when(configService.getConfig("config")).thenThrow(new RuntimeException("not ready"));
-        assertTrue(notifier.shouldRunDefault("test-key"));
+    void shouldRun_withFixedPeriod_zeroPeriod_alwaysRuns() {
+        assertTrue(notifier.shouldRun("zero-key", 0L), "周期为 0 时每次放行");
+        assertTrue(notifier.shouldRun("zero-key", 0L));
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplatePlaceholderValidatorTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplatePlaceholderValidatorTest.java
@@ -40,4 +40,29 @@ class TemplatePlaceholderValidatorTest {
         assertFalse(issues.isEmpty());
         assertTrue(issues.stream().anyMatch(i -> i.contains("模板变量未知")));
     }
+
+    @Test
+    void playerDigest_knownPlaceholders_pass() {
+        FileConfiguration cfg = mock(FileConfiguration.class);
+        when(cfg.getString(anyString(), anyString())).thenReturn("");
+        when(cfg.getString(eq("templates.player_digest"), anyString()))
+                .thenReturn("{join_summary}{quit_summary}{kick_summary}{online_count}{max_count}{online_list}");
+        when(cfg.get(anyString())).thenReturn(null);
+        when(cfg.contains(anyString())).thenReturn(false);
+
+        List<String> issues = TemplatePlaceholderValidator.validate(cfg);
+        assertTrue(issues.isEmpty());
+    }
+
+    @Test
+    void playerDigest_unknownPlaceholder_reportsError() {
+        FileConfiguration cfg = mock(FileConfiguration.class);
+        when(cfg.getString(anyString(), anyString())).thenReturn("");
+        when(cfg.getString(eq("templates.player_digest"), anyString())).thenReturn("{bogus_var}");
+        when(cfg.get(anyString())).thenReturn(null);
+        when(cfg.contains(anyString())).thenReturn(false);
+
+        List<String> issues = TemplatePlaceholderValidator.validate(cfg);
+        assertTrue(issues.stream().anyMatch(i -> i.contains("模板变量未知")));
+    }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateServiceTest.java
@@ -36,6 +36,16 @@ class TemplateServiceTest {
     }
 
     @Test
+    void playerDigest_returnsMessageEnvelope() {
+        YamlConfiguration cfg = new YamlConfiguration();
+        Templates templates = Templates.from(cfg);
+        MessageEnvelope result =
+                TemplateService.renderEvent("player_digest", cfg, templates, Map.of("join_summary", "🟢 +2 上线：A、B\n"));
+        assertNotNull(result);
+        assertTrue(result.message().contains("🟢 +2 上线：A、B"), "摘要模板应渲染 join_summary: " + result.message());
+    }
+
+    @Test
     void exceptionAlert_returnsMessageEnvelope() {
         YamlConfiguration cfg = new YamlConfiguration();
         Templates templates = Templates.from(cfg);


### PR DESCRIPTION
## 变更摘要

玩家上下线通知改为**窗口聚合**：窗口内仅 1 条事件走原单条模板（延迟一个窗口），多条事件合并渲染 `player_digest` 摘要并按状态精确计数（🟢 +N/🔴 -N/⛔ -N）。限流通过窗口合并实现，**没有任何静默丢弃路径**——每条事件要么作为唯一事件单条渲染，要么进入摘要被精确计数。

同时修复集成测试暴露的生产 bug：`player_digest` 模板此前未接线（`Templates` 缺字段、`TemplateService` 返回空串），聚合摘要消息在真实运行中渲染为空。

新增 MockBukkit 聚合集成测试层，验证单发模板、突发摘要精确计数、名称截断不影响计数、窗口边界、以及跨窗口对账（事件总数 = Σ单条消息数 + Σ摘要计数）。

## 变更类型

- [x] feat: 新功能（窗口聚合限流）
- [x] fix: Bug 修复（player_digest 模板接线）
- [ ] refactor: 代码重构
- [ ] chore: 构建/配置/依赖变更
- [ ] docs: 文档变更

## 测试说明

- [x] `./gradlew spotlessCheck` 通过
- [x] `./gradlew test` 通过（994 个用例）
- [x] `./gradlew integrationTest` 通过（91 个用例）
- [x] `./gradlew check` 通过

## 额外说明

包含三个提交，各独立可构建：

1. `feat(player_notify)` 窗口聚合功能 + 配置 + 单测
2. `fix(templates)` 接线 player_digest 摘要模板
3. `test(player_notify)` MockBukkit 集成测试层

已在本机跑通全量门禁；本 PR 上将运行 CI `build` 检查。
