### PR TITLE
feat(security): P2-1 聊天反垃圾/反广告

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -6,6 +6,7 @@ import static io.papermc.paper.command.brigadier.Commands.literal;
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
 import com.jokerhub.paper.plugin.orzmc.commands.OrzConfigCommand;
 import com.jokerhub.paper.plugin.orzmc.events.OrzBowShootEvent;
+import com.jokerhub.paper.plugin.orzmc.events.OrzChatEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzCommandGuardEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzDebugEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzMenuEvent;
@@ -16,6 +17,8 @@ import com.jokerhub.paper.plugin.orzmc.events.OrzServerEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzTNTEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzTPEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzWhiteListEvent;
+import com.jokerhub.paper.plugin.orzmc.features.chat.ChatSpamFilterEventService;
+import com.jokerhub.paper.plugin.orzmc.features.chat.ChatSpamFilterService;
 import com.jokerhub.paper.plugin.orzmc.features.command.CommandFeedbackService;
 import com.jokerhub.paper.plugin.orzmc.features.command.binding.AdminOnlyInterceptor;
 import com.jokerhub.paper.plugin.orzmc.features.command.binding.CommandInterceptor;
@@ -100,6 +103,8 @@ public final class FeatureModule implements ServiceModule {
     private final ServerLifecycleService serverLifecycleService;
     /** 启动安全自检报告（安全加固 P1-2）：ServerLoadEvent 时采集配置 PRIVATE 私信管理员。 */
     private final StartupSecurityAuditService startupSecurityAuditService;
+    /** 聊天反垃圾（安全加固 P2-1）：AsyncChatEvent 按玩家限流 + 链接/重复检测。 */
+    private final ChatSpamFilterEventService chatSpamFilterEventService;
 
     private final MenuCommandService menuCommandService;
     private final PortalCommandService portalCommandService;
@@ -164,6 +169,9 @@ public final class FeatureModule implements ServiceModule {
                 new ServerLifecycleService(platform.serverFacade(), platform.configs(), botModule.notifier());
         this.startupSecurityAuditService =
                 new StartupSecurityAuditService(platform.serverFacade(), platform.configs(), botModule.notifier());
+        // 聊天反垃圾：纯判定核心 + 事件编排；chat 每次读取最新配置（Supplier），/config reload 生效
+        this.chatSpamFilterEventService = new ChatSpamFilterEventService(
+                new ChatSpamFilterService(platform.configs()::chat), platform.configs(), platform.textStyles());
         this.menuCommandService = new MenuCommandService(platform.textStyles());
         this.portalCommandService = new PortalCommandService(portalModule.portalService(), platform.textStyles());
         this.orzConfigCommand = new OrzConfigCommand(
@@ -261,6 +269,7 @@ public final class FeatureModule implements ServiceModule {
                             !mainConfig.entityTeleportEnabled(), mainConfig.entityTeleportWhitelist())),
             new OrzTNTEvent(plugin, tntEventService),
             new OrzCommandGuardEvent(plugin, commandGuardEventService),
+            new OrzChatEvent(plugin, chatSpamFilterEventService),
             new OrzMenuEvent(plugin, menuEventService),
             new OrzServerEvent(plugin, serverEventService),
             new OrzSecurityAuditEvent(plugin, startupSecurityAuditService),

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
@@ -2,6 +2,7 @@ package com.jokerhub.paper.plugin.orzmc.core.ports.config;
 
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
@@ -33,6 +34,8 @@ public interface TypedConfigProvider {
     IpWhitelist ipWhitelist();
 
     SecurityGuardConfig securityGuard();
+
+    ChatConfig chat();
 
     MessageEnvelope renderEvent(String eventKey, Map<String, String> vars);
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzChatEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzChatEvent.java
@@ -1,0 +1,34 @@
+package com.jokerhub.paper.plugin.orzmc.events;
+
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.features.chat.ChatSpamFilterEventService;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * 聊天反垃圾监听器（安全加固 P2-1）。
+ *
+ * <p>{@link EventPriority#LOWEST} 最早介入：命中刷屏/广告即取消 {@link AsyncChatEvent}，
+ * 阻止消息进入全局广播；{@link PlayerQuitEvent} 时清理该玩家限流/重复状态。</p>
+ */
+public class OrzChatEvent extends OrzBaseListener {
+
+    private final ChatSpamFilterEventService service;
+
+    public OrzChatEvent(OrzMC plugin, ChatSpamFilterEventService service) {
+        super(plugin);
+        this.service = service;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onAsyncChat(AsyncChatEvent event) {
+        service.onAsyncChat(event);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        service.onPlayerQuit(event);
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/chat/ChatSpamFilterEventService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/chat/ChatSpamFilterEventService.java
@@ -1,0 +1,41 @@
+package com.jokerhub.paper.plugin.orzmc.features.chat;
+
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * 聊天反垃圾事件编排（安全加固 P2-1）。
+ *
+ * <p>把 {@link ChatSpamFilterService} 的纯判定接入 {@link AsyncChatEvent} 事件侧：
+ * 命中即取消事件（阻止全局广播），并以 warn 色向玩家发送配置的提示文案；
+ * {@link PlayerQuitEvent} 时清理该玩家状态，避免内存无界增长。</p>
+ */
+public final class ChatSpamFilterEventService {
+
+    private final ChatSpamFilterService filter;
+    private final TypedConfigProvider configs;
+    private final OrzTextStyles styles;
+
+    public ChatSpamFilterEventService(ChatSpamFilterService filter, TypedConfigProvider configs, OrzTextStyles styles) {
+        this.filter = filter;
+        this.configs = configs;
+        this.styles = styles;
+    }
+
+    public void onAsyncChat(AsyncChatEvent event) {
+        Player player = event.getPlayer();
+        String plain = PlainTextComponentSerializer.plainText().serialize(event.message());
+        if (filter.isSpam(player.getUniqueId(), plain)) {
+            event.setCancelled(true);
+            player.sendMessage(styles.warn(configs.chat().message()));
+        }
+    }
+
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        filter.clear(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/chat/ChatSpamFilterService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/chat/ChatSpamFilterService.java
@@ -1,0 +1,96 @@
+package com.jokerhub.paper.plugin.orzmc.features.chat;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+/**
+ * 聊天反垃圾判定核心（纯逻辑，安全加固 P2-1）。
+ *
+ * <p>在 {@code AsyncChatEvent} 事件线程（异步）上对每条玩家消息做三类检查：</p>
+ * <ol>
+ *   <li><b>链接检测</b>：消息含 {@code http(s)://} 或 {@code www.} 开头的链接即判为广告；</li>
+ *   <li><b>重复检测</b>：与本人上一条已放行消息完全相同即判为刷屏；</li>
+ *   <li><b>限流</b>：60s 滑动窗口内发言超过 {@code max_messages_per_minute} 即判为刷屏。</li>
+ * </ol>
+ *
+ * <p>状态按 {@link UUID} 分桶（{@link ConcurrentHashMap}），事件线程可安全并发；
+ * 命中规则即丢弃该条消息（不再进入全局广播）。配置通过 {@link Supplier} 注入，
+ * 事件侧每次读取最新配置（与 {@code CommandGuardService} 的 Supplier 模式一致），
+ * /config reload 生效。</p>
+ */
+public final class ChatSpamFilterService {
+
+    /** 链接识别：http(s):// 或 www. 开头后接非空白字符。 */
+    private static final Pattern LINK_PATTERN = Pattern.compile("(?i)\\b(?:https?://|www\\.)[^\\s]+");
+
+    /** 限流滑动窗口长度（毫秒）。 */
+    private static final long WINDOW_MS = 60_000L;
+
+    private final Supplier<ChatConfig> configSupplier;
+    private final LongSupplier clock;
+    /** playerId → 窗口内各条消息的发言时刻。 */
+    private final Map<UUID, Deque<Long>> messageTimes = new ConcurrentHashMap<>();
+    /** playerId → 上一条已放行消息（原文，重复检测）。 */
+    private final Map<UUID, String> lastMessages = new ConcurrentHashMap<>();
+
+    public ChatSpamFilterService(Supplier<ChatConfig> configSupplier) {
+        this(configSupplier, System::currentTimeMillis);
+    }
+
+    /** 测试用：注入可控时钟以验证窗口滑动。 */
+    ChatSpamFilterService(Supplier<ChatConfig> configSupplier, LongSupplier clock) {
+        this.configSupplier = configSupplier;
+        this.clock = clock;
+    }
+
+    /** 判定一条玩家消息是否应被丢弃（true = 刷屏/广告）。 */
+    public boolean isSpam(UUID playerId, String message) {
+        ChatConfig cfg = configSupplier.get();
+        if (!cfg.enabled()) {
+            return false;
+        }
+        if (message == null || message.isBlank()) {
+            return false;
+        }
+        if (cfg.detectLinks() && LINK_PATTERN.matcher(message).find()) {
+            return true;
+        }
+        if (cfg.detectRepeat() && message.equals(lastMessages.get(playerId))) {
+            return true;
+        }
+        if (rateLimited(playerId, cfg.maxMessagesPerMinute())) {
+            return true;
+        }
+        lastMessages.put(playerId, message);
+        return false;
+    }
+
+    /** 玩家退出时清理其状态，避免无界增长。 */
+    public void clear(UUID playerId) {
+        messageTimes.remove(playerId);
+        lastMessages.remove(playerId);
+    }
+
+    /** 60s 滑动窗口限流：窗口内条数达到上限即拒绝，否则记录本条发言时刻。 */
+    private boolean rateLimited(UUID playerId, int maxPerMinute) {
+        long now = clock.getAsLong();
+        Deque<Long> times = messageTimes.computeIfAbsent(playerId, k -> new ArrayDeque<>());
+        synchronized (times) {
+            while (!times.isEmpty() && now - times.peekFirst() >= WINDOW_MS) {
+                times.pollFirst();
+            }
+            if (times.size() >= maxPerMinute) {
+                return true;
+            }
+            times.addLast(now);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
@@ -38,6 +38,7 @@ public final class ConfigHealthCheck {
         validateGeoIpSection(cfg.getConfigurationSection("geoip"), issues);
         validateCommandPoliciesSection(cfg.getConfigurationSection("command_policies"), issues);
         validateGuardSection(cfg.getConfigurationSection("guard"), issues);
+        validateChatSection(cfg.getConfigurationSection("chat"), issues);
     }
 
     private static void validateWhitelistSection(ConfigurationSection section, List<String> issues) {
@@ -183,6 +184,25 @@ public final class ConfigHealthCheck {
         if (ae != null && !(ae instanceof Boolean)) issues.add("类型错误: guard.audit_enabled 需为布尔值");
         Object bl = section.get("blocked_commands");
         if (bl != null && !(bl instanceof List<?>)) issues.add("类型错误: guard.blocked_commands 需为列表");
+    }
+
+    private static void validateChatSection(ConfigurationSection section, List<String> issues) {
+        if (section == null) {
+            // 降级为建议：默认配置完整可用，升级安装（config.yml 存在故未复制新默认值）会缺此段，
+            // 属提示而非缺陷，避免升级后每次启动的持久告警
+            issues.add("建议: config.yml 缺失 chat 配置段，将使用默认配置（聊天反垃圾开启）");
+            return;
+        }
+        Object en = section.get("enabled");
+        if (en != null && !(en instanceof Boolean)) issues.add("类型错误: chat.enabled 需为布尔值");
+        int max = section.getInt("max_messages_per_minute", 6);
+        if (max < 1) issues.add("非法: chat.max_messages_per_minute 不得小于 1");
+        Object dl = section.get("detect_links");
+        if (dl != null && !(dl instanceof Boolean)) issues.add("类型错误: chat.detect_links 需为布尔值");
+        Object dr = section.get("detect_repeat");
+        if (dr != null && !(dr instanceof Boolean)) issues.add("类型错误: chat.detect_repeat 需为布尔值");
+        String msg = section.getString("message", "");
+        if (msg.isBlank()) issues.add("缺失: chat.message 不可为空");
     }
 
     private static void validateEasyBot(FileConfiguration cfg, List<String> issues) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
@@ -3,6 +3,7 @@ package com.jokerhub.paper.plugin.orzmc.infra.config;
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
@@ -80,6 +81,12 @@ public final class DefaultTypedConfigProvider implements TypedConfigProvider {
     public SecurityGuardConfig securityGuard() {
         ConfigurationSection section = sectionOrLegacy("config", "guard", "guard.yml");
         return SecurityGuardConfig.from(section);
+    }
+
+    @Override
+    public ChatConfig chat() {
+        ConfigurationSection section = sectionOrLegacy("config", "chat", "chat.yml");
+        return ChatConfig.from(section);
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/ChatConfig.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/ChatConfig.java
@@ -1,0 +1,37 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+/**
+ * 聊天反垃圾/反广告（安全加固 P2-1）配置。
+ *
+ * <p>对应 config.yml 的 {@code chat:} 段，供 {@code ChatSpamFilterService} 使用：
+ * 配置是否启用、每分钟限流条数、是否检测链接/重复文本，以及命中时的提示文案。</p>
+ */
+public record ChatConfig(
+        boolean enabled, int maxMessagesPerMinute, boolean detectLinks, boolean detectRepeat, String message) {
+
+    /** 默认命中提示文案。 */
+    public static final String DEFAULT_MESSAGE = "请勿刷屏或发送广告";
+
+    public static ChatConfig from(ConfigurationSection cfg) {
+        if (cfg == null) {
+            return new ChatConfig(true, 6, true, true, DEFAULT_MESSAGE);
+        }
+        int max = cfg.getInt("max_messages_per_minute", 6);
+        if (max < 1) {
+            // 非正上限会让限流失效（同 1 tick），回退最小 1
+            max = 1;
+        }
+        String msg = cfg.getString("message", DEFAULT_MESSAGE);
+        if (msg == null || msg.isBlank()) {
+            msg = DEFAULT_MESSAGE;
+        }
+        return new ChatConfig(
+                cfg.getBoolean("enabled", true),
+                max,
+                cfg.getBoolean("detect_links", true),
+                cfg.getBoolean("detect_repeat", true),
+                msg);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -137,3 +137,23 @@ guard:
   notify_admins: true
   # 是否记录命令审计到 audit/command_audit.log
   audit_enabled: true
+
+# ==================================================
+#             聊天反垃圾/反广告（安全加固）
+# ==================================================
+# 在异步聊天事件（AsyncChatEvent）上做三类拦截，命中即丢弃该条消息：
+#   max_messages_per_minute —— 60s 滑动窗口内最多发言条数（限流）
+#   detect_links            —— 检测并丢弃含链接（http/https/www.）的消息（反广告）
+#   detect_repeat           —— 检测并丢弃与本人上一条完全相同的消息（反刷屏）
+# 命中任一规则即取消该条聊天并给玩家发送 message 提示。
+chat:
+  # 总开关：关闭后聊天过滤全部停用
+  enabled: true
+  # 每分钟最多发言条数（60s 滑动窗口）
+  max_messages_per_minute: 6
+  # 是否丢弃含链接的消息
+  detect_links: true
+  # 是否丢弃与上一条完全相同的重复消息
+  detect_repeat: true
+  # 命中时的提示文案
+  message: "请勿刷屏或发送广告"

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/chat/ChatSpamFilterEventServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/chat/ChatSpamFilterEventServiceTest.java
@@ -1,0 +1,84 @@
+package com.jokerhub.paper.plugin.orzmc.features.chat;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ChatSpamFilterEventServiceTest {
+
+    private ChatSpamFilterService filter;
+    private TypedConfigProvider configs;
+    private OrzTextStyles styles;
+    private ChatSpamFilterEventService service;
+
+    @BeforeEach
+    void setUp() {
+        ChatConfig config = new ChatConfig(true, 6, true, true, "请勿刷屏或发送广告");
+        filter = new ChatSpamFilterService(() -> config);
+        configs = mock(TypedConfigProvider.class);
+        when(configs.chat()).thenReturn(config);
+        styles = mock(OrzTextStyles.class);
+        when(styles.warn(anyString())).thenReturn(Component.text("请勿刷屏或发送广告"));
+        service = new ChatSpamFilterEventService(filter, configs, styles);
+    }
+
+    @Test
+    void spamMessage_cancelledAndWarned() {
+        Player player = player();
+        AsyncChatEvent event = asyncChatEvent(player, "http://example.com");
+        service.onAsyncChat(event);
+        verify(event).setCancelled(true);
+        verify(player).sendMessage(any(Component.class));
+    }
+
+    @Test
+    void normalMessage_notCancelled() {
+        Player player = player();
+        AsyncChatEvent event = asyncChatEvent(player, "今天天气真好");
+        service.onAsyncChat(event);
+        verify(event, never()).setCancelled(true);
+        verify(player, never()).sendMessage(any(Component.class));
+    }
+
+    @Test
+    void playerQuit_clearsState() {
+        Player player = player();
+        // 触发一次重复命中，确保状态存在
+        service.onAsyncChat(asyncChatEvent(player, "收钻石"));
+        AsyncChatEvent second = asyncChatEvent(player, "收钻石");
+        service.onAsyncChat(second);
+        verify(second).setCancelled(true);
+
+        PlayerQuitEvent quit = mock(PlayerQuitEvent.class);
+        when(quit.getPlayer()).thenReturn(player);
+        service.onPlayerQuit(quit);
+
+        // 退出后状态被清空，同样的消息不再判定为重复
+        AsyncChatEvent third = asyncChatEvent(player, "收钻石");
+        service.onAsyncChat(third);
+        verify(third, never()).setCancelled(true);
+    }
+
+    private static Player player() {
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(UUID.randomUUID());
+        return player;
+    }
+
+    private static AsyncChatEvent asyncChatEvent(Player player, String text) {
+        AsyncChatEvent event = mock(AsyncChatEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.message()).thenReturn(Component.text(text));
+        return event;
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/chat/ChatSpamFilterServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/chat/ChatSpamFilterServiceTest.java
@@ -1,0 +1,129 @@
+package com.jokerhub.paper.plugin.orzmc.features.chat;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+
+class ChatSpamFilterServiceTest {
+
+    private static final UUID PLAYER = UUID.randomUUID();
+
+    private static ChatSpamFilterService service(ChatConfig config) {
+        return new ChatSpamFilterService(() -> config);
+    }
+
+    private static ChatSpamFilterService service(ChatConfig config, LongSupplier clock) {
+        return new ChatSpamFilterService(() -> config, clock);
+    }
+
+    private static ChatConfig defaultConfig() {
+        return new ChatConfig(true, 6, true, true, "请勿刷屏或发送广告");
+    }
+
+    // ---- 总开关 ----
+
+    @Test
+    void disabledConfig_allowsLinksAndFlood() {
+        ChatSpamFilterService svc = service(new ChatConfig(false, 1, true, true, "请勿刷屏或发送广告"));
+        assertFalse(svc.isSpam(PLAYER, "看看 http://example.com 吧"));
+        assertFalse(svc.isSpam(PLAYER, "https://example.com"));
+        assertFalse(svc.isSpam(PLAYER, "收钻石"));
+    }
+
+    @Test
+    void nullOrBlank_neverBlocked() {
+        ChatSpamFilterService svc = service(defaultConfig());
+        assertFalse(svc.isSpam(PLAYER, null));
+        assertFalse(svc.isSpam(PLAYER, "  "));
+    }
+
+    // ---- 链接检测 ----
+
+    @Test
+    void httpUrl_blocked() {
+        ChatSpamFilterService svc = service(defaultConfig());
+        assertTrue(svc.isSpam(PLAYER, "加群看视频 http://t.cn/abc"));
+        assertTrue(svc.isSpam(PLAYER, "官网 https://example.com/join"));
+    }
+
+    @Test
+    void wwwDomain_blocked() {
+        ChatSpamFilterService svc = service(defaultConfig());
+        assertTrue(svc.isSpam(PLAYER, "进服 www.example.com"));
+    }
+
+    @Test
+    void linkDetectionDisabled_allowsLink() {
+        ChatSpamFilterService svc = service(new ChatConfig(true, 6, false, true, "请勿刷屏或发送广告"));
+        assertFalse(svc.isSpam(PLAYER, "看看 http://example.com"));
+    }
+
+    @Test
+    void plainMessage_allowed() {
+        ChatSpamFilterService svc = service(defaultConfig());
+        assertFalse(svc.isSpam(PLAYER, "今天天气真好"));
+        assertFalse(svc.isSpam(PLAYER, "哪里有tnt"));
+    }
+
+    // ---- 重复检测 ----
+
+    @Test
+    void identicalMessage_blocked() {
+        ChatSpamFilterService svc = service(defaultConfig());
+        assertFalse(svc.isSpam(PLAYER, "收钻石"));
+        assertTrue(svc.isSpam(PLAYER, "收钻石"));
+    }
+
+    @Test
+    void distinctMessages_allowed() {
+        ChatSpamFilterService svc = service(defaultConfig());
+        assertFalse(svc.isSpam(PLAYER, "收钻石"));
+        assertFalse(svc.isSpam(PLAYER, "出铁锭"));
+    }
+
+    @Test
+    void repeatDetectionDisabled_allowsSameMessage() {
+        ChatSpamFilterService svc = service(new ChatConfig(true, 6, true, false, "请勿刷屏或发送广告"));
+        assertFalse(svc.isSpam(PLAYER, "收钻石"));
+        assertFalse(svc.isSpam(PLAYER, "收钻石"));
+    }
+
+    // ---- 限流 ----
+
+    @Test
+    void rateLimited_afterMaxMessagesPerMinute() {
+        ChatSpamFilterService svc = service(defaultConfig());
+        // 上限 6：前 6 条放行，第 7 条被限流
+        for (int i = 0; i < 6; i++) {
+            assertFalse(svc.isSpam(PLAYER, "消息" + i), "第 " + (i + 1) + " 条应放行");
+        }
+        assertTrue(svc.isSpam(PLAYER, "第7条"));
+    }
+
+    @Test
+    void windowSlides_afterOneMinute() {
+        AtomicLong now = new AtomicLong(0L);
+        ChatSpamFilterService svc = service(new ChatConfig(true, 2, false, false, "请勿刷屏或发送广告"), now::get);
+        assertFalse(svc.isSpam(PLAYER, "a"));
+        assertFalse(svc.isSpam(PLAYER, "b"));
+        assertTrue(svc.isSpam(PLAYER, "c"));
+        // 60s 后窗口滑动，恢复可用额度
+        now.set(60_000L);
+        assertFalse(svc.isSpam(PLAYER, "d"));
+    }
+
+    // ---- 状态清理 ----
+
+    @Test
+    void clear_resetsPlayerState() {
+        ChatSpamFilterService svc = service(defaultConfig());
+        assertFalse(svc.isSpam(PLAYER, "收钻石"));
+        assertTrue(svc.isSpam(PLAYER, "收钻石")); // 重复
+        svc.clear(PLAYER);
+        assertFalse(svc.isSpam(PLAYER, "收钻石"));
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
@@ -97,6 +97,15 @@ class ConfigHealthCheckTest {
         config.getConfigurationSection("guard").set("blocked_commands", List.of("op", "reload"));
     }
 
+    private void addFullValidConfig_chat() {
+        config.createSection("chat");
+        config.getConfigurationSection("chat").set("enabled", true);
+        config.getConfigurationSection("chat").set("max_messages_per_minute", 6);
+        config.getConfigurationSection("chat").set("detect_links", true);
+        config.getConfigurationSection("chat").set("detect_repeat", true);
+        config.getConfigurationSection("chat").set("message", "请勿刷屏或发送广告");
+    }
+
     private void addFullValidConfig_commandPolicies() {
         config.createSection("command_policies");
         config.getConfigurationSection("command_policies").createSection("tpbow");
@@ -237,6 +246,7 @@ class ConfigHealthCheckTest {
         addFullValidConfig_geoip();
         addFullValidConfig_commandPolicies();
         addFullValidConfig_guard();
+        addFullValidConfig_chat();
         addFullValidConfig_bot();
         addFullValidConfig_templates();
         List<String> issues = runValidate();
@@ -600,6 +610,42 @@ class ConfigHealthCheckTest {
         // no guard section
         List<String> issues = runValidate();
         assertTrue(issues.contains("建议: config.yml 缺失 guard 配置段，将使用默认配置（危险命令拦截开启）"));
+    }
+
+    @Test
+    void missingChatSection_reportsSuggestion() {
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        // no chat section
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("建议: config.yml 缺失 chat 配置段，将使用默认配置（聊天反垃圾开启）"));
+    }
+
+    @Test
+    void chatWrongTypes_reportIssues() {
+        config.createSection("chat").set("enabled", "yes");
+        config.getConfigurationSection("chat").set("max_messages_per_minute", 0);
+        config.getConfigurationSection("chat").set("detect_links", "yes");
+        config.getConfigurationSection("chat").set("detect_repeat", 1);
+        config.getConfigurationSection("chat").set("message", "");
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("类型错误: chat.enabled 需为布尔值"));
+        assertTrue(issues.contains("非法: chat.max_messages_per_minute 不得小于 1"));
+        assertTrue(issues.contains("类型错误: chat.detect_links 需为布尔值"));
+        assertTrue(issues.contains("类型错误: chat.detect_repeat 需为布尔值"));
+        assertTrue(issues.contains("缺失: chat.message 不可为空"));
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/ChatConfigTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/ChatConfigTest.java
@@ -1,0 +1,72 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.junit.jupiter.api.Test;
+
+class ChatConfigTest {
+
+    @Test
+    void fromNull_returnsDefaults() {
+        ChatConfig config = ChatConfig.from(null);
+        assertTrue(config.enabled());
+        assertEquals(6, config.maxMessagesPerMinute());
+        assertTrue(config.detectLinks());
+        assertTrue(config.detectRepeat());
+        assertEquals(ChatConfig.DEFAULT_MESSAGE, config.message());
+    }
+
+    @Test
+    void fromEmpty_returnsDefaults() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled", true)).thenReturn(true);
+        when(cfg.getInt("max_messages_per_minute", 6)).thenReturn(6);
+        when(cfg.getBoolean("detect_links", true)).thenReturn(true);
+        when(cfg.getBoolean("detect_repeat", true)).thenReturn(true);
+        when(cfg.getString("message", ChatConfig.DEFAULT_MESSAGE)).thenReturn(null);
+
+        ChatConfig config = ChatConfig.from(cfg);
+        assertTrue(config.enabled());
+        assertEquals(6, config.maxMessagesPerMinute());
+        assertTrue(config.detectLinks());
+        assertTrue(config.detectRepeat());
+        assertEquals(ChatConfig.DEFAULT_MESSAGE, config.message());
+    }
+
+    @Test
+    void fromFullSection_returnsCorrectValues() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled", true)).thenReturn(false);
+        when(cfg.getInt("max_messages_per_minute", 6)).thenReturn(3);
+        when(cfg.getBoolean("detect_links", true)).thenReturn(false);
+        when(cfg.getBoolean("detect_repeat", true)).thenReturn(false);
+        when(cfg.getString("message", ChatConfig.DEFAULT_MESSAGE)).thenReturn("自定义提示");
+
+        ChatConfig config = ChatConfig.from(cfg);
+        assertFalse(config.enabled());
+        assertEquals(3, config.maxMessagesPerMinute());
+        assertFalse(config.detectLinks());
+        assertFalse(config.detectRepeat());
+        assertEquals("自定义提示", config.message());
+    }
+
+    @Test
+    void fromSection_clampsNonPositiveMaxToOne() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getInt("max_messages_per_minute", 6)).thenReturn(0);
+
+        ChatConfig config = ChatConfig.from(cfg);
+        assertEquals(1, config.maxMessagesPerMinute());
+    }
+
+    @Test
+    void fromSection_blankMessageFallsBackToDefault() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getString("message", ChatConfig.DEFAULT_MESSAGE)).thenReturn("   ");
+
+        ChatConfig config = ChatConfig.from(cfg);
+        assertEquals(ChatConfig.DEFAULT_MESSAGE, config.message());
+    }
+}


### PR DESCRIPTION
## 概述
安全加固路线图 P2-1：聊天反垃圾/反广告。

在 `AsyncChatEvent`（异步线程）上按玩家做三类拦截，命中即丢弃该条消息（阻止全局广播）并给玩家发送 warn 提示：
- **链接检测**：消息含 `http(s)://` 或 `www.` 开头链接 → 广告
- **重复检测**：与本人上一条已放行消息完全相同 → 刷屏
- **限流**：60s 滑动窗口内发言超过 `max_messages_per_minute` → 刷屏

状态按 `UUID` 分桶（`ConcurrentHashMap`），事件线程安全；`PlayerQuitEvent` 清理状态防无界增长。

## 改动
- `infra/config/configs/ChatConfig.java`：`chat:` 段类型化配置记录（enabled / max_messages_per_minute / detect_links / detect_repeat / message），默认开启（6 条/分钟）
- `TypedConfigProvider` + `DefaultTypedConfigProvider`：新增 `chat()`（sectionOrLegacy("config", "chat", "chat.yml")）
- `ConfigHealthCheck`：新增 `validateChatSection`（缺失为"建议"降级，与 guard/player_notify 同模式，避免升级安装持久告警）
- `features/chat/ChatSpamFilterService.java`：纯判定核心（Supplier 注入配置，/config reload 生效；注入时钟便于测试窗口滑动）
- `features/chat/ChatSpamFilterEventService.java`：事件编排（取消 + warn 提示；退出清理）
- `events/OrzChatEvent.java`：`LOWEST` 优先级监听 `AsyncChatEvent` + `PlayerQuitEvent`
- `config.yml`：新增 `chat:` 段
- `FeatureModule`：装配 chatSpamFilterEventService 并注册监听器
- 测试：`ChatSpamFilterServiceTest`（12 例）、`ChatSpamFilterEventServiceTest`（3 例）、`ChatConfigTest`（5 例）、`ConfigHealthCheckTest`（chat 段 happy path + 缺失 + 类型错误）

## 设计说明
- 纯判定核心与事件编排分离，与 `CommandGuardService`/`CommandGuardEventService` 同构
- `PlainTextComponentSerializer.plainText().serialize(event.message())` 取纯文本（剥离样式）再检测
- 限流窗口用 `System::currentTimeMillis` 注入，`LongSupplier` 便于单元测试验证窗口滑动
- 重复检测为逐条精确匹配，避免误杀语义相近的聊天

## 验证
- `./gradlew spotlessApply` + `./gradlew :test` + `./gradlew spotlessCheck` 全绿
- 新增 20 例测试全通过