### PR TITLE
feat(maintenance): 定时备份支持 /config reload 热重载 + 默认配置键

### DIFF
--- a/docs/security-hardening-roadmap.md
+++ b/docs/security-hardening-roadmap.md
@@ -99,7 +99,7 @@
 ### P1-1 定时自动备份
 
 - **目标**：文章 26 §5 明确"备份不要依赖手动"。插件已有完整备份机械（`$b`、踢人→save-off→压缩→save-on、保留轮转、维护 MOTD/锁登录），只缺调度。
-- **行为**：`MaintenanceConfig` 增加 `backupIntervalHours`（默认 `0` = 关闭）；新增 `features/maintenance/ScheduledBackupService.java`，用 `SafeScheduler.runTaskTimer` 按小时触发 `WorldMaintenanceService.backup()`；`runExclusive` 天然互斥，运行中跳过；错误沿用现有 PRIVATE 私信。
+- **行为**：`MaintenanceConfig` 增加 `backupIntervalHours`（默认 `0` = 关闭）；新增 `features/maintenance/ScheduledBackupService.java`，用 `SafeScheduler.runTaskTimer` 按小时触发 `WorldMaintenanceService.backup()`；`runExclusive` 天然互斥，运行中跳过；错误沿用现有 PRIVATE 私信。**热重载**：常驻轻量检查器（每分钟）惰性读取配置，间隔/开关经 `/config reload` 修改后下一检查点即生效，无需重启。
 - **验收**：`ScheduledBackupServiceTest`（0 不调度、正数调度且重复 tick 不叠加）+ `MaintenanceConfigTest` 扩展。
 
 ### P1-2 启动安全自检报告

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/ScheduledBackupService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/ScheduledBackupService.java
@@ -11,18 +11,34 @@ import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
  * {@link WorldMaintenanceService#backup(long, int, java.util.function.Consumer)}，
  * 把文章 26 §5「备份不要依赖手动」落地为自动调度。</p>
  *
+ * <p>热重载：注册一个轻量检查器（每分钟一次），每次 tick 惰性读取配置；间隔/开关
+ * 字段经 {@code /config reload} 修改后，下一个检查点即按新值重排，无需重启。</p>
+ *
  * <p>并发安全：重复 tick 不会叠加 —— {@link WorldMaintenanceService#runExclusive} 内部
  * 用 {@code AtomicBoolean} 互斥，前一次备份尚未结束时再次触发直接跳过；错误通知沿用
  * 现有 PRIVATE 私信路由（由 {@code Notifier} 的 MAINTENANCE_BACKUP_ERROR 处理）。</p>
  */
 public final class ScheduledBackupService {
 
-    /** 1 小时的 tick 数（20 tick/s）。 */
-    private static final long HOUR_TICKS = 20L * 60L * 60L;
+    /** 1 分钟的 tick 数（20 tick/s），检查器周期。 */
+    private static final long CHECK_TICKS = 20L * 60L;
+
+    /** 每次检查推进的游戏分钟数。 */
+    private static final long CHECK_MINUTES = 1L;
 
     private final ServerFacade server;
     private final TypedConfigProvider configs;
     private final WorldMaintenanceService maintenance;
+
+    /** 当前计划的间隔小时数（0 = 关闭）；与配置不一致时表示发生了热重载。 */
+    private long plannedIntervalHours;
+
+    /** 自「当前计划」开始累计的游戏分钟数，达到 {@link #targetMinutes} 触发一次备份。 */
+    private long elapsedMinutes;
+
+    /** 当前计划对应的触发分钟数（间隔小时 × 60）。 */
+    private long targetMinutes;
+
     private org.bukkit.scheduler.BukkitTask task;
 
     public ScheduledBackupService(
@@ -32,14 +48,19 @@ public final class ScheduledBackupService {
         this.maintenance = maintenance;
     }
 
-    /** 按配置调度定时备份；间隔 ≤ 0 表示关闭，不调度任何任务。 */
+    /**
+     * 注册常驻检查器。无论开关状态都注册（关闭时每分钟空跑，成本可忽略），
+     * 这样运行中通过 {@code /config reload} 修改间隔/开关也能即时生效。
+     */
     public void setup() {
-        long intervalHours = configs.maintenance().backupIntervalHours();
-        if (intervalHours <= 0) {
-            return;
+        if (task != null) {
+            task.cancel();
         }
-        long periodTicks = Math.multiplyExact(intervalHours, HOUR_TICKS);
-        this.task = server.runTaskTimer(this::tick, periodTicks, periodTicks);
+        // 强制首个检查点按当前配置重排（插件重载后重新倒计时）
+        plannedIntervalHours = 0;
+        elapsedMinutes = 0;
+        targetMinutes = 0;
+        this.task = server.runTaskTimer(this::tick, CHECK_TICKS, CHECK_TICKS);
     }
 
     /** 取消定时任务（插件卸载时）。 */
@@ -50,9 +71,28 @@ public final class ScheduledBackupService {
         }
     }
 
-    /** 触发一次备份；进行中的备份互斥跳过，进度仅落服务器日志（不打扰群聊）。 */
+    /** 每分钟检查一次：配置变化重排倒计时；到点触发一次备份。 */
     void tick() {
         MaintenanceConfig cfg = configs.maintenance();
+        long intervalHours = cfg.backupIntervalHours();
+        if (intervalHours != plannedIntervalHours) {
+            // 配置变化（含首启 / 关闭 / 调整间隔）：按当前值重排，倒计时从此刻开始
+            plannedIntervalHours = intervalHours;
+            elapsedMinutes = 0;
+            targetMinutes = intervalHours <= 0 ? 0 : Math.multiplyExact(intervalHours, 60L);
+        }
+        if (plannedIntervalHours <= 0) {
+            return; // 关闭：不触发
+        }
+        elapsedMinutes += CHECK_MINUTES;
+        if (elapsedMinutes >= targetMinutes) {
+            runBackup(cfg);
+            elapsedMinutes = 0;
+        }
+    }
+
+    /** 触发一次备份；进行中的备份互斥跳过，进度仅落服务器日志（不打扰群聊）。 */
+    private void runBackup(MaintenanceConfig cfg) {
         maintenance.backup(
                 cfg.optimizeTickTimeThreshold(),
                 cfg.backupRetentionCount(),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,6 +28,9 @@ maintenance:
   optimize_tick_time_threshold: 300
   backup_retention_count: 5
   backup_maintenance_motd: "服务器维护中，稍后再试"
+  # 定时自动备份间隔（小时）：0 = 关闭；>0 表示每 N 小时自动备份一次。
+  # 该字段支持 /config reload 热重载：修改后无需重启，下一个检查点（每分钟）即生效。
+  backup_interval_hours: 0
 
 # ==================================================
 #                   TNT 检查配置

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/assembly/MaintenanceModuleTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/assembly/MaintenanceModuleTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import org.bukkit.scheduler.BukkitTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +31,13 @@ class MaintenanceModuleTest {
         TypedConfigProvider configs = mock(TypedConfigProvider.class);
         lenient().when(configs.maintenance()).thenReturn(new MaintenanceConfig(false, 300L, 5, "服务器维护中，稍后再试", 0L));
         lenient().when(platform.configs()).thenReturn(configs);
+        // 热重载后 setup() 无论开关都注册常驻检查器，需要 server 提供 runTaskTimer
+        // （该 stub 仅 setup_doesNotThrow 用到，标记 lenient）。
+        ServerFacade server = mock(ServerFacade.class);
+        lenient()
+                .when(server.runTaskTimer(any(Runnable.class), anyLong(), anyLong()))
+                .thenReturn(mock(BukkitTask.class));
+        lenient().when(platform.serverFacade()).thenReturn(server);
         module = new MaintenanceModule(platform, botModule);
     }
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/ScheduledBackupServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/ScheduledBackupServiceTest.java
@@ -12,7 +12,6 @@ import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import org.bukkit.scheduler.BukkitTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 class ScheduledBackupServiceTest {
 
@@ -33,40 +32,94 @@ class ScheduledBackupServiceTest {
     }
 
     @Test
-    void setup_zeroHours_doesNotSchedule() {
+    void setup_alwaysRegistersMinuteChecker() {
+        // 无论开关状态都注册常驻检查器（每分钟 1200 ticks），以支持 /config reload 热重载即时生效
         when(configs.maintenance()).thenReturn(config(0L));
         ScheduledBackupService service =
                 new ScheduledBackupService(server, configs, mock(WorldMaintenanceService.class));
 
         service.setup();
 
-        verify(server, never()).runTaskTimer(any(Runnable.class), anyLong(), anyLong());
+        verify(server).runTaskTimer(any(Runnable.class), eq(1200L), eq(1200L));
     }
 
     @Test
-    void setup_positiveHours_schedulesRepeatingTimer() {
-        when(configs.maintenance()).thenReturn(config(2L));
-        ScheduledBackupService service =
-                new ScheduledBackupService(server, configs, mock(WorldMaintenanceService.class));
+    void tick_disabled_neverFiresBackup() {
+        when(configs.maintenance()).thenReturn(config(0L));
+        WorldMaintenanceService maintenance = mock(WorldMaintenanceService.class);
+        ScheduledBackupService service = new ScheduledBackupService(server, configs, maintenance);
 
-        service.setup();
+        for (int i = 0; i < 200; i++) {
+            service.tick();
+        }
 
-        // 2 小时 = 2 * 72000 ticks，delay 与 period 相同（首次 2 小时后触发，之后每 2 小时一次）
-        verify(server).runTaskTimer(any(Runnable.class), eq(144000L), eq(144000L));
+        verifyNoInteractions(maintenance);
     }
 
     @Test
-    void tick_triggersBackupWithMaintenanceConfig() {
+    void tick_enabled_firesAfterIntervalHours() {
         when(configs.maintenance()).thenReturn(config(1L));
         WorldMaintenanceService maintenance = mock(WorldMaintenanceService.class);
         ScheduledBackupService service = new ScheduledBackupService(server, configs, maintenance);
-        service.setup();
 
-        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        verify(server).runTaskTimer(captor.capture(), anyLong(), anyLong());
-        captor.getValue().run();
+        for (int i = 0; i < 59; i++) {
+            service.tick();
+        }
+        verifyNoInteractions(maintenance); // 第 59 分钟仍未到点
+
+        service.tick(); // 第 60 分钟 → 触发一次备份
 
         verify(maintenance).backup(eq(300L), eq(5), any());
+    }
+
+    @Test
+    void tick_firesBackupOncePerInterval() {
+        when(configs.maintenance()).thenReturn(config(1L));
+        WorldMaintenanceService maintenance = mock(WorldMaintenanceService.class);
+        ScheduledBackupService service = new ScheduledBackupService(server, configs, maintenance);
+
+        for (int i = 0; i < 120; i++) {
+            service.tick();
+        }
+
+        verify(maintenance, times(2)).backup(eq(300L), eq(5), any());
+    }
+
+    @Test
+    void tick_intervalChangedViaReload_reschedulesFromNow() {
+        // 热重载：2 小时 → 1 小时，配置变化后的下一个检查点即按新间隔重排倒计时
+        when(configs.maintenance()).thenReturn(config(2L));
+        WorldMaintenanceService maintenance = mock(WorldMaintenanceService.class);
+        ScheduledBackupService service = new ScheduledBackupService(server, configs, maintenance);
+
+        for (int i = 0; i < 30; i++) {
+            service.tick(); // 2 小时计划下累计 30 分钟，未到点
+        }
+        verifyNoInteractions(maintenance);
+
+        when(configs.maintenance()).thenReturn(config(1L)); // 模拟 /config reload 把间隔改为 1 小时
+        for (int i = 0; i < 60; i++) {
+            service.tick(); // 按新间隔重新累计
+        }
+
+        verify(maintenance, times(1)).backup(eq(300L), eq(5), any());
+    }
+
+    @Test
+    void tick_disabledMidRun_stopsFiring() {
+        when(configs.maintenance()).thenReturn(config(1L));
+        WorldMaintenanceService maintenance = mock(WorldMaintenanceService.class);
+        ScheduledBackupService service = new ScheduledBackupService(server, configs, maintenance);
+
+        for (int i = 0; i < 30; i++) {
+            service.tick();
+        }
+        when(configs.maintenance()).thenReturn(config(0L)); // 模拟 /config reload 关闭
+        for (int i = 0; i < 200; i++) {
+            service.tick();
+        }
+
+        verifyNoInteractions(maintenance);
     }
 
     @Test
@@ -79,8 +132,14 @@ class ScheduledBackupServiceTest {
                 new WorldMaintenanceService(server, configs, styles, mock(Notifier.class));
         ScheduledBackupService service = new ScheduledBackupService(server, configs, maintenance);
 
-        service.tick();
-        service.tick();
+        for (int i = 0; i < 60; i++) { // 第一个周期到点 → 备份启动（异步，进行中）
+            service.tick();
+        }
+        assertTrue(maintenance.isRunning());
+
+        for (int i = 0; i < 60; i++) { // 第二个周期到点 → runExclusive 互斥，跳过
+            service.tick();
+        }
 
         verify(server, times(1)).runSync(any(Runnable.class));
         assertTrue(maintenance.isRunning());


### PR DESCRIPTION
## 变更内容

1. **config.yml**：`maintenance:` 段默认新增 `backup_interval_hours: 0`（0 = 关闭），附中文注释说明开启方式与热重载支持。此前该键缺省（0），默认关闭行为不变。
2. **ScheduledBackupService**：由「setup 时按间隔注册一次性周期定时器（interval 写死、改需重启）」改为「注册常驻轻量检查器（每分钟 1200 ticks），每次 tick 惰性读取 `maintenance.backup_interval_hours`」：
   - 间隔/开关经 `/config reload`（裸命令 reloadAll 或 `/config reload config`）修改后，下一检查点即按新值重排倒计时，**无需重启**；
   - 间隔 ≤ 0 = 关闭，每分钟空跑成本可忽略；重新启用/调间隔后倒计时从当刻重新开始；
   - `setup()` 幂等（先取消旧任务再注册），为将来把 `setup()` 挂到 reload 回调留了安全边界；
   - 触发仍沿用纯游戏 tick 语义（累计游戏分钟），不引入系统时钟依赖。
3. **测试**：`ScheduledBackupServiceTest` 重写覆盖新语义（关闭不触发 / 到点触发 / 每周期一次 / 热重载重排 / 运行中关闭停止 / runExclusive 不叠加）；`MaintenanceModuleTest` 补齐 server stub（setup 现在始终注册检查器）。

## 验收
- `./gradlew spotlessCheck :test` 本地全绿（1148 tests）
- 单测覆盖热重载路径（`tick_intervalChangedViaReload_reschedulesFromNow` / `tick_disabledMidRun_stopsFiring`）