### PR TITLE
feat(security): IP 黑名单增强（IPv6 CIDR + 封禁命中告警）

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -281,7 +281,9 @@ public final class FeatureModule implements ServiceModule {
                     playerEventService,
                     guideService,
                     platform.textStyles(),
-                    maintenanceModule.worldMaintenanceService()),
+                    maintenanceModule.worldMaintenanceService(),
+                    botModule.notifier(),
+                    platform.configs()),
             new OrzTPEvent(
                     plugin,
                     platform.serverFacade(),

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEvent.java
@@ -1,12 +1,17 @@
 package com.jokerhub.paper.plugin.orzmc.events;
 
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.features.guide.GuideService;
 import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
 import com.jokerhub.paper.plugin.orzmc.features.player.PlayerEventService;
 import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
+import com.jokerhub.paper.plugin.orzmc.infra.config.TemplateKeys;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
+import java.util.Map;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
@@ -21,6 +26,8 @@ public class OrzPlayerEvent extends OrzBaseListener {
     private final GuideService guideService;
     private final OrzTextStyles styles;
     private final WorldMaintenanceService maintenanceService;
+    private final Notifier notifier;
+    private final TypedConfigProvider configs;
 
     public OrzPlayerEvent(
             OrzMC plugin,
@@ -29,7 +36,9 @@ public class OrzPlayerEvent extends OrzBaseListener {
             PlayerEventService service,
             GuideService guideService,
             OrzTextStyles styles,
-            WorldMaintenanceService maintenanceService) {
+            WorldMaintenanceService maintenanceService,
+            Notifier notifier,
+            TypedConfigProvider configs) {
         super(plugin);
         this.geoIpAccessService = geoIpAccessService;
         this.blacklistService = blacklistService;
@@ -37,6 +46,8 @@ public class OrzPlayerEvent extends OrzBaseListener {
         this.guideService = guideService;
         this.styles = styles;
         this.maintenanceService = maintenanceService;
+        this.notifier = notifier;
+        this.configs = configs;
     }
 
     @EventHandler
@@ -49,8 +60,10 @@ public class OrzPlayerEvent extends OrzBaseListener {
             return;
         }
         String ipAddress = event.getAddress().getHostAddress();
-        if (blacklistService.isBlocked(ipAddress)) {
+        String matchedPattern = blacklistService.matchedPattern(ipAddress);
+        if (matchedPattern != null) {
             event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, styles.error("你的IP已被禁止访问"));
+            notifyBanHit(event.getPlayerProfile().getName(), ipAddress, matchedPattern);
             return;
         }
         String playerName = event.getPlayerProfile().getName();
@@ -87,5 +100,14 @@ public class OrzPlayerEvent extends OrzBaseListener {
             return;
         }
         service.notifyPlayerState(event.getPlayer(), PlayerEventService.PlayerState.KICK);
+    }
+
+    /** 封禁命中（安全加固 P2-4）：PRIVATE 私信管理员 + 服务端日志。 */
+    private void notifyBanHit(String player, String ip, String pattern) {
+        String fallback = "⚠ IP 黑名单拦截\n玩家: " + player + "\nIP: " + ip + "\n命中规则: " + pattern;
+        MessageEnvelope env = configs.renderTemplate(
+                TemplateKeys.IP_BLACKLIST_BLOCK, Map.of("player", player, "ip", ip, "pattern", pattern), fallback);
+        notifier.event(TemplateKeys.IP_BLACKLIST_BLOCK, env);
+        plugin.getLogger().warning("黑名单拦截: " + player + " (" + ip + ") 命中规则 " + pattern);
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/BlacklistService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/security/BlacklistService.java
@@ -3,6 +3,7 @@ package com.jokerhub.paper.plugin.orzmc.features.security;
 import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -23,11 +24,20 @@ public final class BlacklistService {
     // ---- query ----
 
     public boolean isBlocked(String ip) {
-        if (ip == null || ip.isEmpty()) return false;
+        return matchedPattern(ip) != null;
+    }
+
+    /**
+     * 返回第一个命中的规则；未命中返回 {@code null}。
+     *
+     * <p>安全加固 P2-4：封禁命中告警需要展示命中的具体规则（如 IPv6 CIDR 段）。</p>
+     */
+    public String matchedPattern(String ip) {
+        if (ip == null || ip.isEmpty()) return null;
         for (String pattern : patterns) {
-            if (matches(ip, pattern)) return true;
+            if (matches(ip, pattern)) return pattern;
         }
-        return false;
+        return null;
     }
 
     // ---- mutate ----
@@ -86,7 +96,17 @@ public final class BlacklistService {
     }
 
     private static boolean exactMatches(String ip, String pattern) {
-        return ip.equals(pattern);
+        if (ip.equals(pattern)) return true;
+        // IPv6 有多种合法文本形式（如 2001:db8::1 与 2001:0db8:0:0:0:0:0:1），
+        // 双方均可解析为 InetAddress 时按字节序列比较；纯 IPv4 字符串不同即不同。
+        if (ip.indexOf(':') < 0 && pattern.indexOf(':') < 0) return false;
+        try {
+            return Arrays.equals(
+                    InetAddress.getByName(ip).getAddress(),
+                    InetAddress.getByName(pattern).getAddress());
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private static boolean cidrMatches(String ip, String cidr) {
@@ -100,31 +120,37 @@ public final class BlacklistService {
             } catch (NumberFormatException e) {
                 return false;
             }
-            if (prefix < 0 || prefix > 32) return false;
 
             byte[] ipBytes = InetAddress.getByName(ip).getAddress();
             byte[] subnetBytes = InetAddress.getByName(subnetStr).getAddress();
-            if (ipBytes.length != 4 || subnetBytes.length != 4) return false;
+            if (ipBytes.length != subnetBytes.length) return false; // IPv4 与 IPv6 不匹配
+            if (prefix < 0 || prefix > ipBytes.length * 8) return false;
 
-            int ipInt = toInt(ipBytes);
-            int subnetInt = toInt(subnetBytes);
-            int mask = prefix == 0 ? 0 : 0xFFFFFFFF << (32 - prefix);
-
-            return (ipInt & mask) == (subnetInt & mask);
+            return matchesPrefix(ipBytes, subnetBytes, prefix);
         } catch (Exception e) {
             return false;
         }
     }
 
+    /** 逐字节比较前 {@code prefix} 位（IPv4 最多 32 位，IPv6 最多 128 位）。 */
+    private static boolean matchesPrefix(byte[] ip, byte[] subnet, int prefix) {
+        int fullBytes = prefix / 8;
+        int remBits = prefix % 8;
+        for (int i = 0; i < fullBytes; i++) {
+            if (ip[i] != subnet[i]) return false;
+        }
+        if (remBits > 0) {
+            int mask = 0xFF << (8 - remBits);
+            if ((ip[fullBytes] & mask) != (subnet[fullBytes] & mask)) return false;
+        }
+        return true;
+    }
+
     private static boolean wildcardMatches(String ip, String pattern) {
-        // Convert wildcard pattern to regex: * matches remaining octets
+        // IPv4 专用通配：* 匹配剩余网段。IPv6 请使用 CIDR（IPv6 地址含冒号，此正则不会命中）。
         // 10.*        → 10\.\d{1,3}(\.\d{1,3})*
         // 192.168.*   → 192\.168\.\d{1,3}(\.\d{1,3})*
         String regex = "^" + pattern.replace(".", "\\.").replace("*", "\\d{1,3}(\\.\\d{1,3})*") + "$";
         return ip.matches(regex);
-    }
-
-    private static int toInt(byte[] bytes) {
-        return ((bytes[0] & 0xFF) << 24) | ((bytes[1] & 0xFF) << 16) | ((bytes[2] & 0xFF) << 8) | (bytes[3] & 0xFF);
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeys.java
@@ -44,6 +44,7 @@ public final class TemplateKeys {
     public static final String SECURITY_AUDIT = "security_audit";
     public static final String LOGIN_RATE_LIMIT_ALERT = "login_rate_limit_alert";
     public static final String EXPLOIT_BLOCKED = "exploit_blocked";
+    public static final String IP_BLACKLIST_BLOCK = "ip_blacklist_block";
 
     // ---- TNT 事件 ----
     public static final String TNT_ALERT = "tnt_alert";
@@ -86,13 +87,13 @@ public final class TemplateKeys {
      * 所有已知的模板事件 key。用于 {@link ConfigHealthCheck} 校验。
      *
      * <p>不含 {@link #PLAYER_DIGEST}、{@link #COMMAND_GUARD_BLOCKED}、{@link #SECURITY_AUDIT}、
-     * {@link #LOGIN_RATE_LIMIT_ALERT} 与 {@link #EXPLOIT_BLOCKED}：调用方始终传入 fallback
-     * 兜底文案（PLAYER_DIGEST 在 {@code Templates} 中有完整 Java 默认模板，COMMAND_GUARD_BLOCKED
-     * 在 {@code CommandGuardEventService}、SECURITY_AUDIT 在 {@code StartupSecurityAuditService}、
-     * LOGIN_RATE_LIMIT_ALERT 在 {@code LoginRateLimitEventService}、EXPLOIT_BLOCKED 在
-     * {@code ExploitHardeningEventService} 中内联兜底），升级安装（templates.yml 已存在故未复制
-     * 新默认值）不携带该键即可正常工作；纳入 ALL 会要求模板文件提供该键，造成升级后每次启动的
-     * 持久「缺失」告警。</p>
+     * {@link #LOGIN_RATE_LIMIT_ALERT}、{@link #EXPLOIT_BLOCKED} 与 {@link #IP_BLACKLIST_BLOCK}：
+     * 调用方始终传入 fallback 兜底文案（PLAYER_DIGEST 在 {@code Templates} 中有完整 Java 默认模板，
+     * COMMAND_GUARD_BLOCKED 在 {@code CommandGuardEventService}、SECURITY_AUDIT 在
+     * {@code StartupSecurityAuditService}、LOGIN_RATE_LIMIT_ALERT 在 {@code LoginRateLimitEventService}、
+     * EXPLOIT_BLOCKED 在 {@code ExploitHardeningEventService}、IP_BLACKLIST_BLOCK 在
+     * {@code OrzPlayerEvent} 中内联兜底），升级安装（templates.yml 已存在故未复制新默认值）不携带
+     * 该键即可正常工作；纳入 ALL 会要求模板文件提供该键，造成升级后每次启动的持久「缺失」告警。</p>
      */
     public static final String[] ALL = {
         PLAYER_JOIN,

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/notify/Notifier.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/notify/Notifier.java
@@ -53,7 +53,8 @@ public final class Notifier {
                             TemplateKeys.COMMAND_GUARD_BLOCKED,
                             TemplateKeys.SECURITY_AUDIT,
                             TemplateKeys.LOGIN_RATE_LIMIT_ALERT,
-                            TemplateKeys.EXPLOIT_BLOCKED -> MessageEnvelope.TargetType.PRIVATE;
+                            TemplateKeys.EXPLOIT_BLOCKED,
+                            TemplateKeys.IP_BLACKLIST_BLOCK -> MessageEnvelope.TargetType.PRIVATE;
                     default -> MessageEnvelope.TargetType.PUBLIC;
                 };
         botMessageService.send(envelope.withTargetType(target));

--- a/src/main/resources/templates.yml
+++ b/src/main/resources/templates.yml
@@ -32,6 +32,7 @@ templates:
     security_audit: PLAIN
     login_rate_limit_alert: PLAIN
     exploit_blocked: PLAIN
+    ip_blacklist_block: PLAIN
     maintenance_backup_stage: CODE_BLOCK
     maintenance_backup_done: CODE_BLOCK
     maintenance_backup_error: CODE_BLOCK
@@ -85,6 +86,7 @@ templates:
   security_audit: "🛡 安全自检报告\n在线模式: {online_mode}\n命令方块: {command_block}\nRCON: {rcon}\n白名单: {whitelist}\nOP: {ops}\n关键插件: {plugins}"
   login_rate_limit_alert: "⚠ 登录限流\nIP: {ip}\n玩家: {player}\n原因: {reason}"
   exploit_blocked: "⚠ 漏洞利用拦截\n玩家: {player}\n原因: {reason}"
+  ip_blacklist_block: "⚠ IP 黑名单拦截\n玩家: {player}\nIP: {ip}\n命中规则: {pattern}"
   player_join: "{name} 上线\n------当前在线({online_count}/{max_count})------\n{online_list}"
   player_quit: "{name} 下线\n------当前在线({online_count}/{max_count})------\n{online_list}"
   player_kick: "{name} 被踢\n------当前在线({online_count}/{max_count})------\n{online_list}"

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzPlayerEventTest.java
@@ -5,16 +5,20 @@ import static org.mockito.Mockito.*;
 
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.features.guide.GuideService;
 import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
 import com.jokerhub.paper.plugin.orzmc.features.player.PlayerEventService;
 import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.GeoIpAccessService;
+import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
 import java.net.InetAddress;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
@@ -49,6 +53,15 @@ class OrzPlayerEventTest extends ServiceTestBase {
     private WorldMaintenanceService maintenanceService;
 
     @Mock
+    private Notifier notifier;
+
+    @Mock
+    private TypedConfigProvider configs;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
     private AsyncPlayerPreLoginEvent event;
 
     @Mock
@@ -75,7 +88,10 @@ class OrzPlayerEventTest extends ServiceTestBase {
         when(event.getPlayerProfile()).thenReturn(profile);
         when(profile.getName()).thenReturn("player1");
         when(maintenanceService.isRunning()).thenReturn(false);
-        when(blacklistService.isBlocked(anyString())).thenReturn(false);
+        when(blacklistService.matchedPattern(anyString())).thenReturn(null);
+        when(configs.renderTemplate(anyString(), anyMap(), anyString()))
+                .thenReturn(MessageEnvelope.publicMessage("ip_blacklist_block"));
+        when(plugin.getLogger()).thenReturn(logger);
         when(styles.warn(anyString())).thenReturn(Component.text("warn"));
         when(styles.error(anyString())).thenReturn(Component.text("error"));
         when(joinEvent.getPlayer()).thenReturn(player);
@@ -83,7 +99,15 @@ class OrzPlayerEventTest extends ServiceTestBase {
         when(kickEvent.getPlayer()).thenReturn(player);
 
         listener = new OrzPlayerEvent(
-                plugin, geoIpAccessService, blacklistService, service, guideService, styles, maintenanceService);
+                plugin,
+                geoIpAccessService,
+                blacklistService,
+                service,
+                guideService,
+                styles,
+                maintenanceService,
+                notifier,
+                configs);
     }
 
     @Test
@@ -107,13 +131,30 @@ class OrzPlayerEventTest extends ServiceTestBase {
     }
 
     @Test
-    void onPlayerPreLogin_blacklisted_disallowsAndSkipsGeoIp() {
-        when(blacklistService.isBlocked("1.2.3.4")).thenReturn(true);
+    void onPlayerPreLogin_blacklisted_disallowsNotifiesAndLogs() {
+        when(blacklistService.matchedPattern("1.2.3.4")).thenReturn("1.2.3.4");
 
         listener.onPlayerPreLogin(event);
 
         verify(event).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+        // P2-4：封禁命中 PRIVATE 告警 + 日志
+        verify(notifier).event(eq("ip_blacklist_block"), any(MessageEnvelope.class));
+        verify(logger).warning(anyString());
         verifyNoInteractions(geoIpAccessService, service);
+    }
+
+    @Test
+    void onPlayerPreLogin_blacklistedV6_notifiesWithPattern() throws Exception {
+        InetAddress v6 = InetAddress.getByName("2001:db8::1");
+        when(event.getAddress()).thenReturn(v6);
+        // 命中规则的返回与地址文本形式无关：getHostAddress() 会展开为 2001:db8:0:0:0:0:0:1
+        when(blacklistService.matchedPattern(anyString())).thenReturn("2001:db8::/32");
+
+        listener.onPlayerPreLogin(event);
+
+        verify(event).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
+        verify(notifier).event(eq("ip_blacklist_block"), any(MessageEnvelope.class));
+        verify(configs).renderTemplate(eq("ip_blacklist_block"), anyMap(), anyString());
     }
 
     @Test
@@ -124,7 +165,7 @@ class OrzPlayerEventTest extends ServiceTestBase {
 
         listener.onPlayerPreLogin(event);
 
-        verify(blacklistService).isBlocked("");
+        verify(blacklistService).matchedPattern("");
         verifyNoInteractions(geoIpAccessService, service);
         verify(event, never()).disallow(eq(AsyncPlayerPreLoginEvent.Result.KICK_OTHER), any(Component.class));
     }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/BlacklistServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/security/BlacklistServiceTest.java
@@ -76,6 +76,82 @@ class BlacklistServiceTest {
         assertEquals(expected, service.isBlocked(ip));
     }
 
+    // ---- IPv6 精确匹配（文本形式规范化）----
+
+    @Test
+    void exactMatch_ipv6_canonicalFormsEqual() {
+        setupPatterns("2001:db8::1");
+        assertTrue(service.isBlocked("2001:db8::1"));
+        assertTrue(service.isBlocked("2001:0db8:0:0:0:0:0:1"));
+    }
+
+    @Test
+    void exactMatch_ipv6_allowsDifferent() {
+        setupPatterns("2001:db8::1");
+        assertFalse(service.isBlocked("2001:db8::2"));
+    }
+
+    // ---- IPv6 CIDR ----
+
+    @ParameterizedTest
+    @CsvSource({
+        "2001:db8::/32,     2001:db8:1::5,   true",
+        "2001:db8::/32,     2001:db9::1,     false",
+        "fd00::/8,          fd12:3456::1,    true",
+        "fd00::/8,          2001:db8::1,     false",
+        "::/0,              ::1,             true",
+        "::1/128,           ::1,             true",
+        "::1/128,           ::2,             false",
+    })
+    void cidrMatch_ipv6(String pattern, String ip, boolean expected) {
+        setupPatterns(pattern);
+        assertEquals(expected, service.isBlocked(ip));
+    }
+
+    // ---- IPv4 / IPv6 族不匹配 ----
+
+    @Test
+    void cidrMatch_v4PatternVsV6Ip_notBlocked() {
+        setupPatterns("10.0.0.0/8");
+        assertFalse(service.isBlocked("2001:db8::1"));
+    }
+
+    @Test
+    void cidrMatch_v6PatternVsV4Ip_notBlocked() {
+        setupPatterns("2001:db8::/32");
+        assertFalse(service.isBlocked("10.0.0.1"));
+    }
+
+    // ---- 前缀越界 ----
+
+    @ParameterizedTest
+    @CsvSource({
+        "2001:db8::/129,  2001:db8::1,   false",
+        "2001:db8::/-1,   2001:db8::1,   false",
+    })
+    void cidrMatch_invalidPrefix_notBlocked(String pattern, String ip, boolean expected) {
+        setupPatterns(pattern);
+        assertEquals(expected, service.isBlocked(ip));
+    }
+
+    // ---- matchedPattern（P2-4 封禁告警需命中规则）----
+
+    @Test
+    void matchedPattern_returnsHitPattern() {
+        setupPatterns("1.2.3.4", "10.0.0.0/8", "2001:db8::/32");
+        assertEquals("10.0.0.0/8", service.matchedPattern("10.1.2.3"));
+        assertEquals("2001:db8::/32", service.matchedPattern("2001:db8:abcd::5"));
+        assertEquals("1.2.3.4", service.matchedPattern("1.2.3.4"));
+    }
+
+    @Test
+    void matchedPattern_noHit_returnsNull() {
+        setupPatterns("1.2.3.4");
+        assertNull(service.matchedPattern("5.6.7.8"));
+        assertNull(service.matchedPattern(""));
+        assertNull(service.matchedPattern(null));
+    }
+
     // ---- blacklist is empty by default ----
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeysTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/TemplateKeysTest.java
@@ -59,5 +59,6 @@ class TemplateKeysTest {
         assertEquals("security_audit", TemplateKeys.SECURITY_AUDIT);
         assertEquals("login_rate_limit_alert", TemplateKeys.LOGIN_RATE_LIMIT_ALERT);
         assertEquals("exploit_blocked", TemplateKeys.EXPLOIT_BLOCKED);
+        assertEquals("ip_blacklist_block", TemplateKeys.IP_BLACKLIST_BLOCK);
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/notify/NotifierTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/notify/NotifierTest.java
@@ -83,8 +83,9 @@ class NotifierTest extends ServiceTestBase {
         notifier.routeEvent("security_audit", env);
         notifier.routeEvent("login_rate_limit_alert", env);
         notifier.routeEvent("exploit_blocked", env);
+        notifier.routeEvent("ip_blacklist_block", env);
 
-        verify(botMessageService, times(7))
+        verify(botMessageService, times(8))
                 .send(argThat(message -> message.targetType() == MessageEnvelope.TargetType.PRIVATE));
     }
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateResourceSmokeTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/templates/TemplateResourceSmokeTest.java
@@ -145,4 +145,24 @@ public class TemplateResourceSmokeTest extends ServiceTestBase {
         Assertions.assertFalse(
                 rendered.contains("{player}") || rendered.contains("{reason}"), "不得残留字面占位符: " + rendered);
     }
+
+    @Test
+    public void testIpBlacklistBlockTemplateResolvesWithRealText() throws Exception {
+        // 安全加固 P2-4：封禁命中告警模板必须渲染真实中文文案，而非字面 "{ip}" 等占位符
+        YamlConfiguration cfg = load("templates.yml");
+        String resolved = TemplateRenderer.resolveTemplate("ip_blacklist_block", cfg, "");
+        Assertions.assertFalse(resolved.isEmpty(), "ip_blacklist_block 模板缺失");
+
+        var vars = java.util.Map.of(
+                "player", "alice",
+                "ip", "2001:db8::1",
+                "pattern", "2001:db8::/32");
+        String rendered = TemplateRenderer.render(resolved, vars);
+
+        Assertions.assertTrue(rendered.contains("alice"), "应含玩家名: " + rendered);
+        Assertions.assertTrue(rendered.contains("2001:db8::/32"), "应含命中规则: " + rendered);
+        Assertions.assertFalse(
+                rendered.contains("{player}") || rendered.contains("{ip}") || rendered.contains("{pattern}"),
+                "不得残留字面占位符: " + rendered);
+    }
 }


### PR DESCRIPTION
## 安全加固路线图 P2-4

### BlacklistService IPv6 支持

| 能力 | 变更 |
|---|---|
| IPv6 CIDR | `cidrMatches` 重写为家族无关的位掩码比较：IPv4 前缀 ≤32、IPv6 ≤128，逐字节比较前 N 位 |
| IPv6 精确匹配 | 文本形式规范化（`2001:db8::1` ≡ `2001:0db8:0:0:0:0:0:1`，按 InetAddress 字节比较） |
| 族不匹配 | v4 规则 vs v6 IP 互不命中（字节长度不同即 false） |
| matchedPattern | 新增 `matchedPattern(ip)` 返回命中的具体规则（IPv6 CIDR 段名），`isBlocked` 委托 |

> 通配符（`192.168.*`）保持 IPv4 专用，IPv6 请使用 CIDR（地址含冒号，现有正则天然不命中）。

### 封禁命中 PRIVATE 告警 + 日志

- `OrzPlayerEvent.onPlayerPreLogin`：黑名单命中 → disallow + **PRIVATE 私信管理员**（模板 `ip_blacklist_block`，含玩家/IP/命中规则）+ `plugin.getLogger().warning` 服务端日志
- `TemplateKeys.IP_BLACKLIST_BLOCK`：**不入 ALL**（Java 兜底文案，沿用 P2-2/P2-3 先例），升级安装缺模板自动兜底
- `Notifier` PRIVATE 路由新增该键

### 兼容性

- `isBlocked` 语义不变（委托 matchedPattern），既有调用方（`OrzPlayerEvent`、`` 群指令）零改动
- 黑名单为独立 `ip_blacklist` 配置文件，无新配置项

### 测试（新增 21 个 + 扩展，全绿）

- BlacklistServiceTest +20：IPv6 精确/CIDR、v4-v6 族不匹配、前缀越界、matchedPattern
- OrzPlayerEventTest：告警 + 日志 + 模板渲染校验（V6 命中场景）
- TemplateKeysTest / NotifierTest / TemplateResourceSmokeTest 扩展