### PR TITLE
feat(login_rate_limit): 进服限流/反 bot（按 IP 限频率/并发）

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -9,6 +9,7 @@ import com.jokerhub.paper.plugin.orzmc.events.OrzBowShootEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzChatEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzCommandGuardEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzDebugEvent;
+import com.jokerhub.paper.plugin.orzmc.events.OrzLoginRateLimitEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzMenuEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzPlayerEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzPortalEvent;
@@ -35,6 +36,8 @@ import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandAuditService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandGuardEventService;
 import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
+import com.jokerhub.paper.plugin.orzmc.features.security.LoginRateLimitEventService;
+import com.jokerhub.paper.plugin.orzmc.features.security.LoginRateLimitService;
 import com.jokerhub.paper.plugin.orzmc.features.server.ServerEventService;
 import com.jokerhub.paper.plugin.orzmc.features.server.ServerFeedbackService;
 import com.jokerhub.paper.plugin.orzmc.features.server.ServerLifecycleService;
@@ -105,6 +108,8 @@ public final class FeatureModule implements ServiceModule {
     private final StartupSecurityAuditService startupSecurityAuditService;
     /** 聊天反垃圾（安全加固 P2-1）：AsyncChatEvent 按玩家限流 + 链接/重复检测。 */
     private final ChatSpamFilterEventService chatSpamFilterEventService;
+    /** 进服限流/反 bot（安全加固 P2-2）：AsyncPlayerPreLoginEvent 按 IP 限频率/并发。 */
+    private final LoginRateLimitEventService loginRateLimitEventService;
 
     private final MenuCommandService menuCommandService;
     private final PortalCommandService portalCommandService;
@@ -172,6 +177,12 @@ public final class FeatureModule implements ServiceModule {
         // 聊天反垃圾：纯判定核心 + 事件编排；chat 每次读取最新配置（Supplier），/config reload 生效
         this.chatSpamFilterEventService = new ChatSpamFilterEventService(
                 new ChatSpamFilterService(platform.configs()::chat), platform.configs(), platform.textStyles());
+        // 进服限流：纯判定核心 + 事件编排；login_rate_limit 每次读取最新配置（Supplier），/config reload 生效
+        this.loginRateLimitEventService = new LoginRateLimitEventService(
+                new LoginRateLimitService(platform.configs()::loginRateLimit),
+                platform.configs(),
+                botModule.notifier(),
+                platform.textStyles());
         this.menuCommandService = new MenuCommandService(platform.textStyles());
         this.portalCommandService = new PortalCommandService(portalModule.portalService(), platform.textStyles());
         this.orzConfigCommand = new OrzConfigCommand(
@@ -270,6 +281,7 @@ public final class FeatureModule implements ServiceModule {
             new OrzTNTEvent(plugin, tntEventService),
             new OrzCommandGuardEvent(plugin, commandGuardEventService),
             new OrzChatEvent(plugin, chatSpamFilterEventService),
+            new OrzLoginRateLimitEvent(plugin, loginRateLimitEventService),
             new OrzMenuEvent(plugin, menuEventService),
             new OrzServerEvent(plugin, serverEventService),
             new OrzSecurityAuditEvent(plugin, startupSecurityAuditService),

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
@@ -4,6 +4,7 @@ import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.SecurityGuardConfig;
@@ -36,6 +37,8 @@ public interface TypedConfigProvider {
     SecurityGuardConfig securityGuard();
 
     ChatConfig chat();
+
+    LoginRateLimitConfig loginRateLimit();
 
     MessageEnvelope renderEvent(String eventKey, Map<String, String> vars);
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzLoginRateLimitEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzLoginRateLimitEvent.java
@@ -1,0 +1,41 @@
+package com.jokerhub.paper.plugin.orzmc.events;
+
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.features.security.LoginRateLimitEventService;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * 进服限流/反 bot 监听器（安全加固 P2-2）。
+ *
+ * <p>{@link EventPriority#LOW} 在 {@code OrzPlayerEvent}（NORMAL）之前介入：频率/并发超限即
+ * {@code disallow}，且早于 GeoIP 查询拦截，减少对查询服务的无效压力；
+ * {@link PlayerJoinEvent}/{@link PlayerQuitEvent} 维护同 IP 并发计数。</p>
+ */
+public class OrzLoginRateLimitEvent extends OrzBaseListener {
+
+    private final LoginRateLimitEventService service;
+
+    public OrzLoginRateLimitEvent(OrzMC plugin, LoginRateLimitEventService service) {
+        super(plugin);
+        this.service = service;
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onPlayerPreLogin(AsyncPlayerPreLoginEvent event) {
+        service.onPlayerPreLogin(event);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        service.onPlayerJoin(event);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        service.onPlayerQuit(event);
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/LoginRateLimitEventService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/LoginRateLimitEventService.java
@@ -1,0 +1,100 @@
+package com.jokerhub.paper.plugin.orzmc.features.security;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.config.TemplateKeys;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
+import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.profile.PlayerProfile;
+
+/**
+ * 进服限流事件编排（安全加固 P2-2）。
+ *
+ * <p>把 {@link LoginRateLimitService} 的纯判定接入事件侧：</p>
+ * <ul>
+ *   <li>{@link AsyncPlayerPreLoginEvent}：频率超限或同 IP 并发超限 → {@code disallow} +
+ *       warn 提示 +（按 {@code notify_admins} 配置）PRIVATE 私信管理员（模板
+ *       {@code login_rate_limit_alert}，Java 兜底文案防模板缺失）；</li>
+ *   <li>{@link PlayerJoinEvent}：登记并发；{@link PlayerQuitEvent}：注销并发。</li>
+ * </ul>
+ */
+public final class LoginRateLimitEventService {
+
+    private final LoginRateLimitService limiter;
+    private final TypedConfigProvider configs;
+    private final Notifier notifier;
+    private final OrzTextStyles styles;
+
+    public LoginRateLimitEventService(
+            LoginRateLimitService limiter, TypedConfigProvider configs, Notifier notifier, OrzTextStyles styles) {
+        this.limiter = limiter;
+        this.configs = configs;
+        this.notifier = notifier;
+        this.styles = styles;
+    }
+
+    public void onPlayerPreLogin(AsyncPlayerPreLoginEvent event) {
+        LoginRateLimitConfig cfg = configs.loginRateLimit();
+        if (!cfg.enabled()) {
+            return;
+        }
+        InetAddress address = event.getAddress();
+        if (address == null) {
+            return;
+        }
+        String ip = address.getHostAddress();
+        String reason = null;
+        if (limiter.isRateLimited(ip)) {
+            reason = "频率超限（" + cfg.maxLoginAttemptsPerMinute() + " 次/分钟）";
+        } else if (limiter.isConcurrencyReached(ip)) {
+            reason = "同 IP 并发超限（" + cfg.maxConcurrentPerIp() + " 人）";
+        }
+        if (reason == null) {
+            return;
+        }
+        event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, styles.warn(cfg.message()));
+        if (cfg.notifyAdmins()) {
+            notifyAdmin(ip, playerName(event), reason);
+        }
+    }
+
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        String ip = ipOf(player.getAddress());
+        if (ip == null) {
+            return;
+        }
+        limiter.onPlayerJoin(ip, player.getName());
+    }
+
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        limiter.onPlayerQuit(event.getPlayer().getName());
+    }
+
+    private void notifyAdmin(String ip, String player, String reason) {
+        String fallback = "⚠ 登录限流\nIP: " + ip + "\n玩家: " + player + "\n原因: " + reason;
+        MessageEnvelope env = configs.renderTemplate(
+                TemplateKeys.LOGIN_RATE_LIMIT_ALERT, Map.of("ip", ip, "player", player, "reason", reason), fallback);
+        notifier.event(TemplateKeys.LOGIN_RATE_LIMIT_ALERT, env);
+    }
+
+    private static String ipOf(InetSocketAddress socket) {
+        if (socket == null || socket.getAddress() == null) {
+            return null;
+        }
+        return socket.getAddress().getHostAddress();
+    }
+
+    private static String playerName(AsyncPlayerPreLoginEvent event) {
+        PlayerProfile profile = event.getPlayerProfile();
+        return profile != null && profile.getName() != null ? profile.getName() : "未知玩家";
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/LoginRateLimitService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/LoginRateLimitService.java
@@ -1,0 +1,110 @@
+package com.jokerhub.paper.plugin.orzmc.features.security;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * 进服限流/反 bot 判定核心（纯逻辑，安全加固 P2-2）。
+ *
+ * <p>在 {@code AsyncPlayerPreLoginEvent} 事件线程（异步）上按 IP 做两类检查：</p>
+ * <ol>
+ *   <li><b>频率</b>：60s 滑动窗口内登录尝试超过 {@code max_login_attempts_per_minute} 即拒绝——
+ *       拦截 bot 群刷登录包；</li>
+ *   <li><b>并发</b>：该 IP 当前在线玩家数达到 {@code max_concurrent_per_ip} 即拒绝——
+ *       拦截单 IP 多开/代练/alt 农场。</li>
+ * </ol>
+ *
+ * <p>状态按 IP 字符串分桶（{@link ConcurrentHashMap}），事件线程可安全并发；玩家加入时登记
+ * 并发、退出时按玩家名反查 IP 注销（退出时 socket 可能已关闭无法取地址）。配置通过
+ * {@link Supplier} 注入，事件侧每次读取最新配置（与 {@code ChatSpamFilterService} 一致），
+ * /config reload 生效。</p>
+ */
+public final class LoginRateLimitService {
+
+    /** 频率限流滑动窗口长度（毫秒）。 */
+    private static final long WINDOW_MS = 60_000L;
+
+    private final Supplier<LoginRateLimitConfig> configSupplier;
+    private final LongSupplier clock;
+    /** ip → 窗口内各次登录尝试时刻。 */
+    private final Map<String, Deque<Long>> attemptTimes = new ConcurrentHashMap<>();
+    /** ip → 当前在线玩家名集合（并发计数）。 */
+    private final Map<String, Set<String>> onlineByIp = new ConcurrentHashMap<>();
+    /** 玩家名 → ip（退出时反查，地址可能已关闭）。 */
+    private final Map<String, String> ipByPlayer = new ConcurrentHashMap<>();
+
+    public LoginRateLimitService(Supplier<LoginRateLimitConfig> configSupplier) {
+        this(configSupplier, System::currentTimeMillis);
+    }
+
+    /** 测试用：注入可控时钟以验证窗口滑动。 */
+    LoginRateLimitService(Supplier<LoginRateLimitConfig> configSupplier, LongSupplier clock) {
+        this.configSupplier = configSupplier;
+        this.clock = clock;
+    }
+
+    /** 判定该 IP 是否频率超限；放行则记录本次尝试。 */
+    public boolean isRateLimited(String ip) {
+        if (!enabled()) {
+            return false;
+        }
+        long now = clock.getAsLong();
+        Deque<Long> times = attemptTimes.computeIfAbsent(ip, k -> new ArrayDeque<>());
+        synchronized (times) {
+            while (!times.isEmpty() && now - times.peekFirst() >= WINDOW_MS) {
+                times.pollFirst();
+            }
+            if (times.size() >= configSupplier.get().maxLoginAttemptsPerMinute()) {
+                return true;
+            }
+            times.addLast(now);
+            return false;
+        }
+    }
+
+    /** 判定该 IP 当前在线玩家是否已达并发上限。 */
+    public boolean isConcurrencyReached(String ip) {
+        if (!enabled()) {
+            return false;
+        }
+        Set<String> online = onlineByIp.get(ip);
+        return online != null && online.size() >= configSupplier.get().maxConcurrentPerIp();
+    }
+
+    /** 玩家成功加入后登记并发（同一 IP 下的在线名单）。 */
+    public void onPlayerJoin(String ip, String playerName) {
+        ipByPlayer.put(playerName, ip);
+        onlineByIp.computeIfAbsent(ip, k -> ConcurrentHashMap.newKeySet()).add(playerName);
+    }
+
+    /** 玩家退出后注销并发（按玩家名反查 IP，socket 可能已关闭）。 */
+    public void onPlayerQuit(String playerName) {
+        String ip = ipByPlayer.remove(playerName);
+        if (ip == null) {
+            return;
+        }
+        Set<String> online = onlineByIp.get(ip);
+        if (online != null) {
+            online.remove(playerName);
+            if (online.isEmpty()) {
+                onlineByIp.remove(ip, online);
+            }
+        }
+    }
+
+    /** 清理单个 IP 的限流/并发状态。 */
+    public void clear(String ip) {
+        attemptTimes.remove(ip);
+        onlineByIp.remove(ip);
+    }
+
+    private boolean enabled() {
+        return configSupplier.get().enabled();
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
@@ -39,6 +39,7 @@ public final class ConfigHealthCheck {
         validateCommandPoliciesSection(cfg.getConfigurationSection("command_policies"), issues);
         validateGuardSection(cfg.getConfigurationSection("guard"), issues);
         validateChatSection(cfg.getConfigurationSection("chat"), issues);
+        validateLoginRateLimitSection(cfg.getConfigurationSection("login_rate_limit"), issues);
     }
 
     private static void validateWhitelistSection(ConfigurationSection section, List<String> issues) {
@@ -203,6 +204,24 @@ public final class ConfigHealthCheck {
         if (dr != null && !(dr instanceof Boolean)) issues.add("类型错误: chat.detect_repeat 需为布尔值");
         String msg = section.getString("message", "");
         if (msg.isBlank()) issues.add("缺失: chat.message 不可为空");
+    }
+
+    private static void validateLoginRateLimitSection(ConfigurationSection section, List<String> issues) {
+        if (section == null) {
+            // 降级为建议：默认配置完整可用，升级安装（config.yml 存在故未复制新默认值）会缺此段
+            issues.add("建议: config.yml 缺失 login_rate_limit 配置段，将使用默认配置（进服限流开启）");
+            return;
+        }
+        Object en = section.get("enabled");
+        if (en != null && !(en instanceof Boolean)) issues.add("类型错误: login_rate_limit.enabled 需为布尔值");
+        int freq = section.getInt("max_login_attempts_per_minute", 5);
+        if (freq < 1) issues.add("非法: login_rate_limit.max_login_attempts_per_minute 不得小于 1");
+        int conc = section.getInt("max_concurrent_per_ip", 3);
+        if (conc < 1) issues.add("非法: login_rate_limit.max_concurrent_per_ip 不得小于 1");
+        Object na = section.get("notify_admins");
+        if (na != null && !(na instanceof Boolean)) issues.add("类型错误: login_rate_limit.notify_admins 需为布尔值");
+        String msg = section.getString("message", "");
+        if (msg.isBlank()) issues.add("缺失: login_rate_limit.message 不可为空");
     }
 
     private static void validateEasyBot(FileConfiguration cfg, List<String> issues) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
@@ -5,6 +5,7 @@ import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.SecurityGuardConfig;
@@ -87,6 +88,12 @@ public final class DefaultTypedConfigProvider implements TypedConfigProvider {
     public ChatConfig chat() {
         ConfigurationSection section = sectionOrLegacy("config", "chat", "chat.yml");
         return ChatConfig.from(section);
+    }
+
+    @Override
+    public LoginRateLimitConfig loginRateLimit() {
+        ConfigurationSection section = sectionOrLegacy("config", "login_rate_limit", "login_rate_limit.yml");
+        return LoginRateLimitConfig.from(section);
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
@@ -42,6 +42,7 @@ public final class TemplateKeys {
     public static final String WHITELIST_TOGGLE_ALERT = "whitelist_toggle_alert";
     public static final String COMMAND_GUARD_BLOCKED = "command_guard_blocked";
     public static final String SECURITY_AUDIT = "security_audit";
+    public static final String LOGIN_RATE_LIMIT_ALERT = "login_rate_limit_alert";
 
     // ---- TNT 事件 ----
     public static final String TNT_ALERT = "tnt_alert";
@@ -83,12 +84,13 @@ public final class TemplateKeys {
     /**
      * 所有已知的模板事件 key。用于 {@link ConfigHealthCheck} 校验。
      *
-     * <p>不含 {@link #PLAYER_DIGEST}、{@link #COMMAND_GUARD_BLOCKED} 与 {@link #SECURITY_AUDIT}：
-     * 调用方始终传入 fallback 兜底文案（PLAYER_DIGEST 在 {@code Templates} 中有完整 Java 默认
-     * 模板，COMMAND_GUARD_BLOCKED 在 {@code CommandGuardEventService}、SECURITY_AUDIT 在
-     * {@code StartupSecurityAuditService} 中内联兜底），升级安装（templates.yml 已存在故未复制
-     * 新默认值）不携带该键即可正常工作；纳入 ALL 会要求模板文件提供该键，造成升级后每次启动的
-     * 持久「缺失」告警。</p>
+     * <p>不含 {@link #PLAYER_DIGEST}、{@link #COMMAND_GUARD_BLOCKED}、{@link #SECURITY_AUDIT} 与
+     * {@link #LOGIN_RATE_LIMIT_ALERT}：调用方始终传入 fallback 兜底文案（PLAYER_DIGEST 在
+     * {@code Templates} 中有完整 Java 默认模板，COMMAND_GUARD_BLOCKED 在
+     * {@code CommandGuardEventService}、SECURITY_AUDIT 在 {@code StartupSecurityAuditService}、
+     * LOGIN_RATE_LIMIT_ALERT 在 {@code LoginRateLimitEventService} 中内联兜底），升级安装
+     * （templates.yml 已存在故未复制新默认值）不携带该键即可正常工作；纳入 ALL 会要求模板文件
+     * 提供该键，造成升级后每次启动的持久「缺失」告警。</p>
      */
     public static final String[] ALL = {
         PLAYER_JOIN,

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/LoginRateLimitConfig.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/LoginRateLimitConfig.java
@@ -1,0 +1,38 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+/**
+ * 进服限流/反 bot（安全加固 P2-2）配置。
+ *
+ * <p>对应 config.yml 的 {@code login_rate_limit:} 段，供 {@code LoginRateLimitService} 使用：
+ * 配置是否启用、每分钟登录尝试上限（频率）、同 IP 并发在线上限（并发），以及命中时
+ * 是否 PRIVATE 私信管理员与玩家提示文案。</p>
+ */
+public record LoginRateLimitConfig(
+        boolean enabled, int maxLoginAttemptsPerMinute, int maxConcurrentPerIp, boolean notifyAdmins, String message) {
+
+    /** 默认命中提示文案。 */
+    public static final String DEFAULT_MESSAGE = "登录过于频繁，请稍后再试";
+
+    public static LoginRateLimitConfig from(ConfigurationSection cfg) {
+        if (cfg == null) {
+            return new LoginRateLimitConfig(true, 5, 3, true, DEFAULT_MESSAGE);
+        }
+        int freq = cfg.getInt("max_login_attempts_per_minute", 5);
+        if (freq < 1) {
+            // 非正上限会让限流失效，回退最小 1
+            freq = 1;
+        }
+        int concurrent = cfg.getInt("max_concurrent_per_ip", 3);
+        if (concurrent < 1) {
+            concurrent = 1;
+        }
+        String msg = cfg.getString("message", DEFAULT_MESSAGE);
+        if (msg == null || msg.isBlank()) {
+            msg = DEFAULT_MESSAGE;
+        }
+        return new LoginRateLimitConfig(
+                cfg.getBoolean("enabled", true), freq, concurrent, cfg.getBoolean("notify_admins", true), msg);
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/notify/Notifier.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/notify/Notifier.java
@@ -51,7 +51,8 @@ public final class Notifier {
                             TemplateKeys.MAINTENANCE_BACKUP_ERROR,
                             TemplateKeys.MAINTENANCE_OPTIMIZE_ERROR,
                             TemplateKeys.COMMAND_GUARD_BLOCKED,
-                            TemplateKeys.SECURITY_AUDIT -> MessageEnvelope.TargetType.PRIVATE;
+                            TemplateKeys.SECURITY_AUDIT,
+                            TemplateKeys.LOGIN_RATE_LIMIT_ALERT -> MessageEnvelope.TargetType.PRIVATE;
                     default -> MessageEnvelope.TargetType.PUBLIC;
                 };
         botMessageService.send(envelope.withTargetType(target));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -157,3 +157,22 @@ chat:
   detect_repeat: true
   # 命中时的提示文案
   message: "请勿刷屏或发送广告"
+
+# ==================================================
+#             进服限流/反 bot（安全加固）
+# ==================================================
+# 在异步登录事件（AsyncPlayerPreLoginEvent）上按 IP 做两类拦截，命中即拒绝进入：
+#   max_login_attempts_per_minute —— 60s 滑动窗口内最多登录尝试次数（频率，反 bot 群刷）
+#   max_concurrent_per_ip        —— 同 IP 最大在线上限（并发，反多开/alt 农场）
+# 命中时按 notify_admins 配置 PRIVATE 私信管理员，并给玩家发送 message 提示。
+login_rate_limit:
+  # 总开关：关闭后进服限流全部停用
+  enabled: true
+  # 每分钟最多登录尝试次数（60s 滑动窗口）
+  max_login_attempts_per_minute: 5
+  # 同 IP 最大在线上限
+  max_concurrent_per_ip: 3
+  # 命中时是否 PRIVATE 私信管理员
+  notify_admins: true
+  # 命中时的提示文案
+  message: "登录过于频繁，请稍后再试"

--- a/src/main/resources/templates.yml
+++ b/src/main/resources/templates.yml
@@ -30,6 +30,7 @@ templates:
     whitelist_toggle_alert: PLAIN
     command_guard_blocked: PLAIN
     security_audit: PLAIN
+    login_rate_limit_alert: PLAIN
     maintenance_backup_stage: CODE_BLOCK
     maintenance_backup_done: CODE_BLOCK
     maintenance_backup_error: CODE_BLOCK
@@ -81,6 +82,7 @@ templates:
   whitelist_toggle_alert: "{message}"
   command_guard_blocked: "⚠ 高危命令已被拦截\n命令: {command}\n来源: {source} | 发送者: {sender}\n原因: {reason}"
   security_audit: "🛡 安全自检报告\n在线模式: {online_mode}\n命令方块: {command_block}\nRCON: {rcon}\n白名单: {whitelist}\nOP: {ops}\n关键插件: {plugins}"
+  login_rate_limit_alert: "⚠ 登录限流\nIP: {ip}\n玩家: {player}\n原因: {reason}"
   player_join: "{name} 上线\n------当前在线({online_count}/{max_count})------\n{online_list}"
   player_quit: "{name} 下线\n------当前在线({online_count}/{max_count})------\n{online_list}"
   player_kick: "{name} 被踢\n------当前在线({online_count}/{max_count})------\n{online_list}"

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/LoginRateLimitEventServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/LoginRateLimitEventServiceTest.java
@@ -1,0 +1,160 @@
+package com.jokerhub.paper.plugin.orzmc.features.security;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
+import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitEventServiceTest {
+
+    private LoginRateLimitService limiter;
+    private TypedConfigProvider configs;
+    private Notifier notifier;
+    private OrzTextStyles styles;
+    private LoginRateLimitEventService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        LoginRateLimitConfig config = new LoginRateLimitConfig(true, 5, 3, true, "登录过于频繁，请稍后再试");
+        limiter = mock(LoginRateLimitService.class);
+        configs = mock(TypedConfigProvider.class);
+        when(configs.loginRateLimit()).thenReturn(config);
+        when(configs.renderTemplate(anyString(), anyMap(), anyString()))
+                .thenReturn(MessageEnvelope.publicMessage("login_rate_limit_alert"));
+        notifier = mock(Notifier.class);
+        styles = mock(OrzTextStyles.class);
+        when(styles.warn(anyString())).thenReturn(Component.text("登录过于频繁，请稍后再试"));
+        service = new LoginRateLimitEventService(limiter, configs, notifier, styles);
+    }
+
+    // ---- 频率超限 ----
+
+    @Test
+    void rateLimited_disallowAndNotifyAdmin() throws Exception {
+        when(limiter.isRateLimited("1.2.3.4")).thenReturn(true);
+        AsyncPlayerPreLoginEvent event = preLoginEvent("1.2.3.4", "alice");
+        service.onPlayerPreLogin(event);
+        verify(event).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+        verify(notifier).event(eq("login_rate_limit_alert"), any(MessageEnvelope.class));
+        // 频率超限后不再检查并发
+        verify(limiter, never()).isConcurrencyReached(anyString());
+    }
+
+    // ---- 并发超限 ----
+
+    @Test
+    void concurrencyReached_disallowAndNotifyAdmin() throws Exception {
+        when(limiter.isConcurrencyReached("1.2.3.4")).thenReturn(true);
+        AsyncPlayerPreLoginEvent event = preLoginEvent("1.2.3.4", "alice");
+        service.onPlayerPreLogin(event);
+        verify(event).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+        verify(notifier).event(eq("login_rate_limit_alert"), any(MessageEnvelope.class));
+    }
+
+    // ---- 正常登录 ----
+
+    @Test
+    void normalLogin_allowed_noDisallowNoNotify() throws Exception {
+        AsyncPlayerPreLoginEvent event = preLoginEvent("1.2.3.4", "alice");
+        service.onPlayerPreLogin(event);
+        verify(event, never()).disallow(any(AsyncPlayerPreLoginEvent.Result.class), any(Component.class));
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+    }
+
+    // ---- 告警开关 ----
+
+    @Test
+    void notifyAdminsDisabled_disallowWithoutNotify() throws Exception {
+        when(configs.loginRateLimit()).thenReturn(new LoginRateLimitConfig(true, 5, 3, false, "登录过于频繁，请稍后再试"));
+        when(limiter.isRateLimited("1.2.3.4")).thenReturn(true);
+        AsyncPlayerPreLoginEvent event = preLoginEvent("1.2.3.4", "alice");
+        service.onPlayerPreLogin(event);
+        verify(event).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+    }
+
+    // ---- 总开关 ----
+
+    @Test
+    void disabledConfig_noop() throws Exception {
+        when(configs.loginRateLimit()).thenReturn(new LoginRateLimitConfig(false, 5, 3, true, "登录过于频繁，请稍后再试"));
+        AsyncPlayerPreLoginEvent event = preLoginEvent("1.2.3.4", "alice");
+        service.onPlayerPreLogin(event);
+        verify(event, never()).disallow(any(AsyncPlayerPreLoginEvent.Result.class), any(Component.class));
+        verify(limiter, never()).isRateLimited(anyString());
+        verify(limiter, never()).isConcurrencyReached(anyString());
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+    }
+
+    // ---- 异常输入 ----
+
+    @Test
+    void nullAddress_noop() {
+        AsyncPlayerPreLoginEvent event = mock(AsyncPlayerPreLoginEvent.class);
+        when(event.getAddress()).thenReturn(null);
+        service.onPlayerPreLogin(event);
+        verify(event, never()).disallow(any(AsyncPlayerPreLoginEvent.Result.class), any(Component.class));
+        verify(limiter, never()).isRateLimited(anyString());
+    }
+
+    // ---- 并发登记/注销 ----
+
+    @Test
+    void onPlayerJoin_registersConcurrency() throws Exception {
+        PlayerJoinEvent event = joinEvent("alice", "1.2.3.4");
+        service.onPlayerJoin(event);
+        verify(limiter).onPlayerJoin("1.2.3.4", "alice");
+    }
+
+    @Test
+    void onPlayerJoin_nullSocket_noop() {
+        PlayerJoinEvent event = mock(PlayerJoinEvent.class);
+        Player player = mock(Player.class);
+        when(player.getAddress()).thenReturn(null);
+        when(event.getPlayer()).thenReturn(player);
+        service.onPlayerJoin(event);
+        verify(limiter, never()).onPlayerJoin(anyString(), anyString());
+    }
+
+    @Test
+    void onPlayerQuit_removesConcurrency() {
+        PlayerQuitEvent event = mock(PlayerQuitEvent.class);
+        Player player = mock(Player.class);
+        when(player.getName()).thenReturn("alice");
+        when(event.getPlayer()).thenReturn(player);
+        service.onPlayerQuit(event);
+        verify(limiter).onPlayerQuit("alice");
+    }
+
+    private static AsyncPlayerPreLoginEvent preLoginEvent(String ip, String playerName) throws Exception {
+        AsyncPlayerPreLoginEvent event = mock(AsyncPlayerPreLoginEvent.class);
+        when(event.getAddress()).thenReturn(InetAddress.getByName(ip));
+        com.destroystokyo.paper.profile.PlayerProfile profile =
+                mock(com.destroystokyo.paper.profile.PlayerProfile.class);
+        when(profile.getName()).thenReturn(playerName);
+        when(event.getPlayerProfile()).thenReturn(profile);
+        return event;
+    }
+
+    private static PlayerJoinEvent joinEvent(String playerName, String ip) throws Exception {
+        PlayerJoinEvent event = mock(PlayerJoinEvent.class);
+        Player player = mock(Player.class);
+        when(player.getName()).thenReturn(playerName);
+        when(player.getAddress()).thenReturn(new InetSocketAddress(InetAddress.getByName(ip), 25565));
+        when(event.getPlayer()).thenReturn(player);
+        return event;
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/LoginRateLimitServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/LoginRateLimitServiceTest.java
@@ -1,0 +1,130 @@
+package com.jokerhub.paper.plugin.orzmc.features.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitServiceTest {
+
+    private static final String IP = "1.2.3.4";
+
+    private static LoginRateLimitService service(LoginRateLimitConfig config) {
+        return new LoginRateLimitService(() -> config);
+    }
+
+    private static LoginRateLimitService service(LoginRateLimitConfig config, LongSupplier clock) {
+        return new LoginRateLimitService(() -> config, clock);
+    }
+
+    private static LoginRateLimitConfig defaultConfig() {
+        return new LoginRateLimitConfig(true, 5, 3, true, "登录过于频繁，请稍后再试");
+    }
+
+    // ---- 总开关 ----
+
+    @Test
+    void disabledConfig_allowsFloodAndConcurrency() {
+        LoginRateLimitService svc = service(new LoginRateLimitConfig(false, 1, 1, true, "登录过于频繁，请稍后再试"));
+        for (int i = 0; i < 10; i++) {
+            assertFalse(svc.isRateLimited(IP), "关闭时应放行所有登录尝试");
+        }
+        svc.onPlayerJoin(IP, "alice");
+        svc.onPlayerJoin(IP, "bob");
+        assertFalse(svc.isConcurrencyReached(IP), "关闭时不应判定并发超限");
+    }
+
+    // ---- 频率限流 ----
+
+    @Test
+    void rateLimited_afterMaxAttemptsPerMinute() {
+        LoginRateLimitService svc = service(defaultConfig());
+        // 上限 5：前 5 次放行并记录，第 6 次被限流
+        for (int i = 0; i < 5; i++) {
+            assertFalse(svc.isRateLimited(IP), "第 " + (i + 1) + " 次尝试应放行");
+        }
+        assertTrue(svc.isRateLimited(IP));
+    }
+
+    @Test
+    void windowSlides_afterOneMinute() {
+        AtomicLong now = new AtomicLong(0L);
+        LoginRateLimitService svc = service(defaultConfig(), now::get);
+        for (int i = 0; i < 5; i++) {
+            assertFalse(svc.isRateLimited(IP));
+        }
+        assertTrue(svc.isRateLimited(IP));
+        // 60s 后窗口滑动，恢复可用额度
+        now.set(60_000L);
+        assertFalse(svc.isRateLimited(IP));
+    }
+
+    @Test
+    void rateLimit_isPerIp() {
+        LoginRateLimitService svc = service(defaultConfig());
+        for (int i = 0; i < 5; i++) {
+            assertFalse(svc.isRateLimited(IP));
+        }
+        assertTrue(svc.isRateLimited(IP));
+        // 其他 IP 不受影响
+        assertFalse(svc.isRateLimited("5.6.7.8"));
+    }
+
+    // ---- 并发限制 ----
+
+    @Test
+    void concurrencyReached_afterMaxOnline() {
+        LoginRateLimitService svc = service(defaultConfig());
+        svc.onPlayerJoin(IP, "alice");
+        svc.onPlayerJoin(IP, "bob");
+        svc.onPlayerJoin(IP, "carol");
+        assertTrue(svc.isConcurrencyReached(IP));
+    }
+
+    @Test
+    void concurrency_allowsWithinLimit() {
+        LoginRateLimitService svc = service(defaultConfig());
+        svc.onPlayerJoin(IP, "alice");
+        svc.onPlayerJoin(IP, "bob");
+        assertFalse(svc.isConcurrencyReached(IP));
+    }
+
+    @Test
+    void onPlayerQuit_freesConcurrencySlot() {
+        LoginRateLimitService svc = service(defaultConfig());
+        svc.onPlayerJoin(IP, "alice");
+        svc.onPlayerJoin(IP, "bob");
+        svc.onPlayerJoin(IP, "carol");
+        assertTrue(svc.isConcurrencyReached(IP));
+        svc.onPlayerQuit("bob");
+        assertFalse(svc.isConcurrencyReached(IP));
+    }
+
+    @Test
+    void onPlayerQuit_unknownPlayer_noop() {
+        LoginRateLimitService svc = service(defaultConfig());
+        svc.onPlayerJoin(IP, "alice");
+        svc.onPlayerQuit("nobody");
+        assertFalse(svc.isConcurrencyReached(IP));
+    }
+
+    // ---- 状态清理 ----
+
+    @Test
+    void clear_resetsBothState() {
+        LoginRateLimitService svc = service(defaultConfig());
+        for (int i = 0; i < 5; i++) {
+            assertFalse(svc.isRateLimited(IP));
+        }
+        assertTrue(svc.isRateLimited(IP));
+        svc.onPlayerJoin(IP, "alice");
+        svc.onPlayerJoin(IP, "bob");
+        svc.onPlayerJoin(IP, "carol");
+        assertTrue(svc.isConcurrencyReached(IP));
+        svc.clear(IP);
+        assertFalse(svc.isRateLimited(IP));
+        assertFalse(svc.isConcurrencyReached(IP));
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
@@ -106,6 +106,15 @@ class ConfigHealthCheckTest {
         config.getConfigurationSection("chat").set("message", "请勿刷屏或发送广告");
     }
 
+    private void addFullValidConfig_loginRateLimit() {
+        config.createSection("login_rate_limit");
+        config.getConfigurationSection("login_rate_limit").set("enabled", true);
+        config.getConfigurationSection("login_rate_limit").set("max_login_attempts_per_minute", 5);
+        config.getConfigurationSection("login_rate_limit").set("max_concurrent_per_ip", 3);
+        config.getConfigurationSection("login_rate_limit").set("notify_admins", true);
+        config.getConfigurationSection("login_rate_limit").set("message", "登录过于频繁，请稍后再试");
+    }
+
     private void addFullValidConfig_commandPolicies() {
         config.createSection("command_policies");
         config.getConfigurationSection("command_policies").createSection("tpbow");
@@ -247,6 +256,7 @@ class ConfigHealthCheckTest {
         addFullValidConfig_commandPolicies();
         addFullValidConfig_guard();
         addFullValidConfig_chat();
+        addFullValidConfig_loginRateLimit();
         addFullValidConfig_bot();
         addFullValidConfig_templates();
         List<String> issues = runValidate();
@@ -624,6 +634,42 @@ class ConfigHealthCheckTest {
         // no chat section
         List<String> issues = runValidate();
         assertTrue(issues.contains("建议: config.yml 缺失 chat 配置段，将使用默认配置（聊天反垃圾开启）"));
+    }
+
+    @Test
+    void missingLoginRateLimitSection_reportsSuggestion() {
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        // no login_rate_limit section
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("建议: config.yml 缺失 login_rate_limit 配置段，将使用默认配置（进服限流开启）"));
+    }
+
+    @Test
+    void loginRateLimitWrongTypes_reportIssues() {
+        config.createSection("login_rate_limit").set("enabled", "yes");
+        config.getConfigurationSection("login_rate_limit").set("max_login_attempts_per_minute", 0);
+        config.getConfigurationSection("login_rate_limit").set("max_concurrent_per_ip", 0);
+        config.getConfigurationSection("login_rate_limit").set("notify_admins", "yes");
+        config.getConfigurationSection("login_rate_limit").set("message", "");
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("类型错误: login_rate_limit.enabled 需为布尔值"));
+        assertTrue(issues.contains("非法: login_rate_limit.max_login_attempts_per_minute 不得小于 1"));
+        assertTrue(issues.contains("非法: login_rate_limit.max_concurrent_per_ip 不得小于 1"));
+        assertTrue(issues.contains("类型错误: login_rate_limit.notify_admins 需为布尔值"));
+        assertTrue(issues.contains("缺失: login_rate_limit.message 不可为空"));
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeysTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeysTest.java
@@ -57,5 +57,6 @@ class TemplateKeysTest {
         assertEquals("whitelist_block", TemplateKeys.WHITELIST_BLOCK);
         assertEquals("command_guard_blocked", TemplateKeys.COMMAND_GUARD_BLOCKED);
         assertEquals("security_audit", TemplateKeys.SECURITY_AUDIT);
+        assertEquals("login_rate_limit_alert", TemplateKeys.LOGIN_RATE_LIMIT_ALERT);
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/LoginRateLimitConfigTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/LoginRateLimitConfigTest.java
@@ -1,0 +1,74 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.junit.jupiter.api.Test;
+
+class LoginRateLimitConfigTest {
+
+    @Test
+    void fromNull_returnsDefaults() {
+        LoginRateLimitConfig config = LoginRateLimitConfig.from(null);
+        assertTrue(config.enabled());
+        assertEquals(5, config.maxLoginAttemptsPerMinute());
+        assertEquals(3, config.maxConcurrentPerIp());
+        assertTrue(config.notifyAdmins());
+        assertEquals(LoginRateLimitConfig.DEFAULT_MESSAGE, config.message());
+    }
+
+    @Test
+    void fromEmpty_returnsDefaults() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled", true)).thenReturn(true);
+        when(cfg.getInt("max_login_attempts_per_minute", 5)).thenReturn(5);
+        when(cfg.getInt("max_concurrent_per_ip", 3)).thenReturn(3);
+        when(cfg.getBoolean("notify_admins", true)).thenReturn(true);
+        when(cfg.getString("message", LoginRateLimitConfig.DEFAULT_MESSAGE)).thenReturn(null);
+
+        LoginRateLimitConfig config = LoginRateLimitConfig.from(cfg);
+        assertTrue(config.enabled());
+        assertEquals(5, config.maxLoginAttemptsPerMinute());
+        assertEquals(3, config.maxConcurrentPerIp());
+        assertTrue(config.notifyAdmins());
+        assertEquals(LoginRateLimitConfig.DEFAULT_MESSAGE, config.message());
+    }
+
+    @Test
+    void fromFullSection_returnsCorrectValues() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled", true)).thenReturn(false);
+        when(cfg.getInt("max_login_attempts_per_minute", 5)).thenReturn(2);
+        when(cfg.getInt("max_concurrent_per_ip", 3)).thenReturn(1);
+        when(cfg.getBoolean("notify_admins", true)).thenReturn(false);
+        when(cfg.getString("message", LoginRateLimitConfig.DEFAULT_MESSAGE)).thenReturn("自定义提示");
+
+        LoginRateLimitConfig config = LoginRateLimitConfig.from(cfg);
+        assertFalse(config.enabled());
+        assertEquals(2, config.maxLoginAttemptsPerMinute());
+        assertEquals(1, config.maxConcurrentPerIp());
+        assertFalse(config.notifyAdmins());
+        assertEquals("自定义提示", config.message());
+    }
+
+    @Test
+    void fromSection_clampsNonPositiveToMin() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getInt("max_login_attempts_per_minute", 5)).thenReturn(0);
+        when(cfg.getInt("max_concurrent_per_ip", 3)).thenReturn(0);
+
+        LoginRateLimitConfig config = LoginRateLimitConfig.from(cfg);
+        assertEquals(1, config.maxLoginAttemptsPerMinute());
+        assertEquals(1, config.maxConcurrentPerIp());
+    }
+
+    @Test
+    void fromSection_blankMessageFallsBackToDefault() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getString("message", LoginRateLimitConfig.DEFAULT_MESSAGE)).thenReturn("   ");
+
+        LoginRateLimitConfig config = LoginRateLimitConfig.from(cfg);
+        assertEquals(LoginRateLimitConfig.DEFAULT_MESSAGE, config.message());
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/notify/NotifierTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/notify/NotifierTest.java
@@ -81,8 +81,9 @@ class NotifierTest extends ServiceTestBase {
         notifier.routeEvent("maintenance_optimize_error", env);
         notifier.routeEvent("command_guard_blocked", env);
         notifier.routeEvent("security_audit", env);
+        notifier.routeEvent("login_rate_limit_alert", env);
 
-        verify(botMessageService, times(5))
+        verify(botMessageService, times(6))
                 .send(argThat(message -> message.targetType() == MessageEnvelope.TargetType.PRIVATE));
     }
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateResourceSmokeTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateResourceSmokeTest.java
@@ -107,4 +107,24 @@ public class TemplateResourceSmokeTest extends ServiceTestBase {
         Assertions.assertFalse(
                 rendered.contains("{online_mode}") || rendered.contains("{plugins}"), "不得残留字面占位符: " + rendered);
     }
+
+    @Test
+    public void testLoginRateLimitAlertTemplateResolvesWithRealText() throws Exception {
+        // 安全加固 P2-2：进服限流告警模板必须渲染真实中文文案，而非字面 "{ip}" 等占位符
+        YamlConfiguration cfg = load("templates.yml");
+        String resolved = TemplateRenderer.resolveTemplate("login_rate_limit_alert", cfg, "");
+        Assertions.assertFalse(resolved.isEmpty(), "login_rate_limit_alert 模板缺失");
+
+        var vars = java.util.Map.of(
+                "ip", "1.2.3.4",
+                "player", "alice",
+                "reason", "频率超限（5 次/分钟）");
+        String rendered = TemplateRenderer.render(resolved, vars);
+
+        Assertions.assertTrue(rendered.contains("1.2.3.4"), "应含 IP: " + rendered);
+        Assertions.assertTrue(rendered.contains("alice"), "应含玩家名: " + rendered);
+        Assertions.assertFalse(
+                rendered.contains("{ip}") || rendered.contains("{player}") || rendered.contains("{reason}"),
+                "不得残留字面占位符: " + rendered);
+    }
 }


### PR DESCRIPTION
## 安全加固 P2-2：进服限流/反 bot

在 `AsyncPlayerPreLoginEvent`（LOW 优先级，早于 GeoIP 查询）上按 IP 做两类拦截，命中即 `disallow` + 可选 PRIVATE 私信管理员：

- **频率**：60s 滑动窗口内登录尝试超过 `max_login_attempts_per_minute`（默认 5）→ 拦截 bot 群刷登录包
- **并发**：同 IP 当前在线玩家达到 `max_concurrent_per_ip`（默认 3）→ 拦截多开/alt 农场

### 改动
| 文件 | 说明 |
|------|------|
| `LoginRateLimitConfig` | `login_rate_limit` 配置记录（含默认值、钳制、空文案兜底） |
| `LoginRateLimitService` | 纯判定核心，注入时钟可测；join/quit 维护并发（quit 按玩家名反查 IP，socket 已关闭兜底） |
| `LoginRateLimitEventService` + `OrzLoginRateLimitEvent` | 事件编排 + LOW 优先级监听器；`login_rate_limit_alert` 模板 + Java 兜底（不入 ALL，避免升级安装缺失告警） |
| FeatureModule / TypedConfigProvider / ConfigHealthCheck / templates.yml / config.yml | 装配、建议级健康检查、模板与默认配置 |
| 测试 | LoginRateLimitServiceTest(9) + LoginRateLimitEventServiceTest(9) + LoginRateLimitConfigTest(5) + Notifier/TemplateKeys/Smoke/ConfigHealthCheck 扩展 |

### 验收
- [x] `./gradlew spotlessApply :test spotlessCheck` 全绿