### PR TITLE
feat(exploit_hardening): 已知漏洞加固（书页/32k物品/单区块实体上限）

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -9,6 +9,7 @@ import com.jokerhub.paper.plugin.orzmc.events.OrzBowShootEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzChatEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzCommandGuardEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzDebugEvent;
+import com.jokerhub.paper.plugin.orzmc.events.OrzExploitHardeningEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzLoginRateLimitEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzMenuEvent;
 import com.jokerhub.paper.plugin.orzmc.events.OrzPlayerEvent;
@@ -35,6 +36,8 @@ import com.jokerhub.paper.plugin.orzmc.features.portal.PortalEventService;
 import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandAuditService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandGuardEventService;
+import com.jokerhub.paper.plugin.orzmc.features.security.ExploitHardeningEventService;
+import com.jokerhub.paper.plugin.orzmc.features.security.ExploitHardeningService;
 import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
 import com.jokerhub.paper.plugin.orzmc.features.security.LoginRateLimitEventService;
 import com.jokerhub.paper.plugin.orzmc.features.security.LoginRateLimitService;
@@ -110,6 +113,8 @@ public final class FeatureModule implements ServiceModule {
     private final ChatSpamFilterEventService chatSpamFilterEventService;
     /** 进服限流/反 bot（安全加固 P2-2）：AsyncPlayerPreLoginEvent 按 IP 限频率/并发。 */
     private final LoginRateLimitEventService loginRateLimitEventService;
+    /** 已知漏洞加固（安全加固 P2-3）：书页上限 / 32k 物品 / 单区块实体上限。 */
+    private final ExploitHardeningEventService exploitHardeningEventService;
 
     private final MenuCommandService menuCommandService;
     private final PortalCommandService portalCommandService;
@@ -180,6 +185,12 @@ public final class FeatureModule implements ServiceModule {
         // 进服限流：纯判定核心 + 事件编排；login_rate_limit 每次读取最新配置（Supplier），/config reload 生效
         this.loginRateLimitEventService = new LoginRateLimitEventService(
                 new LoginRateLimitService(platform.configs()::loginRateLimit),
+                platform.configs(),
+                botModule.notifier(),
+                platform.textStyles());
+        // 漏洞加固：纯判定核心 + 事件编排；exploit_hardening 每次读取最新配置（Supplier），/config reload 生效
+        this.exploitHardeningEventService = new ExploitHardeningEventService(
+                new ExploitHardeningService(platform.configs()::exploitHardening),
                 platform.configs(),
                 botModule.notifier(),
                 platform.textStyles());
@@ -282,6 +293,7 @@ public final class FeatureModule implements ServiceModule {
             new OrzCommandGuardEvent(plugin, commandGuardEventService),
             new OrzChatEvent(plugin, chatSpamFilterEventService),
             new OrzLoginRateLimitEvent(plugin, loginRateLimitEventService),
+            new OrzExploitHardeningEvent(plugin, exploitHardeningEventService),
             new OrzMenuEvent(plugin, menuEventService),
             new OrzServerEvent(plugin, serverEventService),
             new OrzSecurityAuditEvent(plugin, startupSecurityAuditService),

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
@@ -3,6 +3,7 @@ package com.jokerhub.paper.plugin.orzmc.core.ports.config;
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ExploitHardeningConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
@@ -39,6 +40,9 @@ public interface TypedConfigProvider {
     ChatConfig chat();
 
     LoginRateLimitConfig loginRateLimit();
+
+    /** 已知漏洞加固（P2-3）配置。 */
+    ExploitHardeningConfig exploitHardening();
 
     MessageEnvelope renderEvent(String eventKey, Map<String, String> vars);
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzExploitHardeningEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzExploitHardeningEvent.java
@@ -1,0 +1,41 @@
+package com.jokerhub.paper.plugin.orzmc.events;
+
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.features.security.ExploitHardeningEventService;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntitySpawnEvent;
+import org.bukkit.event.player.PlayerEditBookEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+/**
+ * 已知漏洞加固监听器（安全加固 P2-3）。
+ *
+ * <p>书页超限（{@link PlayerEditBookEvent}）与实体生成（{@link EntitySpawnEvent}）在
+ * {@link EventPriority#LOW} 尽早介入；背包扫描（{@link PlayerJoinEvent}）在玩家加入时清理
+ * 32k 物品。</p>
+ */
+public class OrzExploitHardeningEvent extends OrzBaseListener {
+
+    private final ExploitHardeningEventService service;
+
+    public OrzExploitHardeningEvent(OrzMC plugin, ExploitHardeningEventService service) {
+        super(plugin);
+        this.service = service;
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onPlayerEditBook(PlayerEditBookEvent event) {
+        service.onPlayerEditBook(event);
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onEntitySpawn(EntitySpawnEvent event) {
+        service.onEntitySpawn(event);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        service.onPlayerJoin(event);
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/ExploitHardeningEventService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/ExploitHardeningEventService.java
@@ -1,0 +1,117 @@
+package com.jokerhub.paper.plugin.orzmc.features.security;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.config.TemplateKeys;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ExploitHardeningConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
+import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import java.util.List;
+import java.util.Map;
+import org.bukkit.Chunk;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.entity.EntitySpawnEvent;
+import org.bukkit.event.player.PlayerEditBookEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * 已知漏洞加固事件编排（安全加固 P2-3）。
+ *
+ * <p>把 {@link ExploitHardeningService} 的纯判定接入事件侧：</p>
+ * <ul>
+ *   <li>{@link PlayerEditBookEvent}：书页超限 → {@code cancel} + warn 提示 +（按配置）PRIVATE
+ *       私信管理员（模板 {@code exploit_blocked}，Java 兜底文案防模板缺失）；</li>
+ *   <li>{@link EntitySpawnEvent}：所在区块实体数已达上限 → {@code cancel}（掉落物/抛射物豁免，
+ *       避免吞掉落物与弹射物，静默不告警防刷屏）；</li>
+ *   <li>{@link PlayerJoinEvent}：扫描背包，属性修饰符数量异常的物品（32k 利用）清除全部
+ *       修饰符 + warn 提示 +（按配置）PRIVATE 告警。</li>
+ * </ul>
+ */
+public final class ExploitHardeningEventService {
+
+    private final ExploitHardeningService limiter;
+    private final TypedConfigProvider configs;
+    private final Notifier notifier;
+    private final OrzTextStyles styles;
+
+    public ExploitHardeningEventService(
+            ExploitHardeningService limiter, TypedConfigProvider configs, Notifier notifier, OrzTextStyles styles) {
+        this.limiter = limiter;
+        this.configs = configs;
+        this.notifier = notifier;
+        this.styles = styles;
+    }
+
+    public void onPlayerEditBook(PlayerEditBookEvent event) {
+        BookMeta meta = event.getNewBookMeta();
+        if (meta == null) {
+            return;
+        }
+        List<String> pages = meta.getPages();
+        int pageCount = pages == null ? 0 : pages.size();
+        if (!limiter.isBookOverPageLimit(pageCount)) {
+            return;
+        }
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        player.sendMessage(styles.warn(configs.exploitHardening().message()));
+        if (configs.exploitHardening().notifyAdmins()) {
+            notifyAdmin(player.getName(), "书页超限（" + pageCount + " 页）");
+        }
+    }
+
+    public void onEntitySpawn(EntitySpawnEvent event) {
+        Entity entity = event.getEntity();
+        if (entity instanceof Item || entity instanceof Projectile) {
+            // 掉落物/抛射物豁免：避免在满员区块吞掉落物与弹射物
+            return;
+        }
+        Chunk chunk = event.getLocation().getChunk();
+        if (!limiter.isChunkAtEntityLimit(chunk.getEntities().length)) {
+            return;
+        }
+        event.setCancelled(true);
+    }
+
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        int stripped = 0;
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null) {
+                continue;
+            }
+            ItemMeta meta = item.getItemMeta();
+            if (meta == null || !meta.hasAttributeModifiers()) {
+                continue;
+            }
+            int count = meta.getAttributeModifiers().size();
+            if (!limiter.isAttributeModifiersExcessive(count)) {
+                continue;
+            }
+            meta.setAttributeModifiers(null);
+            item.setItemMeta(meta);
+            stripped++;
+        }
+        if (stripped == 0) {
+            return;
+        }
+        player.sendMessage(styles.warn(configs.exploitHardening().message()));
+        if (configs.exploitHardening().notifyAdmins()) {
+            notifyAdmin(player.getName(), "物品属性修饰符异常（清理 " + stripped + " 件）");
+        }
+    }
+
+    private void notifyAdmin(String player, String reason) {
+        ExploitHardeningConfig cfg = configs.exploitHardening();
+        String fallback = "⚠ 漏洞利用拦截\n玩家: " + player + "\n原因: " + reason;
+        MessageEnvelope env = configs.renderTemplate(
+                TemplateKeys.EXPLOIT_BLOCKED, Map.of("player", player, "reason", reason), fallback);
+        notifier.event(TemplateKeys.EXPLOIT_BLOCKED, env);
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/ExploitHardeningService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/ExploitHardeningService.java
@@ -1,0 +1,57 @@
+package com.jokerhub.paper.plugin.orzmc.features.security;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ExploitHardeningConfig;
+import java.util.function.Supplier;
+
+/**
+ * 已知漏洞加固判定核心（纯逻辑，安全加固 P2-3）。
+ *
+ * <p>对应站点文章《PaperMC 开放服务器检查清单》§4「已知漏洞加固」三类利用的插件侧兜底：</p>
+ * <ol>
+ *   <li><b>书页上限</b>：书与笔页数超过 {@code book_max_pages} 即拒绝（防超大书页/大量书导致的崩溃，
+ *       与 Paper {@code item-validation.page-max} 同向）；</li>
+ *   <li><b>物品 NBT 上限（防 32k）</b>：物品属性修饰符数量超过 {@code item_max_attribute_modifiers}
+ *       即判定异常——32k 利用通过 NBT 叠加超量属性修饰符；</li>
+ *   <li><b>实体上限</b>：单区块实体数达到 {@code entity_max_per_chunk} 即拒绝新的实体生成
+ *       （防卡服机：盔甲架/碰撞/投射物刷量）。</li>
+ * </ol>
+ *
+ * <p>各子项独立开关（book_enabled/item_enabled/entity_enabled），配置通过 {@link Supplier} 注入，
+ * 事件侧每次读取最新配置（与 {@code ChatSpamFilterService} 一致），/config reload 生效。</p>
+ */
+public final class ExploitHardeningService {
+
+    private final Supplier<ExploitHardeningConfig> configSupplier;
+
+    public ExploitHardeningService(Supplier<ExploitHardeningConfig> configSupplier) {
+        this.configSupplier = configSupplier;
+    }
+
+    /** 书页数是否超限。 */
+    public boolean isBookOverPageLimit(int pageCount) {
+        if (!enabled() || !configSupplier.get().bookEnabled()) {
+            return false;
+        }
+        return pageCount > configSupplier.get().maxBookPages();
+    }
+
+    /** 物品属性修饰符数量是否异常（防 32k）。 */
+    public boolean isAttributeModifiersExcessive(int modifierCount) {
+        if (!enabled() || !configSupplier.get().itemEnabled()) {
+            return false;
+        }
+        return modifierCount > configSupplier.get().maxAttributeModifiers();
+    }
+
+    /** 区块当前实体数是否已达上限（应拒绝新的生成）。 */
+    public boolean isChunkAtEntityLimit(int entityCount) {
+        if (!enabled() || !configSupplier.get().entityEnabled()) {
+            return false;
+        }
+        return entityCount >= configSupplier.get().maxEntitiesPerChunk();
+    }
+
+    private boolean enabled() {
+        return configSupplier.get().enabled();
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheck.java
@@ -40,6 +40,7 @@ public final class ConfigHealthCheck {
         validateGuardSection(cfg.getConfigurationSection("guard"), issues);
         validateChatSection(cfg.getConfigurationSection("chat"), issues);
         validateLoginRateLimitSection(cfg.getConfigurationSection("login_rate_limit"), issues);
+        validateExploitHardeningSection(cfg.getConfigurationSection("exploit_hardening"), issues);
     }
 
     private static void validateWhitelistSection(ConfigurationSection section, List<String> issues) {
@@ -222,6 +223,32 @@ public final class ConfigHealthCheck {
         if (na != null && !(na instanceof Boolean)) issues.add("类型错误: login_rate_limit.notify_admins 需为布尔值");
         String msg = section.getString("message", "");
         if (msg.isBlank()) issues.add("缺失: login_rate_limit.message 不可为空");
+    }
+
+    private static void validateExploitHardeningSection(ConfigurationSection section, List<String> issues) {
+        if (section == null) {
+            // 降级为建议：默认配置完整可用，升级安装（config.yml 存在故未复制新默认值）会缺此段
+            issues.add("建议: config.yml 缺失 exploit_hardening 配置段，将使用默认配置（漏洞加固开启）");
+            return;
+        }
+        Object en = section.get("enabled");
+        if (en != null && !(en instanceof Boolean)) issues.add("类型错误: exploit_hardening.enabled 需为布尔值");
+        for (String key : List.of("book_enabled", "item_enabled", "entity_enabled")) {
+            Object flag = section.get(key);
+            if (flag != null && !(flag instanceof Boolean)) {
+                issues.add("类型错误: exploit_hardening." + key + " 需为布尔值");
+            }
+        }
+        Object na = section.get("notify_admins");
+        if (na != null && !(na instanceof Boolean)) issues.add("类型错误: exploit_hardening.notify_admins 需为布尔值");
+        int pages = section.getInt("book_max_pages", 100);
+        if (pages < 1) issues.add("非法: exploit_hardening.book_max_pages 不得小于 1");
+        int attrs = section.getInt("item_max_attribute_modifiers", 6);
+        if (attrs < 1) issues.add("非法: exploit_hardening.item_max_attribute_modifiers 不得小于 1");
+        int entities = section.getInt("entity_max_per_chunk", 128);
+        if (entities < 1) issues.add("非法: exploit_hardening.entity_max_per_chunk 不得小于 1");
+        String msg = section.getString("message", "");
+        if (msg.isBlank()) issues.add("缺失: exploit_hardening.message 不可为空");
     }
 
     private static void validateEasyBot(FileConfiguration cfg, List<String> issues) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
@@ -4,6 +4,7 @@ import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ChatConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ExploitHardeningConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
@@ -94,6 +95,12 @@ public final class DefaultTypedConfigProvider implements TypedConfigProvider {
     public LoginRateLimitConfig loginRateLimit() {
         ConfigurationSection section = sectionOrLegacy("config", "login_rate_limit", "login_rate_limit.yml");
         return LoginRateLimitConfig.from(section);
+    }
+
+    @Override
+    public ExploitHardeningConfig exploitHardening() {
+        ConfigurationSection section = sectionOrLegacy("config", "exploit_hardening", "exploit_hardening.yml");
+        return ExploitHardeningConfig.from(section);
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
@@ -43,6 +43,7 @@ public final class TemplateKeys {
     public static final String COMMAND_GUARD_BLOCKED = "command_guard_blocked";
     public static final String SECURITY_AUDIT = "security_audit";
     public static final String LOGIN_RATE_LIMIT_ALERT = "login_rate_limit_alert";
+    public static final String EXPLOIT_BLOCKED = "exploit_blocked";
 
     // ---- TNT 事件 ----
     public static final String TNT_ALERT = "tnt_alert";
@@ -84,13 +85,14 @@ public final class TemplateKeys {
     /**
      * 所有已知的模板事件 key。用于 {@link ConfigHealthCheck} 校验。
      *
-     * <p>不含 {@link #PLAYER_DIGEST}、{@link #COMMAND_GUARD_BLOCKED}、{@link #SECURITY_AUDIT} 与
-     * {@link #LOGIN_RATE_LIMIT_ALERT}：调用方始终传入 fallback 兜底文案（PLAYER_DIGEST 在
-     * {@code Templates} 中有完整 Java 默认模板，COMMAND_GUARD_BLOCKED 在
-     * {@code CommandGuardEventService}、SECURITY_AUDIT 在 {@code StartupSecurityAuditService}、
-     * LOGIN_RATE_LIMIT_ALERT 在 {@code LoginRateLimitEventService} 中内联兜底），升级安装
-     * （templates.yml 已存在故未复制新默认值）不携带该键即可正常工作；纳入 ALL 会要求模板文件
-     * 提供该键，造成升级后每次启动的持久「缺失」告警。</p>
+     * <p>不含 {@link #PLAYER_DIGEST}、{@link #COMMAND_GUARD_BLOCKED}、{@link #SECURITY_AUDIT}、
+     * {@link #LOGIN_RATE_LIMIT_ALERT} 与 {@link #EXPLOIT_BLOCKED}：调用方始终传入 fallback
+     * 兜底文案（PLAYER_DIGEST 在 {@code Templates} 中有完整 Java 默认模板，COMMAND_GUARD_BLOCKED
+     * 在 {@code CommandGuardEventService}、SECURITY_AUDIT 在 {@code StartupSecurityAuditService}、
+     * LOGIN_RATE_LIMIT_ALERT 在 {@code LoginRateLimitEventService}、EXPLOIT_BLOCKED 在
+     * {@code ExploitHardeningEventService} 中内联兜底），升级安装（templates.yml 已存在故未复制
+     * 新默认值）不携带该键即可正常工作；纳入 ALL 会要求模板文件提供该键，造成升级后每次启动的
+     * 持久「缺失」告警。</p>
      */
     public static final String[] ALL = {
         PLAYER_JOIN,

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/ExploitHardeningConfig.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/ExploitHardeningConfig.java
@@ -1,0 +1,52 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+/**
+ * 已知漏洞加固（安全加固 P2-3）配置。
+ *
+ * <p>对应 config.yml 的 {@code exploit_hardening:} 段，供 {@code ExploitHardeningService} 使用：
+ * 书与笔页数上限（防超大书页崩溃）、物品属性修饰符数量上限（防 32k）、单区块实体数上限
+ * （防卡服机），以及命中时是否 PRIVATE 私信管理员与玩家提示文案。</p>
+ */
+public record ExploitHardeningConfig(
+        boolean enabled,
+        boolean bookEnabled,
+        int maxBookPages,
+        boolean itemEnabled,
+        int maxAttributeModifiers,
+        boolean entityEnabled,
+        int maxEntitiesPerChunk,
+        boolean notifyAdmins,
+        String message) {
+
+    /** 默认命中提示文案。 */
+    public static final String DEFAULT_MESSAGE = "检测到异常内容，已自动处理";
+
+    public static ExploitHardeningConfig from(ConfigurationSection cfg) {
+        if (cfg == null) {
+            return new ExploitHardeningConfig(true, true, 100, true, 6, true, 128, true, DEFAULT_MESSAGE);
+        }
+        int pages = clampMin(cfg.getInt("book_max_pages", 100), 1);
+        int attrs = clampMin(cfg.getInt("item_max_attribute_modifiers", 6), 1);
+        int entities = clampMin(cfg.getInt("entity_max_per_chunk", 128), 1);
+        String msg = cfg.getString("message", DEFAULT_MESSAGE);
+        if (msg == null || msg.isBlank()) {
+            msg = DEFAULT_MESSAGE;
+        }
+        return new ExploitHardeningConfig(
+                cfg.getBoolean("enabled", true),
+                cfg.getBoolean("book_enabled", true),
+                pages,
+                cfg.getBoolean("item_enabled", true),
+                attrs,
+                cfg.getBoolean("entity_enabled", true),
+                entities,
+                cfg.getBoolean("notify_admins", true),
+                msg);
+    }
+
+    private static int clampMin(int value, int min) {
+        return value < min ? min : value;
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/notify/Notifier.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/notify/Notifier.java
@@ -52,7 +52,8 @@ public final class Notifier {
                             TemplateKeys.MAINTENANCE_OPTIMIZE_ERROR,
                             TemplateKeys.COMMAND_GUARD_BLOCKED,
                             TemplateKeys.SECURITY_AUDIT,
-                            TemplateKeys.LOGIN_RATE_LIMIT_ALERT -> MessageEnvelope.TargetType.PRIVATE;
+                            TemplateKeys.LOGIN_RATE_LIMIT_ALERT,
+                            TemplateKeys.EXPLOIT_BLOCKED -> MessageEnvelope.TargetType.PRIVATE;
                     default -> MessageEnvelope.TargetType.PUBLIC;
                 };
         botMessageService.send(envelope.withTargetType(target));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -176,3 +176,29 @@ login_rate_limit:
   notify_admins: true
   # 命中时的提示文案
   message: "登录过于频繁，请稍后再试"
+
+# ==================================================
+#             已知漏洞加固（安全加固 P2-3）
+# ==================================================
+# 三类已知利用的插件侧兜底（对应站点文章《PaperMC 开放服务器检查清单》§4）：
+#   book_enabled / book_max_pages           —— 书与笔页数上限（防超大书页/大量书崩溃）
+#   item_enabled / item_max_attribute_modifiers —— 物品属性修饰符数量上限（防 32k：NBT 叠加超量属性）
+#   entity_enabled / entity_max_per_chunk   —— 单区块实体数上限（防卡服机，到达上限后拒绝新的实体生成，
+#                                              掉落物/抛射物豁免）
+# 命中书页/物品规则时按 notify_admins 配置 PRIVATE 私信管理员，并给玩家发送 message 提示。
+exploit_hardening:
+  # 总开关：关闭后漏洞加固全部停用
+  enabled: true
+  # 书与笔：每本最多页数（关闭请用 book_enabled=false）
+  book_enabled: true
+  book_max_pages: 100
+  # 物品：属性修饰符数量上限（关闭请用 item_enabled=false）
+  item_enabled: true
+  item_max_attribute_modifiers: 6
+  # 实体：单区块实体数上限（关闭请用 entity_enabled=false）
+  entity_enabled: true
+  entity_max_per_chunk: 128
+  # 命中书页/物品时是否 PRIVATE 私信管理员（实体拦截静默，防刷屏）
+  notify_admins: true
+  # 命中时的提示文案
+  message: "检测到异常内容，已自动处理"

--- a/src/main/resources/templates.yml
+++ b/src/main/resources/templates.yml
@@ -31,6 +31,7 @@ templates:
     command_guard_blocked: PLAIN
     security_audit: PLAIN
     login_rate_limit_alert: PLAIN
+    exploit_blocked: PLAIN
     maintenance_backup_stage: CODE_BLOCK
     maintenance_backup_done: CODE_BLOCK
     maintenance_backup_error: CODE_BLOCK
@@ -83,6 +84,7 @@ templates:
   command_guard_blocked: "⚠ 高危命令已被拦截\n命令: {command}\n来源: {source} | 发送者: {sender}\n原因: {reason}"
   security_audit: "🛡 安全自检报告\n在线模式: {online_mode}\n命令方块: {command_block}\nRCON: {rcon}\n白名单: {whitelist}\nOP: {ops}\n关键插件: {plugins}"
   login_rate_limit_alert: "⚠ 登录限流\nIP: {ip}\n玩家: {player}\n原因: {reason}"
+  exploit_blocked: "⚠ 漏洞利用拦截\n玩家: {player}\n原因: {reason}"
   player_join: "{name} 上线\n------当前在线({online_count}/{max_count})------\n{online_list}"
   player_quit: "{name} 下线\n------当前在线({online_count}/{max_count})------\n{online_list}"
   player_kick: "{name} 被踢\n------当前在线({online_count}/{max_count})------\n{online_list}"

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/ExploitHardeningEventServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/ExploitHardeningEventServiceTest.java
@@ -1,0 +1,227 @@
+package com.jokerhub.paper.plugin.orzmc.features.security;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.Multimap;
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ExploitHardeningConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
+import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import java.util.ArrayList;
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntitySpawnEvent;
+import org.bukkit.event.player.PlayerEditBookEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExploitHardeningEventServiceTest {
+
+    private ExploitHardeningService limiter;
+    private TypedConfigProvider configs;
+    private Notifier notifier;
+    private OrzTextStyles styles;
+    private ExploitHardeningEventService service;
+
+    @BeforeEach
+    void setUp() {
+        ExploitHardeningConfig config =
+                new ExploitHardeningConfig(true, true, 100, true, 6, true, 128, true, "检测到异常内容，已自动处理");
+        limiter = mock(ExploitHardeningService.class);
+        configs = mock(TypedConfigProvider.class);
+        when(configs.exploitHardening()).thenReturn(config);
+        when(configs.renderTemplate(anyString(), anyMap(), anyString()))
+                .thenReturn(MessageEnvelope.publicMessage("exploit_blocked"));
+        notifier = mock(Notifier.class);
+        styles = mock(OrzTextStyles.class);
+        when(styles.warn(anyString())).thenReturn(Component.text("检测到异常内容，已自动处理"));
+        service = new ExploitHardeningEventService(limiter, configs, notifier, styles);
+    }
+
+    // ---- 书页超限 ----
+
+    @Test
+    void bookOverLimit_cancelledWarnedAndNotified() {
+        when(limiter.isBookOverPageLimit(anyInt())).thenReturn(true);
+        Player player = player();
+        PlayerEditBookEvent event = bookEvent(player, 150);
+        service.onPlayerEditBook(event);
+        verify(event).setCancelled(true);
+        verify(player).sendMessage(any(Component.class));
+        verify(notifier).event(eq("exploit_blocked"), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void bookWithinLimit_notCancelled() {
+        when(limiter.isBookOverPageLimit(anyInt())).thenReturn(false);
+        Player player = player();
+        PlayerEditBookEvent event = bookEvent(player, 50);
+        service.onPlayerEditBook(event);
+        verify(event, never()).setCancelled(true);
+        verify(player, never()).sendMessage(any(Component.class));
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void bookOverLimit_notifyDisabled_noNotify() {
+        when(limiter.isBookOverPageLimit(anyInt())).thenReturn(true);
+        when(configs.exploitHardening())
+                .thenReturn(new ExploitHardeningConfig(true, true, 100, true, 6, true, 128, false, "x"));
+        Player player = player();
+        PlayerEditBookEvent event = bookEvent(player, 150);
+        service.onPlayerEditBook(event);
+        verify(event).setCancelled(true);
+        verify(player).sendMessage(any(Component.class));
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+    }
+
+    // ---- 实体上限 ----
+
+    @Test
+    void entitySpawnAtChunkCap_cancelled() {
+        when(limiter.isChunkAtEntityLimit(anyInt())).thenReturn(true);
+        EntitySpawnEvent event = spawnEvent(Entity.class, 128);
+        service.onEntitySpawn(event);
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    void entitySpawnBelowCap_allowed() {
+        when(limiter.isChunkAtEntityLimit(anyInt())).thenReturn(false);
+        EntitySpawnEvent event = spawnEvent(Entity.class, 127);
+        service.onEntitySpawn(event);
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    void entitySpawnItem_skippedEvenAtCap() {
+        when(limiter.isChunkAtEntityLimit(anyInt())).thenReturn(true);
+        EntitySpawnEvent event = spawnEvent(Item.class, 999);
+        service.onEntitySpawn(event);
+        verify(event, never()).setCancelled(true);
+        verify(limiter, never()).isChunkAtEntityLimit(anyInt());
+    }
+
+    // ---- 背包 32k 清理 ----
+
+    @Test
+    void playerJoin_stripsExcessiveModifiersAndNotifies() {
+        when(limiter.isAttributeModifiersExcessive(anyInt())).thenReturn(true);
+        Player player = player();
+        PlayerJoinEvent event = joinEvent(player);
+        ItemStack item = mock(ItemStack.class);
+        ItemMeta meta = mock(ItemMeta.class);
+        when(item.getItemMeta()).thenReturn(meta);
+        when(meta.hasAttributeModifiers()).thenReturn(true);
+        Multimap<Attribute, AttributeModifier> map = modifiers(7);
+        when(meta.getAttributeModifiers()).thenReturn(map);
+        PlayerInventory inv = inventory(item);
+        when(player.getInventory()).thenReturn(inv);
+
+        service.onPlayerJoin(event);
+
+        verify(meta).setAttributeModifiers(null);
+        verify(item).setItemMeta(meta);
+        verify(player).sendMessage(any(Component.class));
+        verify(notifier).event(eq("exploit_blocked"), any(MessageEnvelope.class));
+    }
+
+    @Test
+    void playerJoin_withinLimit_keepsItem() {
+        when(limiter.isAttributeModifiersExcessive(anyInt())).thenReturn(false);
+        Player player = player();
+        PlayerJoinEvent event = joinEvent(player);
+        ItemStack item = mock(ItemStack.class);
+        ItemMeta meta = mock(ItemMeta.class);
+        when(item.getItemMeta()).thenReturn(meta);
+        when(meta.hasAttributeModifiers()).thenReturn(true);
+        Multimap<Attribute, AttributeModifier> map = modifiers(3);
+        when(meta.getAttributeModifiers()).thenReturn(map);
+        PlayerInventory inv = inventory(item);
+        when(player.getInventory()).thenReturn(inv);
+
+        service.onPlayerJoin(event);
+
+        verify(meta, never()).setAttributeModifiers(any());
+        verify(item, never()).setItemMeta(any());
+        verify(player, never()).sendMessage(any(Component.class));
+    }
+
+    @Test
+    void playerJoin_cleanInventory_noop() {
+        Player player = player();
+        PlayerJoinEvent event = joinEvent(player);
+        PlayerInventory inv = inventory();
+        when(player.getInventory()).thenReturn(inv);
+
+        service.onPlayerJoin(event);
+
+        verify(player, never()).sendMessage(any(Component.class));
+        verify(notifier, never()).event(anyString(), any(MessageEnvelope.class));
+    }
+
+    // ---- helpers ----
+
+    private static Player player() {
+        Player player = mock(Player.class);
+        when(player.getName()).thenReturn("alice");
+        return player;
+    }
+
+    private static PlayerInventory inventory(ItemStack... items) {
+        PlayerInventory inv = mock(PlayerInventory.class);
+        when(inv.getContents()).thenReturn(items);
+        return inv;
+    }
+
+    private static PlayerEditBookEvent bookEvent(Player player, int pages) {
+        PlayerEditBookEvent event = mock(PlayerEditBookEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        BookMeta meta = mock(BookMeta.class);
+        List<String> pageList = new ArrayList<>();
+        for (int i = 0; i < pages; i++) {
+            pageList.add("第" + i + "页内容");
+        }
+        when(meta.getPages()).thenReturn(pageList);
+        when(event.getNewBookMeta()).thenReturn(meta);
+        return event;
+    }
+
+    private static EntitySpawnEvent spawnEvent(Class<? extends Entity> entityType, int chunkEntityCount) {
+        EntitySpawnEvent event = mock(EntitySpawnEvent.class);
+        when(event.getEntity()).thenReturn(mock(entityType));
+        Location loc = mock(Location.class);
+        when(event.getLocation()).thenReturn(loc);
+        Chunk chunk = mock(Chunk.class);
+        when(loc.getChunk()).thenReturn(chunk);
+        when(chunk.getEntities()).thenReturn(new Entity[chunkEntityCount]);
+        return event;
+    }
+
+    private static PlayerJoinEvent joinEvent(Player player) {
+        PlayerJoinEvent event = mock(PlayerJoinEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        return event;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Multimap<Attribute, AttributeModifier> modifiers(int count) {
+        Multimap<Attribute, AttributeModifier> map = mock(Multimap.class);
+        when(map.size()).thenReturn(count);
+        return map;
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/ExploitHardeningServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/ExploitHardeningServiceTest.java
@@ -1,0 +1,94 @@
+package com.jokerhub.paper.plugin.orzmc.features.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.ExploitHardeningConfig;
+import org.junit.jupiter.api.Test;
+
+class ExploitHardeningServiceTest {
+
+    private static ExploitHardeningService service(ExploitHardeningConfig config) {
+        return new ExploitHardeningService(() -> config);
+    }
+
+    private static ExploitHardeningConfig defaultConfig() {
+        return new ExploitHardeningConfig(true, true, 100, true, 6, true, 128, true, "检测到异常内容，已自动处理");
+    }
+
+    // ---- 总开关 ----
+
+    @Test
+    void disabledConfig_allChecksBypassed() {
+        ExploitHardeningService svc = service(new ExploitHardeningConfig(false, true, 1, true, 1, true, 1, true, "x"));
+        assertFalse(svc.isBookOverPageLimit(999));
+        assertFalse(svc.isAttributeModifiersExcessive(999));
+        assertFalse(svc.isChunkAtEntityLimit(999));
+    }
+
+    // ---- 书页上限 ----
+
+    @Test
+    void bookOverPageLimit_beyondMax() {
+        ExploitHardeningService svc = service(defaultConfig());
+        assertTrue(svc.isBookOverPageLimit(101));
+    }
+
+    @Test
+    void bookWithinLimit_allowed() {
+        ExploitHardeningService svc = service(defaultConfig());
+        assertFalse(svc.isBookOverPageLimit(100));
+        assertFalse(svc.isBookOverPageLimit(0));
+    }
+
+    @Test
+    void bookCheckDisabled_allowsAnyPageCount() {
+        ExploitHardeningService svc =
+                service(new ExploitHardeningConfig(true, false, 100, true, 6, true, 128, true, "x"));
+        assertFalse(svc.isBookOverPageLimit(999));
+    }
+
+    // ---- 物品属性修饰符（防 32k）----
+
+    @Test
+    void attributeModifiersExcessive_beyondMax() {
+        ExploitHardeningService svc = service(defaultConfig());
+        assertTrue(svc.isAttributeModifiersExcessive(7));
+    }
+
+    @Test
+    void attributeModifiersWithinLimit_allowed() {
+        ExploitHardeningService svc = service(defaultConfig());
+        assertFalse(svc.isAttributeModifiersExcessive(6));
+        assertFalse(svc.isAttributeModifiersExcessive(0));
+    }
+
+    @Test
+    void itemCheckDisabled_allowsAnyModifierCount() {
+        ExploitHardeningService svc =
+                service(new ExploitHardeningConfig(true, true, 100, false, 6, true, 128, true, "x"));
+        assertFalse(svc.isAttributeModifiersExcessive(999));
+    }
+
+    // ---- 实体上限 ----
+
+    @Test
+    void chunkAtEntityLimit_whenAtMax() {
+        ExploitHardeningService svc = service(defaultConfig());
+        assertTrue(svc.isChunkAtEntityLimit(128));
+        assertTrue(svc.isChunkAtEntityLimit(200));
+    }
+
+    @Test
+    void chunkBelowLimit_spawnAllowed() {
+        ExploitHardeningService svc = service(defaultConfig());
+        assertFalse(svc.isChunkAtEntityLimit(127));
+        assertFalse(svc.isChunkAtEntityLimit(0));
+    }
+
+    @Test
+    void entityCheckDisabled_allowsAnyCount() {
+        ExploitHardeningService svc =
+                service(new ExploitHardeningConfig(true, true, 100, true, 6, false, 128, true, "x"));
+        assertFalse(svc.isChunkAtEntityLimit(999));
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigHealthCheckTest.java
@@ -106,6 +106,19 @@ class ConfigHealthCheckTest {
         config.getConfigurationSection("chat").set("message", "请勿刷屏或发送广告");
     }
 
+    private void addFullValidConfig_exploitHardening() {
+        config.createSection("exploit_hardening");
+        config.getConfigurationSection("exploit_hardening").set("enabled", true);
+        config.getConfigurationSection("exploit_hardening").set("book_enabled", true);
+        config.getConfigurationSection("exploit_hardening").set("book_max_pages", 100);
+        config.getConfigurationSection("exploit_hardening").set("item_enabled", true);
+        config.getConfigurationSection("exploit_hardening").set("item_max_attribute_modifiers", 6);
+        config.getConfigurationSection("exploit_hardening").set("entity_enabled", true);
+        config.getConfigurationSection("exploit_hardening").set("entity_max_per_chunk", 128);
+        config.getConfigurationSection("exploit_hardening").set("notify_admins", true);
+        config.getConfigurationSection("exploit_hardening").set("message", "检测到异常内容，已自动处理");
+    }
+
     private void addFullValidConfig_loginRateLimit() {
         config.createSection("login_rate_limit");
         config.getConfigurationSection("login_rate_limit").set("enabled", true);
@@ -257,6 +270,7 @@ class ConfigHealthCheckTest {
         addFullValidConfig_guard();
         addFullValidConfig_chat();
         addFullValidConfig_loginRateLimit();
+        addFullValidConfig_exploitHardening();
         addFullValidConfig_bot();
         addFullValidConfig_templates();
         List<String> issues = runValidate();
@@ -670,6 +684,48 @@ class ConfigHealthCheckTest {
         assertTrue(issues.contains("非法: login_rate_limit.max_concurrent_per_ip 不得小于 1"));
         assertTrue(issues.contains("类型错误: login_rate_limit.notify_admins 需为布尔值"));
         assertTrue(issues.contains("缺失: login_rate_limit.message 不可为空"));
+    }
+
+    @Test
+    void missingExploitHardeningSection_reportsSuggestion() {
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        // no exploit_hardening section
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("建议: config.yml 缺失 exploit_hardening 配置段，将使用默认配置（漏洞加固开启）"));
+    }
+
+    @Test
+    void exploitHardeningWrongTypes_reportIssues() {
+        config.createSection("exploit_hardening").set("enabled", "yes");
+        config.getConfigurationSection("exploit_hardening").set("book_enabled", "yes");
+        config.getConfigurationSection("exploit_hardening").set("book_max_pages", 0);
+        config.getConfigurationSection("exploit_hardening").set("item_max_attribute_modifiers", 0);
+        config.getConfigurationSection("exploit_hardening").set("entity_enabled", "yes");
+        config.getConfigurationSection("exploit_hardening").set("entity_max_per_chunk", 0);
+        config.getConfigurationSection("exploit_hardening").set("notify_admins", "yes");
+        config.getConfigurationSection("exploit_hardening").set("message", "");
+        addFullValidConfig_whitelist();
+        addFullValidConfig_maintenance();
+        addFullValidConfig_tnt();
+        addFullValidConfig_geoip();
+        addFullValidConfig_commandPolicies();
+        addFullValidConfig_bot();
+        addMinimalValidConfig_templates();
+        List<String> issues = runValidate();
+        assertTrue(issues.contains("类型错误: exploit_hardening.enabled 需为布尔值"));
+        assertTrue(issues.contains("类型错误: exploit_hardening.book_enabled 需为布尔值"));
+        assertTrue(issues.contains("非法: exploit_hardening.book_max_pages 不得小于 1"));
+        assertTrue(issues.contains("非法: exploit_hardening.item_max_attribute_modifiers 不得小于 1"));
+        assertTrue(issues.contains("类型错误: exploit_hardening.entity_enabled 需为布尔值"));
+        assertTrue(issues.contains("非法: exploit_hardening.entity_max_per_chunk 不得小于 1"));
+        assertTrue(issues.contains("类型错误: exploit_hardening.notify_admins 需为布尔值"));
+        assertTrue(issues.contains("缺失: exploit_hardening.message 不可为空"));
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeysTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeysTest.java
@@ -58,5 +58,6 @@ class TemplateKeysTest {
         assertEquals("command_guard_blocked", TemplateKeys.COMMAND_GUARD_BLOCKED);
         assertEquals("security_audit", TemplateKeys.SECURITY_AUDIT);
         assertEquals("login_rate_limit_alert", TemplateKeys.LOGIN_RATE_LIMIT_ALERT);
+        assertEquals("exploit_blocked", TemplateKeys.EXPLOIT_BLOCKED);
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/ExploitHardeningConfigTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/ExploitHardeningConfigTest.java
@@ -1,0 +1,71 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.junit.jupiter.api.Test;
+
+class ExploitHardeningConfigTest {
+
+    @Test
+    void fromNull_returnsDefaults() {
+        ExploitHardeningConfig config = ExploitHardeningConfig.from(null);
+        assertTrue(config.enabled());
+        assertTrue(config.bookEnabled());
+        assertEquals(100, config.maxBookPages());
+        assertTrue(config.itemEnabled());
+        assertEquals(6, config.maxAttributeModifiers());
+        assertTrue(config.entityEnabled());
+        assertEquals(128, config.maxEntitiesPerChunk());
+        assertTrue(config.notifyAdmins());
+        assertEquals(ExploitHardeningConfig.DEFAULT_MESSAGE, config.message());
+    }
+
+    @Test
+    void fromFullSection_returnsCorrectValues() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled", true)).thenReturn(false);
+        when(cfg.getBoolean("book_enabled", true)).thenReturn(false);
+        when(cfg.getInt("book_max_pages", 100)).thenReturn(50);
+        when(cfg.getBoolean("item_enabled", true)).thenReturn(false);
+        when(cfg.getInt("item_max_attribute_modifiers", 6)).thenReturn(3);
+        when(cfg.getBoolean("entity_enabled", true)).thenReturn(false);
+        when(cfg.getInt("entity_max_per_chunk", 128)).thenReturn(64);
+        when(cfg.getBoolean("notify_admins", true)).thenReturn(false);
+        when(cfg.getString("message", ExploitHardeningConfig.DEFAULT_MESSAGE)).thenReturn("自定义");
+
+        ExploitHardeningConfig config = ExploitHardeningConfig.from(cfg);
+        assertFalse(config.enabled());
+        assertFalse(config.bookEnabled());
+        assertEquals(50, config.maxBookPages());
+        assertFalse(config.itemEnabled());
+        assertEquals(3, config.maxAttributeModifiers());
+        assertFalse(config.entityEnabled());
+        assertEquals(64, config.maxEntitiesPerChunk());
+        assertFalse(config.notifyAdmins());
+        assertEquals("自定义", config.message());
+    }
+
+    @Test
+    void fromSection_clampsNonPositiveToMin() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getInt("book_max_pages", 100)).thenReturn(0);
+        when(cfg.getInt("item_max_attribute_modifiers", 6)).thenReturn(0);
+        when(cfg.getInt("entity_max_per_chunk", 128)).thenReturn(0);
+
+        ExploitHardeningConfig config = ExploitHardeningConfig.from(cfg);
+        assertEquals(1, config.maxBookPages());
+        assertEquals(1, config.maxAttributeModifiers());
+        assertEquals(1, config.maxEntitiesPerChunk());
+    }
+
+    @Test
+    void fromSection_blankMessageFallsBackToDefault() {
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getString("message", ExploitHardeningConfig.DEFAULT_MESSAGE)).thenReturn("   ");
+
+        ExploitHardeningConfig config = ExploitHardeningConfig.from(cfg);
+        assertEquals(ExploitHardeningConfig.DEFAULT_MESSAGE, config.message());
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/notify/NotifierTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/notify/NotifierTest.java
@@ -82,8 +82,9 @@ class NotifierTest extends ServiceTestBase {
         notifier.routeEvent("command_guard_blocked", env);
         notifier.routeEvent("security_audit", env);
         notifier.routeEvent("login_rate_limit_alert", env);
+        notifier.routeEvent("exploit_blocked", env);
 
-        verify(botMessageService, times(6))
+        verify(botMessageService, times(7))
                 .send(argThat(message -> message.targetType() == MessageEnvelope.TargetType.PRIVATE));
     }
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateResourceSmokeTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateResourceSmokeTest.java
@@ -127,4 +127,22 @@ public class TemplateResourceSmokeTest extends ServiceTestBase {
                 rendered.contains("{ip}") || rendered.contains("{player}") || rendered.contains("{reason}"),
                 "不得残留字面占位符: " + rendered);
     }
+
+    @Test
+    public void testExploitBlockedTemplateResolvesWithRealText() throws Exception {
+        // 安全加固 P2-3：漏洞利用拦截模板必须渲染真实中文文案，而非字面 "{player}" 等占位符
+        YamlConfiguration cfg = load("templates.yml");
+        String resolved = TemplateRenderer.resolveTemplate("exploit_blocked", cfg, "");
+        Assertions.assertFalse(resolved.isEmpty(), "exploit_blocked 模板缺失");
+
+        var vars = java.util.Map.of(
+                "player", "alice",
+                "reason", "书页超限（150 页）");
+        String rendered = TemplateRenderer.render(resolved, vars);
+
+        Assertions.assertTrue(rendered.contains("alice"), "应含玩家名: " + rendered);
+        Assertions.assertTrue(rendered.contains("书页超限"), "应含原因: " + rendered);
+        Assertions.assertFalse(
+                rendered.contains("{player}") || rendered.contains("{reason}"), "不得残留字面占位符: " + rendered);
+    }
 }


### PR DESCRIPTION
## 安全加固路线图 P2-3 已知漏洞加固

### 实现内容

| 漏洞面 | 接入点 | 处置 |
|---|---|---|
| 书页超限（刷书） | `PlayerEditBookEvent`（LOW 优先） | 超限 → cancel + warn 提示 +（按配置）PRIVATE 私信管理员 |
| 物品 NBT 异常（32k） | `PlayerJoinEvent` 背包扫描 | 属性修饰符数超上限 → 清除全部修饰符（中和 NBT 增益）+ warn + 告警 |
| 单区块实体上限 | `EntitySpawnEvent` | 区块实体数已达上限 → cancel（掉落物/抛射物豁免，静默防刷屏） |

### 结构

- **ExploitHardeningConfig**：类型化配置记录（`sectionOrLegacy("config", "exploit_hardening", "exploit_hardening.yml")`）
- **ExploitHardeningService**：纯核心判定（可注入 `Supplier<Config>`，配合 /config 热重载）
- **ExploitHardeningEventService**：事件编排（纯核心 + 事件解耦）
- **OrzExploitHardeningEvent**：监听器（注册入 FeatureModule 拦截器链）
- **TemplateKeys.EXPLOIT_BLOCKED** + templates.yml 模板 + Notifier PRIVATE 路由 + ConfigHealthCheck 校验（缺失为「建议」级，兼容升级安装）

### 兼容性

- EXPLOIT_BLOCKED 模板键**不**纳入 TemplateKeys.ALL（沿用 P2-2 先例），升级安装缺模板时 Java 兜底文案自动生效
- 三个子项（book_enabled/item_enabled/entity_enabled）+ 总开关全部可独立关闭，默认开启
- notify_admins 独立开关，关闭时仅玩家本地提示不打扰管理员

### 测试（新增 22 个 + 既有扩展，全绿）

- ExploitHardeningServiceTest（10）：三判定边界/开关旁路
- ExploitHardeningConfigTest（4）：默认值/钳制
- ExploitHardeningEventServiceTest（8）：书页取消+告警、实体豁免、32k 清理等
- ConfigHealthCheckTest / NotifierTest / TemplateKeysTest / TemplateResourceSmokeTest 扩展