### PR TITLE
feat(folia): 调度器门面 + 旁路整改 + isGlobalTickThread（Folia 适配 PR-1）

### DIFF
--- a/docs/folia-migration.md
+++ b/docs/folia-migration.md
@@ -1,0 +1,210 @@
+# OrzMC 插件 Folia 适配评估与迁移路线
+
+> 定位：Folia 适配的**现状缺口清单 + 决策记录 + 分 PR 落地计划**。所有改动按本文件
+> 决策逐批执行，每批独立走 PR（分支 → CI 绿 → merge）。
+>
+> 最后更新：2026-08-18
+
+---
+
+## 1. 现状与目标
+
+**现状**：`src/main/resources/paper-plugin.yml:10` 声明 `folia-supported: false`，
+Folia 会直接拒绝加载本插件。即便翻牌，所有调度都经 `ServerFacade` 落到
+`Bukkit.getScheduler()`（Folia 已移除该 API，调用即抛异常），另有若干实体/区块操作
+在 region 线程模型下会抛「not the correct region」异常。`runServer` 仅能启动 Paper。
+
+**目标**：双运行时（Paper 26.x + Folia 功能均正常），本地可用 `runFolia` 冒烟，
+Hangar/Modrinth 同步发布 Folia loader。
+
+**范围**：调度器统一切换 → 区域亲和迁移 → 并发安全 → 声明/构建/发布 → 测试与 CI。
+全部为**插件侧**改造，不动 orzmc-api 的端口契约（见 D2）。
+
+---
+
+## 2. 现状缺口清单
+
+| 缺口 | 位置 | Folia 下的后果 |
+|---|---|---|
+| 调度器 | `infra/server/ServerFacade.java`（runSync/runAsync/runLater/runTaskTimer） | `Bukkit.getScheduler()` 已移除，调用即抛 |
+| 调度旁路 | `assembly/FeatureModule.java`（/orzdebug）、`events/OrzRankEvent.java`、`events/OrzDebugEvent.java`（RCON） | 直连 `runTaskAsynchronously`，同上 |
+| 主线程判定 | `features/rank/LuckPermsPromoter.java`（`Bukkit.isPrimaryThread()`） | Folia 上恒为 false，async 线程 self-schedule + join 死锁 |
+| 实体踢人 | `features/whitelist/WhitelistService.java`、`features/maintenance/WorldMaintenanceService.java` | 跨 region 调 `player.kick()` 抛异常 |
+| 实体传送 | `features/teleport/TeleportBowService.java`（`player.teleport()`） | 跨 region 同步传送抛异常，应改 `teleportAsync` |
+| 方块/区块 | `infra/portal/*`、`features/teleport/ForceLoadedChunkLease.java`、`TeleportBowFlightTracker.java` | 非本 region 线程访问区块抛异常 |
+| 并发安全 | `TntEventService`、`PlayerEventAggregator`、`ForceLoadedChunkLease`、`TeleportBowFlightTracker`、`PortalService` | 事件按 region 并发，共享状态无保护 |
+| 声明 | `paper-plugin.yml` | `folia-supported: false` 直接拒绝加载 |
+| 构建/发布 | `build.gradle.kts`、Hangar/Modrinth 配置 | 无 `runFolia`；发布 platforms/loaders 仅 paper |
+
+---
+
+## 3. 关键设计决策
+
+### D1 调度器：统一切到 Paper/Folia 兼容调度器（单一代码路径）
+
+`ServerFacade` 的 4 个方法改用 `getGlobalRegionScheduler()` / `getAsyncScheduler()`：
+
+| 方法 | 原实现 | 新实现 |
+|---|---|---|
+| `runSync` | `getScheduler().runTask` | `getGlobalRegionScheduler().execute(plugin, task)` |
+| `runAsync` | `getScheduler().runTaskAsynchronously` | `getAsyncScheduler().runNow(plugin, t -> task.run())` |
+| `runLater` | `getScheduler().runTaskLater` | `getGlobalRegionScheduler().runDelayed(plugin, t -> task.run(), delayTicks)` |
+| `runTaskTimer` | `getScheduler().runTaskTimer` | `getGlobalRegionScheduler().runAtFixedRate(...)`，返回 `ScheduledTask` |
+
+- **Paper 上语义一致**：GlobalRegionScheduler 即主线程执行，tick 语义与 BukkitScheduler 相同。
+- **Folia 上安全**：runSync 落在全局区域线程（≈主线程）。
+- **证据（已从 jar 字节码核实）**：paper-api 26.1.2 含上述全部 API；MockBukkit 4.115.0
+  已接线 Folia 调度器（`FoliaGlobalRegionScheduler.runAtFixedRate` →
+  `BukkitSchedulerMock.runTaskTimer`），`server.getScheduler().performOneTick()` 照常推进。
+- **⚠ MockBukkit 局限（实测修正）**：MockBukkit 4.115.0 的 `PaperScheduledTask.cancel()`
+  是**未实现的桩**（抛 `UnimplementedOperationException`）。它经 `unmock()` 的
+  `disablePlugins()` 触发时会让静态 mock 泄漏，集成测试连锁「Already mocking」。
+  **对策**：`ScheduledBackupService` / `TeleportBowFlightTracker` 的取消改为**尽力取消**
+  （try/catch RuntimeException + 告警日志）——真实 Paper/Folia 插件禁用时都会自动回收本插件任务，
+  显式取消仅为了及时释放，取消失败不应中断卸载流程。这不是给测试打补丁，而是更稳的卸载行为。
+- `runTaskTimer` 返回类型 `BukkitTask` → `ScheduledTask`，`cancel()` 调用点不变。
+
+### D2 orzmc-api 端口保持最小
+
+`ServerScheduler` 端口（runSync/runAsync/runLater）**不加** runTaskTimer / region 维度——
+orzmc-api 是纯 Java 零 Bukkit 依赖子模块，`ScheduledTask` 是 Paper 类型会破坏纯净性。
+两个定时器均构造注入 `ServerFacade` 具体类，不受影响。
+
+### D3 区域亲和迁移（逐调用点）
+
+- **踢人** → `player.getScheduler().run(plugin, t -> player.kick(...), () -> {})`：
+  - `features/whitelist/WhitelistService.java`（注入 `JavaPlugin`）
+  - `features/maintenance/WorldMaintenanceService.java`（runExclusive 内；`save-off`/`save-on`
+    控制台命令留在 global region 的 dispatchCommand）
+- **传送** → `player.teleportAsync(safe)`：`features/teleport/TeleportBowService.java`
+- **方块/区块** → `Bukkit.getRegionScheduler().run(plugin, world, cx, cz, task)`，
+  任务内只访问该 chunk 区域：
+  - `infra/portal/PortalBuilder.java`（anchor chunk）、`PortalCleaner.java`（3×3 chunk 逐个投递 +
+    实体清理改 `chunk.getEntities()` 限定本 chunk）、`PortalLabelRenderer.java`（anchor chunk）
+  - `features/teleport/ForceLoadedChunkLease.java`（acquire/release 经 region scheduler；
+    `isChunkLoaded`/`getPlayers` 线程安全直接调）
+  - `features/teleport/TeleportBowFlightTracker.java`（已加载分支经 region scheduler；
+    `getChunkAtAsync` 回调本身就在目标 region 线程，安全）
+  - `ExploitHardeningEventService` **无需改**（EntitySpawnEvent 本就在 region 线程，加注释说明）
+- **跨 chunk 方块操作风险**：一期基线按 anchor chunk 投递 + 跨界 warning 降级，
+  二期按 chunk 分解（见 §7 分期）。
+
+### D4 主线程判定替换
+
+`Bukkit.isPrimaryThread()` → `Bukkit.isGlobalTickThread()`：
+- **Paper 主线程**与 **Folia global region 线程**上均为 true；
+- async 线程（LP loadUser 等）上为 false → 回调度器执行，消除 self-schedule + join 死锁。
+- 注：原计划考虑的 `getGlobalRegionScheduler().isOwnedByCurrentThread()` 在 paper-api 26.1.2
+  **不存在**，已改用 `Bukkit.isGlobalTickThread()`（语义等价，编译期核实）。
+
+### D5 runFolia（run-paper 3.1.0）
+
+```kotlin
+runPaper.folia.registerTask {
+    minecraftVersion(debugServerVersion)   // 26.2，Folia 与 Paper 同一版本体系
+    args("--nogui", "--online-mode=false")
+    runDirectory.set(layout.projectDirectory.dir("run-folia"))  // 隔离，不与 run/plugins 共用
+}
+```
+
+- `paper-plugin.yml`：`folia-supported: false` → `true`
+- 运行 `./gradlew runFolia`；清缓存 `./gradlew cleanFoliaCache`
+- `runDirectory` 隔离避免 Folia 尝试加载 `run/plugins` 里的 Vault/EssentialsX/EzShops 等不兼容插件
+- **runServer vs runFolia 结论**：`runServer` 仅能启动 Paper（run-paper 的 platform 固定为 paper），
+  **不支持 Folia**。替代方案评估：
+
+| 方案 | 成本 | 结论 |
+|---|---|---|
+| `runPaper.folia.registerTask`（`runFolia`） | 零额外依赖、插件 jar 自动复制、独立缓存 | ✅ 采用 |
+| 手动下载 Folia jar + 手写启动脚本 | 每次冒烟要手动放 jar/配置 | 性价比低 |
+| Docker 起 Folia | 需要镜像维护 + 端口映射，冒烟改代码要重建 | 性价比低 |
+
+### D6 测试策略（单元/集成测试是否需要单独 Folia 处理）
+
+**单元测试不需要单独 Folia 套件**，三层解释：
+
+1. **单测零改动面**：测试全部 mock 调度门面（`ServerFacade`/`ServerScheduler`），运行时无关；
+   统一切到 Folia 兼容调度器后方法签名不变 → 绝大多数单测不动。只有 `ServerFacadeTest`
+   因实现从 `BukkitScheduler` 换为 `GlobalRegionScheduler`/`AsyncScheduler` 需重写，
+   外加 `MaintenanceModuleTest`/`ScheduledBackupServiceTest`/`TeleportBowFlightTrackerTest`
+   的 `BukkitTask` mock 改 `ScheduledTask`。
+2. **新增「区域亲和语义」单测**（这是 Folia 专属断言，跑普通 JUnit、不需要真实 Folia）：
+   给区域亲和包一层可注入的 `RegionSchedulerProvider`（`run(world, cx, cz, task)`），
+   `verify(provider).run(plugin, world, cx, cz, task)` 断言方块/区块操作投递正确坐标；
+   `mock(Player.getScheduler())` 验证 kick 投递；`verify(player).teleportAsync(...)` 验证传送；
+   Tnt/PlayerEventAggregator 并发单测。
+3. **集成测试（MockBukkit）保持单一套件**：MockBukkit 4.115.0 已把 Folia 调度器路由进内部
+   `BukkitSchedulerMock`，`performOneTick()` 照常推进。**局限需文档化**：MockBukkit 单线程模型
+   无法模拟 region 隔离/跨线程竞态——这类 bug 只能靠第 2 层的调度目标断言 + 真实 Folia 冒烟兜底。
+   （另见 D1 的 `PaperScheduledTask.cancel()` 未实现 → 生产代码尽力取消。）
+
+**真实 Folia 验收**：`./gradlew runFolia` 手动冒烟（启动加载 → 白名单 `$w` → TNT 爆炸 →
+传送弓 → 建门/拆门 → `/orzbackup`），无 `IllegalThreadStateException`/死锁。
+
+### D7 并发安全（Folia 下事件按 region 并发暴露的共享状态）
+
+| 位置 | 改法 |
+|---|---|
+| `TntEventService.pendingAlerts`（HashMap get→put 非原子） | `ConcurrentHashMap` + `compute` |
+| `PlayerEventAggregator.batch`（enqueue/flush 跨线程） | 加 `synchronized` |
+| `ForceLoadedChunkLease.counts` | `ConcurrentHashMap` |
+| `TeleportBowFlightTracker.acquired/pending` | `ConcurrentHashMap.newKeySet()` |
+| `PortalService.interiorTargets` | `ConcurrentHashMap` |
+
+### D8 CI 自动化（是否需要补 Folia 处理）
+
+- 主 `check` 流水线（spotlessCheck → test → integrationTest → jacoco → shadowJar）
+  **不进真实服务器**，保持不变。
+- **新增独立 `folia-smoke` CI job**（Java 25，独立 job 不拖慢主构建）：
+  - 新增 `foliaSmoke` Gradle 自定义任务：用 run-paper 的 folia 下载启动 Folia 无头服务器
+    （`--nogui --noconsole`），安装 shadowJar，轮询日志确认 `Done` + OrzMC 加载标记，
+    发 `stop` 断言干净退出，超时即失败。
+  - 初期若不稳定，job 先 `continue-on-error: true`，稳定后转必须。
+  - 备选：文档化手动 `runFolia` 冒烟清单，CI 保持 serverless。**推荐前者**：真实启动回归
+    价值高（能抓「插件在 Folia 启动即崩溃」这类集成测试测不出的回归）。
+
+---
+
+## 4. PR 序列
+
+| PR | 内容 | 验收 |
+|---|---|---|
+| PR-1 | 调度器门面 + 3 处旁路 + `isGlobalTickThread`；`ScheduledTask` 类型波及的 4 个测试；`docs/folia-migration.md` | `./gradlew check` 全绿 |
+| PR-2 | 实体区域亲和（kick → EntityScheduler、teleportAsync） | 单测 + 集成绿；runFolia 冒烟踢人/传送 |
+| PR-3 | 方块/区块区域亲和（portal / force-load / flight tracker） | 单测 + 集成绿；runFolia 冒烟建门/拆门 |
+| PR-4 | 并发安全（TNT / 聚合 / 租约 / tracker / portal） | `./gradlew check` 绿，无回归 |
+| PR-5 | `folia-supported: true` + `runFolia` + 发布 platforms/loaders + `foliaSmoke` 任务 | `runFolia`/`foliaSmoke` 冒烟通过；发布配置可解析 |
+| PR-6 | 测试补齐（区域亲和语义 + 并发）+ CI `folia-smoke` job + README/features.md 标注 | 覆盖率门禁过；CI 新 job 可执行 |
+
+---
+
+## 5. 验证方式
+
+- 每个 PR：`./gradlew spotlessCheck :test :integrationTest`（根目录 `:` 前缀）
+- PR-5：`./gradlew runFolia` / `foliaSmoke` 真实 Folia 冒烟（开发机手动 + CI 独立 job）
+- PR-6 起：CI `folia-smoke` job 自动跑真实 Folia 启动回归（初期 `continue-on-error`）
+- 回归：`./gradlew runServer` Paper 侧冒烟，确认双运行时功能不退化
+
+---
+
+## 6. 风险与规避
+
+| 风险 | 规避 |
+|---|---|
+| Paper 上 global region 与 BukkitScheduler 行为差异 | Paper 官方实现为主线程执行，tick 语义一致；`runServer` + 集成测试回归兜底 |
+| 跨 chunk 方块操作在 Folia 抛异常 | 一期 anchor chunk + warning 降级，二期按 chunk 分解 |
+| runFolia 复用 `run/plugins` 加载不兼容插件 | `runDirectory` 隔离到 `run-folia/` |
+| Folia 事件按 region 并发竞态 | PR-4 线程安全化 |
+| `runTaskTimer` 返回类型波及测试 | PR-1 内同步改 4 个测试文件，避免中间态不绿 |
+| MockBukkit `PaperScheduledTask.cancel()` 未实现 | 生产代码尽力取消（D1），集成测试不连锁失败 |
+| CI 起真实 Folia 服务器的下载/启动不稳定 | `folia-smoke` 独立 job + 超时保护 + 初期 `continue-on-error`；主 `check` 流水线不受影响 |
+| MockBukkit 无法模拟 region 隔离 | 区域亲和单测断言调度目标 + 真实 Folia 冒烟兜底 |
+
+---
+
+## 7. 分期与后续
+
+- **一期（PR-1 ~ PR-6）**：双运行时可用，功能不退化，发布 Folia loader。
+- **二期（可选）**：portal 跨 chunk 方块操作按 chunk 分解（消除 warning 降级）；
+  单元测试用 `RegionSchedulerProvider` 补全区域亲和断言；`folia-smoke` job 由
+  `continue-on-error` 转必须。

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -383,7 +383,7 @@ public final class FeatureModule implements ServiceModule {
                                         String cmd = ctx.getArgument("cmd", String.class);
                                         ctx.getSource().getSender().sendMessage("debug 已受理（模拟 Bot 入站命令）");
                                         var inbound = botModule.botInboundHandler();
-                                        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+                                        platform.serverFacade().runAsync(() -> {
                                             try {
                                                 inbound.handleMessage(cmd, true, "控制台", env -> {
                                                     if (env != null) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzBaseListener.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzBaseListener.java
@@ -1,12 +1,25 @@
 package com.jokerhub.paper.plugin.orzmc.events;
 
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import org.bukkit.event.Listener;
 
 public class OrzBaseListener implements Listener {
     final OrzMC plugin;
+    private ServerFacade serverFacade;
 
     public OrzBaseListener(OrzMC plugin) {
         this.plugin = plugin;
+    }
+
+    /**
+     * 统一调度门面（Paper/Folia 兼容）。子类一律经 {@code serverFacade().runAsync(...)}
+     * 等走门面，避免旁路直连 {@code plugin.getServer().getScheduler()}（Folia 已移除该 API）。
+     */
+    protected final ServerFacade serverFacade() {
+        if (serverFacade == null) {
+            serverFacade = new ServerFacade(plugin);
+        }
+        return serverFacade;
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzDebugEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzDebugEvent.java
@@ -35,7 +35,7 @@ public class OrzDebugEvent extends OrzBaseListener {
             return;
         }
         String cmd = command.substring(debugCmdPrefix.length()).trim();
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        serverFacade().runAsync(() -> {
             try {
                 inboundHandler.handleMessage(
                         cmd, true, "RCON", env -> plugin.getLogger().info("cmd debug: \n" + env.message()));

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzRankEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzRankEvent.java
@@ -25,7 +25,7 @@ public final class OrzRankEvent extends OrzBaseListener {
         // 异步执行晋升检查：LP loadUser（离线 3s 超时）与 stats 读取都可能较慢，
         // 不能阻塞主线程（PlayerJoinEvent 是主线程事件）。
         // 晋升/降级本身经 LuckPermsPromoter 的 scheduler 回主线程执行 LP 变更，线程安全。
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        serverFacade().runAsync(() -> {
             try {
                 service.checkPromotion(event.getPlayer().getUniqueId());
             } catch (Exception e) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/ScheduledBackupService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/ScheduledBackupService.java
@@ -3,6 +3,7 @@ package com.jokerhub.paper.plugin.orzmc.features.maintenance;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 
 /**
  * 定时自动备份（安全加固 P1-1）。
@@ -39,7 +40,7 @@ public final class ScheduledBackupService {
     /** 当前计划对应的触发分钟数（间隔小时 × 60）。 */
     private long targetMinutes;
 
-    private org.bukkit.scheduler.BukkitTask task;
+    private ScheduledTask task;
 
     public ScheduledBackupService(
             ServerFacade server, TypedConfigProvider configs, WorldMaintenanceService maintenance) {
@@ -53,9 +54,7 @@ public final class ScheduledBackupService {
      * 这样运行中通过 {@code /config reload} 修改间隔/开关也能即时生效。
      */
     public void setup() {
-        if (task != null) {
-            task.cancel();
-        }
+        cancelTask(); // 重设前取消旧任务
         // 强制首个检查点按当前配置重排（插件重载后重新倒计时）
         plannedIntervalHours = 0;
         elapsedMinutes = 0;
@@ -65,8 +64,23 @@ public final class ScheduledBackupService {
 
     /** 取消定时任务（插件卸载时）。 */
     public void tearDown() {
-        if (task != null) {
+        cancelTask();
+    }
+
+    /**
+     * 尽力取消：取消失败不阻塞卸载流程。真实 Paper/Folia 在插件禁用时会自动回收
+     * 本插件全部任务，显式取消仅为及时释放；MockBukkit 的 {@code PaperScheduledTask.cancel()}
+     * 尚未实现（4.115.0），测试环境也靠此防御避免卸载异常。
+     */
+    private void cancelTask() {
+        if (task == null) {
+            return;
+        }
+        try {
             task.cancel();
+        } catch (RuntimeException e) {
+            server.logger().warning("[定时备份] 取消调度任务失败: " + e.getMessage());
+        } finally {
             task = null;
         }
     }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/LuckPermsPromoter.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/LuckPermsPromoter.java
@@ -289,7 +289,10 @@ public final class LuckPermsPromoter implements RankPromoter {
 
     /** 在主线程执行 LP 变更（异步线程时经 scheduler 回主线程）。 */
     private <T> T runSync(Supplier<T> action) {
-        if (Bukkit.isPrimaryThread() || scheduler == null) {
+        // Paper 主线程与 Folia global region 线程都是「同步调度线程」，直接执行；
+        // 异步线程（LP loadUser 等）上则回调度器执行，避免 self-schedule + join 死锁。
+        // （isGlobalTickThread 在 Paper 上等价于主线程判定，Folia 上判定 global region 线程）
+        if (Bukkit.isGlobalTickThread() || scheduler == null) {
             return action.get();
         }
         CompletableFuture<T> done = new CompletableFuture<>();

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTracker.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTracker.java
@@ -1,13 +1,13 @@
 package com.jokerhub.paper.plugin.orzmc.features.teleport;
 
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.util.HashSet;
 import java.util.Set;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 
 /**
@@ -41,7 +41,7 @@ final class TeleportBowFlightTracker {
     private Arrow arrow;
     private Player player;
     private World world;
-    private BukkitTask task;
+    private ScheduledTask task;
     private int ticks;
     private boolean active;
 
@@ -148,10 +148,7 @@ final class TeleportBowFlightTracker {
             return;
         }
         active = false;
-        if (task != null) {
-            task.cancel();
-            task = null;
-        }
+        cancelSafely();
         if (world != null) {
             for (long key : acquired) {
                 lease.release(world, (int) (key >> 32), (int) (key & 0xffffffffL));
@@ -162,6 +159,24 @@ final class TeleportBowFlightTracker {
         arrow = null;
         player = null;
         world = null;
+    }
+
+    /**
+     * 尽力取消跟踪任务：取消失败不阻塞收尾。真实 Paper/Folia 在插件禁用时会自动回收
+     * 本插件全部任务；MockBukkit 的 {@code PaperScheduledTask.cancel()} 尚未实现（4.115.0），
+     * 测试环境也靠此防御避免异常中断 stop()。
+     */
+    private void cancelSafely() {
+        if (task == null) {
+            return;
+        }
+        try {
+            task.cancel();
+        } catch (RuntimeException e) {
+            server.logger().warning("取消传送箭跟踪任务失败: " + e.getMessage());
+        } finally {
+            task = null;
+        }
     }
 
     private static long key(int cx, int cz) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/server/ServerFacade.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/server/ServerFacade.java
@@ -3,6 +3,7 @@ package com.jokerhub.paper.plugin.orzmc.infra.server;
 import com.jokerhub.paper.plugin.orzmc.core.ports.server.ServerAccess;
 import com.jokerhub.paper.plugin.orzmc.core.ports.server.ServerLogger;
 import com.jokerhub.paper.plugin.orzmc.core.ports.server.ServerScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
@@ -40,20 +41,24 @@ public final class ServerFacade implements ServerAccess, ServerLogger, ServerSch
         return new NamespacedKey(plugin, value);
     }
 
+    // Folia 兼容调度器（Paper 与 Folia 单一代码路径）：
+    // - Paper 上 GlobalRegionScheduler 即主线程执行，tick 语义与 BukkitScheduler 一致；
+    // - Folia 上 removed 的 BukkitScheduler 被此 API 取代，runSync 落在全局区域线程（≈主线程）。
     public void runSync(Runnable task) {
-        server().getScheduler().runTask(plugin, task);
+        server().getGlobalRegionScheduler().execute(plugin, task);
     }
 
     public void runAsync(Runnable task) {
-        server().getScheduler().runTaskAsynchronously(plugin, task);
+        server().getAsyncScheduler().runNow(plugin, ignored -> task.run());
     }
 
     public void runLater(Runnable task, long delayTicks) {
-        server().getScheduler().runTaskLater(plugin, task, delayTicks);
+        server().getGlobalRegionScheduler().runDelayed(plugin, ignored -> task.run(), delayTicks);
     }
 
-    public org.bukkit.scheduler.BukkitTask runTaskTimer(Runnable task, long delayTicks, long periodTicks) {
-        return server().getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks);
+    public ScheduledTask runTaskTimer(Runnable task, long delayTicks, long periodTicks) {
+        return server().getGlobalRegionScheduler()
+                .runAtFixedRate(plugin, ignored -> task.run(), delayTicks, periodTicks);
     }
 
     public void executeConsoleCommands(Runnable after, String... consoleCmds) {

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/assembly/MaintenanceModuleTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/assembly/MaintenanceModuleTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
-import org.bukkit.scheduler.BukkitTask;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +36,7 @@ class MaintenanceModuleTest {
         ServerFacade server = mock(ServerFacade.class);
         lenient()
                 .when(server.runTaskTimer(any(Runnable.class), anyLong(), anyLong()))
-                .thenReturn(mock(BukkitTask.class));
+                .thenReturn(mock(ScheduledTask.class));
         lenient().when(platform.serverFacade()).thenReturn(server);
         module = new MaintenanceModule(platform, botModule);
     }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzDebugEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzDebugEventTest.java
@@ -6,9 +6,11 @@ import static org.mockito.Mockito.*;
 import com.jokerhub.paper.plugin.orzmc.OrzMC;
 import com.jokerhub.paper.plugin.orzmc.core.bot.BotInboundHandler;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.function.Consumer;
 import org.bukkit.Server;
 import org.bukkit.event.server.RemoteServerCommandEvent;
-import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -17,6 +19,9 @@ import org.mockito.Mock;
 /**
  * orzdebug RCON 通道测试：游戏内/控制台走 Brigadier executes 直调（FeatureModule），
  * 本类仅监听 RemoteServerCommandEvent（RCON 不走 Brigadier）。
+ *
+ * <p>异步派发经 {@link OrzBaseListener#serverFacade()} 门面（Paper/Folia 兼容），
+ * 因此断言目标是 {@link AsyncScheduler#runNow} 而非 BukkitScheduler。
  */
 class OrzDebugEventTest extends ServiceTestBase {
 
@@ -33,7 +38,7 @@ class OrzDebugEventTest extends ServiceTestBase {
     private Server server;
 
     @Mock
-    private BukkitScheduler scheduler;
+    private AsyncScheduler asyncScheduler;
 
     private OrzDebugEvent listener;
 
@@ -55,13 +60,14 @@ class OrzDebugEventTest extends ServiceTestBase {
     void rconDebugHandler_debugCommand_dispatchesAsync() {
         when(event.getCommand()).thenReturn("orzdebug hello $a");
         when(plugin.getServer()).thenReturn(server);
-        when(server.getScheduler()).thenReturn(scheduler);
+        when(server.getAsyncScheduler()).thenReturn(asyncScheduler);
 
         listener.rconDebugHandler(event);
 
-        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        verify(scheduler).runTaskAsynchronously(eq(plugin), captor.capture());
-        captor.getValue().run();
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<ScheduledTask>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(asyncScheduler).runNow(eq(plugin), captor.capture());
+        captor.getValue().accept(mock(ScheduledTask.class));
         verify(inboundHandler).handleMessage(eq("hello $a"), eq(true), eq("RCON"), any());
     }
 
@@ -69,13 +75,14 @@ class OrzDebugEventTest extends ServiceTestBase {
     void rconDebugHandler_leadingSlash_stripped() {
         when(event.getCommand()).thenReturn("/orzdebug $l");
         when(plugin.getServer()).thenReturn(server);
-        when(server.getScheduler()).thenReturn(scheduler);
+        when(server.getAsyncScheduler()).thenReturn(asyncScheduler);
 
         listener.rconDebugHandler(event);
 
-        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        verify(scheduler).runTaskAsynchronously(eq(plugin), captor.capture());
-        captor.getValue().run();
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<ScheduledTask>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(asyncScheduler).runNow(eq(plugin), captor.capture());
+        captor.getValue().accept(mock(ScheduledTask.class));
         verify(inboundHandler).handleMessage(eq("$l"), eq(true), eq("RCON"), any());
     }
 
@@ -83,13 +90,14 @@ class OrzDebugEventTest extends ServiceTestBase {
     void rconDebugHandler_emptyBody_dispatchesEmpty() {
         when(event.getCommand()).thenReturn("orzdebug   ");
         when(plugin.getServer()).thenReturn(server);
-        when(server.getScheduler()).thenReturn(scheduler);
+        when(server.getAsyncScheduler()).thenReturn(asyncScheduler);
 
         listener.rconDebugHandler(event);
 
-        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        verify(scheduler).runTaskAsynchronously(eq(plugin), captor.capture());
-        captor.getValue().run();
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<ScheduledTask>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(asyncScheduler).runNow(eq(plugin), captor.capture());
+        captor.getValue().accept(mock(ScheduledTask.class));
         verify(inboundHandler).handleMessage(eq(""), eq(true), eq("RCON"), any());
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/ScheduledBackupServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/ScheduledBackupServiceTest.java
@@ -9,7 +9,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
-import org.bukkit.scheduler.BukkitTask;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -17,13 +17,13 @@ class ScheduledBackupServiceTest {
 
     private ServerFacade server;
     private TypedConfigProvider configs;
-    private BukkitTask task;
+    private ScheduledTask task;
 
     @BeforeEach
     void setUp() {
         server = mock(ServerFacade.class);
         configs = mock(TypedConfigProvider.class);
-        task = mock(BukkitTask.class);
+        task = mock(ScheduledTask.class);
         when(server.runTaskTimer(any(Runnable.class), anyLong(), anyLong())).thenReturn(task);
     }
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTrackerTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTrackerTest.java
@@ -5,13 +5,13 @@ import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.util.function.Consumer;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ class TeleportBowFlightTrackerTest extends ServiceTestBase {
 
     private ServerFacade server;
     private ForceLoadedChunkLease lease;
-    private BukkitTask task;
+    private ScheduledTask task;
     private Arrow arrow;
     private Player player;
     private World world;
@@ -35,7 +35,7 @@ class TeleportBowFlightTrackerTest extends ServiceTestBase {
     void setUp() {
         server = mock(ServerFacade.class);
         lease = mock(ForceLoadedChunkLease.class);
-        task = mock(BukkitTask.class);
+        task = mock(ScheduledTask.class);
         when(server.runTaskTimer(any(Runnable.class), anyLong(), anyLong())).thenReturn(task);
 
         arrow = mock(Arrow.class);

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/server/ServerFacadeTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/server/ServerFacadeTest.java
@@ -5,13 +5,16 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade.ConsoleCommandResult;
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Server;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -20,7 +23,8 @@ class ServerFacadeTest {
 
     private JavaPlugin plugin;
     private Server server;
-    private BukkitScheduler scheduler;
+    private GlobalRegionScheduler regionScheduler;
+    private AsyncScheduler asyncScheduler;
     private Logger logger;
     private ServerFacade facade;
 
@@ -28,10 +32,12 @@ class ServerFacadeTest {
     void setUp() {
         plugin = mock(JavaPlugin.class);
         server = mock(Server.class);
-        scheduler = mock(BukkitScheduler.class);
+        regionScheduler = mock(GlobalRegionScheduler.class);
+        asyncScheduler = mock(AsyncScheduler.class);
         logger = mock(Logger.class);
         when(plugin.getServer()).thenReturn(server);
-        when(server.getScheduler()).thenReturn(scheduler);
+        when(server.getGlobalRegionScheduler()).thenReturn(regionScheduler);
+        when(server.getAsyncScheduler()).thenReturn(asyncScheduler);
         when(plugin.getLogger()).thenReturn(logger);
         when(plugin.getName()).thenReturn("orzmc");
         facade = new ServerFacade(plugin);
@@ -56,24 +62,47 @@ class ServerFacadeTest {
     // a running Bukkit server environment (getPluginMeta())
 
     @Test
-    void runSync_delegatesToScheduler() {
+    void runSync_delegatesToGlobalRegionScheduler() {
         Runnable task = mock(Runnable.class);
         facade.runSync(task);
-        verify(scheduler).runTask(plugin, task);
+        verify(regionScheduler).execute(plugin, task);
     }
 
     @Test
-    void runAsync_delegatesToScheduler() {
+    void runAsync_delegatesToAsyncScheduler() {
         Runnable task = mock(Runnable.class);
         facade.runAsync(task);
-        verify(scheduler).runTaskAsynchronously(plugin, task);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<ScheduledTask>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(asyncScheduler).runNow(eq(plugin), captor.capture());
+        captor.getValue().accept(mock(ScheduledTask.class));
+
+        verify(task).run();
     }
 
     @Test
-    void runLater_delegatesToScheduler() {
+    void runLater_delegatesToGlobalRegionScheduler() {
         Runnable task = mock(Runnable.class);
         facade.runLater(task, 30L);
-        verify(scheduler).runTaskLater(plugin, task, 30L);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<ScheduledTask>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(regionScheduler).runDelayed(eq(plugin), captor.capture(), eq(30L));
+        captor.getValue().accept(mock(ScheduledTask.class));
+
+        verify(task).run();
+    }
+
+    @Test
+    void runTaskTimer_delegatesToGlobalRegionScheduler() {
+        Runnable task = mock(Runnable.class);
+        ScheduledTask scheduled = mock(ScheduledTask.class);
+        when(regionScheduler.runAtFixedRate(any(), any(), anyLong(), anyLong())).thenReturn(scheduled);
+
+        assertSame(scheduled, facade.runTaskTimer(task, 1L, 20L));
+
+        verify(regionScheduler).runAtFixedRate(eq(plugin), any(), eq(1L), eq(20L));
     }
 
     @Test
@@ -85,7 +114,7 @@ class ServerFacadeTest {
         facade.executeConsoleCommands(after, "/cmd1", "cmd2");
 
         ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        verify(scheduler).runTask(eq(plugin), captor.capture());
+        verify(regionScheduler).execute(eq(plugin), captor.capture());
 
         Runnable task = captor.getValue();
         task.run();
@@ -103,7 +132,7 @@ class ServerFacadeTest {
         facade.executeConsoleCommands(null, "/cmd");
 
         ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        verify(scheduler).runTask(eq(plugin), captor.capture());
+        verify(regionScheduler).execute(eq(plugin), captor.capture());
 
         Runnable task = captor.getValue();
         task.run();


### PR DESCRIPTION
## 背景
插件当前 `paper-plugin.yml` 声明 `folia-supported: false`，且所有调度经 `ServerFacade` 落到 `Bukkit.getScheduler()`（Folia 已移除）。本 PR 是 Folia 适配 6-PR 计划的第 1 步，统一切换到 Paper/Folia 兼容调度器 API。

## 改动
### 主代码
- **`ServerFacade`** 4 个调度方法改用 `getGlobalRegionScheduler()` / `getAsyncScheduler()`：
  - `runSync` → `execute`；`runAsync` → `runNow`；`runLater` → `runDelayed`；`runTaskTimer` → `runAtFixedRate`（返回 `ScheduledTask`）
  - Paper 上 GlobalRegionScheduler 即主线程，tick 语义一致；Folia 单一代码路径
- **3 处旁路直连改走门面**：`FeatureModule`（/orzdebug）、`OrzRankEvent`、`OrzDebugEvent`（RCON），新增 `OrzBaseListener.serverFacade()` 惰性门面
- **`LuckPermsPromoter`**：`Bukkit.isPrimaryThread()` → `Bukkit.isGlobalTickThread()`（Paper 主线程与 Folia global region 线程均 true，消除 async self-schedule+join 死锁）
- **`ScheduledBackupService` / `TeleportBowFlightTracker`**：`task` 字段改 `ScheduledTask`；取消改**尽力取消**（防御 MockBukkit 4.115.0 `PaperScheduledTask.cancel()` 未实现桩导致的卸载连锁失败——实测发现）

### 测试
- `ServerFacadeTest` 重写为断言 `GlobalRegionScheduler`/`AsyncScheduler` 投递
- `MaintenanceModuleTest`/`ScheduledBackupServiceTest`/`TeleportBowFlightTrackerTest`：`BukkitTask` mock → `ScheduledTask`
- `OrzDebugEventTest`：`BukkitScheduler` → `AsyncScheduler`

### 文档
- 新增 `docs/folia-migration.md`：现状缺口清单 + D1-D8 决策 + runServer vs runFolia 结论 + PR 序列 + 分期风险

## 实测发现（plan 修正）
MockBukkit 4.115.0 的 `PaperScheduledTask.cancel()` 是**未实现桩**，经 `unmock()` 的 `disablePlugins()`（try/finally 之外）触发会让静态 mock 泄漏 → 集成测试连锁 `Already mocking`。对策：生产代码尽力取消（真实 Paper/Folia 插件禁用时会自动回收本插件任务，显式取消失败不应中断卸载）。

## 验收
- [x] `./gradlew spotlessCheck` 绿
- [x] `./gradlew :test` 绿
- [x] `./gradlew :integrationTest` 绿
- [x] `./gradlew check` 绿