### PR TITLE
feat(folia): 实体区域亲和迁移（kick → EntityScheduler、teleportAsync）

### DIFF
--- a/docs/folia-migration.md
+++ b/docs/folia-migration.md
@@ -137,6 +137,13 @@ runPaper.folia.registerTask {
    `BukkitSchedulerMock`，`performOneTick()` 照常推进。**局限需文档化**：MockBukkit 单线程模型
    无法模拟 region 隔离/跨线程竞态——这类 bug 只能靠第 2 层的调度目标断言 + 真实 Folia 冒烟兜底。
    （另见 D1 的 `PaperScheduledTask.cancel()` 未实现 → 生产代码尽力取消。）
+4. **⚠ 注册表相关枚举在普通 JUnit 不可用（实测，PR-2 发现）**：`Material.isSolid()`
+   走 `BlockType.isSolid()`（服务端注册表），无服务器时恒为 false → 无法用 block mock 让
+   `TeleportBowService.findNearestSafe` 走到成功路径；`Sound.<clinit>` 需要完整注册表，
+   引用任意 `Sound` 常量即抛 `ExceptionInInitializerError`。对策：区域亲和语义测试改为
+   **直接调包私有的投递方法**（如 `teleportAndFeedback`），断言 `teleportAsync` +
+   `EntityScheduler.run` 被调用，不执行回调体；踢人验证直接调 `kickInPlayerRegion` 类似。
+   PR-3/PR-6 写 portal/区块相关断言时同样避开 `isSolid()`/`Sound`。
 
 **真实 Folia 验收**：`./gradlew runFolia` 手动冒烟（启动加载 → 白名单 `$w` → TNT 爆炸 →
 传送弓 → 建门/拆门 → `/orzbackup`），无 `IllegalThreadStateException`/死锁。

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -220,7 +220,7 @@ public final class BotCommandService implements BotInboundHandler {
         server.runAsync(() -> {
             try {
                 WhitelistConfig whitelistConfig = configs.whitelist();
-                WhitelistService svc = WhitelistService.defaultImpl();
+                WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
                 int delayTicks = Math.max(0, whitelistConfig.paginationDelayTicks());
                 Integer page = parsePageArg(rawArgs);
                 if (isAdmin) {
@@ -255,7 +255,7 @@ public final class BotCommandService implements BotInboundHandler {
         Set<String> userNames = parseArgs(rawArgs);
         if (!guardWhitelistCommand(cmd, isAdmin, userNames, callback)) return;
         server.runSync(() -> {
-            WhitelistService svc = WhitelistService.defaultImpl();
+            WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
             String message = svc.addPlayers(server.server(), userNames);
             emit(callback, "command_whitelist_add_result", Map.of("message", message), message);
         });
@@ -266,7 +266,7 @@ public final class BotCommandService implements BotInboundHandler {
         Set<String> userNames = parseArgs(rawArgs);
         if (!guardWhitelistCommand(cmd, isAdmin, userNames, callback)) return;
         server.runSync(() -> {
-            WhitelistService svc = WhitelistService.defaultImpl();
+            WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
             String message = svc.removePlayers(server.server(), userNames);
             emit(callback, "command_whitelist_remove_result", Map.of("message", message), message);
         });

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
@@ -211,7 +211,8 @@ public class WorldMaintenanceService {
         server.runSync(() -> {
             startMs = System.currentTimeMillis();
             for (Player p : server.server().getOnlinePlayers()) {
-                p.kick(styles.warn(kickText));
+                // Folia：踢人投递到玩家所在 region 线程；save 命令留在 global region 的 dispatchCommand
+                p.getScheduler().run(server.plugin(), t -> p.kick(styles.warn(kickText)), () -> {});
             }
             OrzUtil.executeConsoleCmd(server, () -> {}, "save-off", "save-all flush");
             server.runAsync(() -> {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowService.java
@@ -220,8 +220,24 @@ public final class TeleportBowService {
             player.sendMessage(texts.logText("目标位置不可站立!").color(styles.colorError()));
             return;
         }
-        player.teleport(safe);
-        player.playSound(player.getLocation(), org.bukkit.Sound.ENTITY_CAT_PURR, 1.0F, 1.0F);
-        player.sendMessage(texts.logText("传送完成!").color(styles.colorSuccess()));
+        teleportAndFeedback(player, safe);
+    }
+
+    /**
+     * Folia：跨 region 传送必须用异步 API；完成回调把音效/提示投递到玩家所属 region 线程。
+     * Paper 上 teleportAsync 在主线程完成、getScheduler() 等价于主线程执行，语义不变。
+     * 包私有便于测试直接验证投递目标。
+     */
+    void teleportAndFeedback(Player player, org.bukkit.Location safe) {
+        player.teleportAsync(safe)
+                .thenRun(() -> player.getScheduler()
+                        .run(
+                                server.plugin(),
+                                t -> {
+                                    player.playSound(
+                                            player.getLocation(), org.bukkit.Sound.ENTITY_CAT_PURR, 1.0F, 1.0F);
+                                    player.sendMessage(texts.logText("传送完成!").color(styles.colorSuccess()));
+                                },
+                                () -> {}));
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/whitelist/WhitelistService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/whitelist/WhitelistService.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public interface WhitelistService {
     List<String> buildWhitelistLines(Server server);
@@ -16,11 +17,18 @@ public interface WhitelistService {
 
     String removePlayers(Server server, Set<String> userNames);
 
-    static WhitelistService defaultImpl() {
-        return new DefaultWhitelistService();
+    static WhitelistService defaultImpl(JavaPlugin plugin) {
+        return new DefaultWhitelistService(plugin);
     }
 
     final class DefaultWhitelistService implements WhitelistService {
+        /** 用于把踢人投递到玩家所属 region 线程（Folia），Paper 上无副作用。 */
+        private final JavaPlugin plugin;
+
+        DefaultWhitelistService(JavaPlugin plugin) {
+            this.plugin = plugin;
+        }
+
         @Override
         public List<String> buildWhitelistLines(Server server) {
             ArrayList<OfflinePlayer> whiteListPlayers = new ArrayList<>(server.getWhitelistedPlayers());
@@ -57,7 +65,7 @@ public interface WhitelistService {
                     p.setWhitelisted(false);
                     Player onlinePlayer = server.getPlayer(p.getUniqueId());
                     if (onlinePlayer != null) {
-                        onlinePlayer.kick();
+                        kickInPlayerRegion(onlinePlayer);
                     }
                 }
             }
@@ -102,7 +110,7 @@ public interface WhitelistService {
                     player.setWhitelisted(false);
                     Player onlinePlayer = server.getPlayer(player.getUniqueId());
                     if (onlinePlayer != null) {
-                        onlinePlayer.kick();
+                        kickInPlayerRegion(onlinePlayer);
                     }
                 }
             }
@@ -125,6 +133,15 @@ public interface WhitelistService {
                         notRemoved.stream().sorted().map(name -> "✘ " + name).collect(Collectors.joining("\n")));
             }
             return message.toString();
+        }
+
+        /**
+         * Folia：踢人必须投递到玩家所在 region 线程，直接调用会抛「not the correct region」异常。
+         * 经 {@link Player#getScheduler()} 把 {@code kick()} 放到玩家自己的 region 执行；
+         * Paper 上等价于主线程下 tick 执行，语义不变。
+         */
+        private void kickInPlayerRegion(Player onlinePlayer) {
+            onlinePlayer.getScheduler().run(plugin, t -> onlinePlayer.kick(), () -> {});
         }
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowServiceTest.java
@@ -8,6 +8,10 @@ import com.jokerhub.paper.plugin.orzmc.infra.core.OrzConstants;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -26,6 +30,7 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +42,7 @@ class TeleportBowServiceTest extends ServiceTestBase {
     private ServerFacade serverFacade;
     private OrzTextStyles styles;
     private TeleportBowService service;
+    private JavaPlugin plugin;
 
     private NamespacedKey tpBowKey;
     private MockedStatic<Bukkit> bukkitMock;
@@ -46,6 +52,8 @@ class TeleportBowServiceTest extends ServiceTestBase {
         serverFacade = mock(ServerFacade.class);
         styles = mock(OrzTextStyles.class);
         tpBowKey = mock(NamespacedKey.class);
+        plugin = mock(JavaPlugin.class);
+        when(serverFacade.plugin()).thenReturn(plugin);
 
         ItemFactory itemFactory = mock(ItemFactory.class);
         ItemMeta itemMeta = mock(ItemMeta.class);
@@ -280,5 +288,24 @@ class TeleportBowServiceTest extends ServiceTestBase {
         assertTrue(PlainTextComponentSerializer.plainText()
                 .serialize(captor.getValue())
                 .contains("跨世界"));
+    }
+
+    @Test
+    void teleportAndFeedback_teleportsAsync_andFeedbackInPlayerRegion() {
+        Player player = mock(Player.class);
+        Location safe = mock(Location.class);
+        EntityScheduler entityScheduler = mock(EntityScheduler.class);
+        when(player.teleportAsync(any(Location.class))).thenReturn(CompletableFuture.completedFuture(true));
+        when(player.getScheduler()).thenReturn(entityScheduler);
+
+        service.teleportAndFeedback(player, safe);
+
+        // Folia 区域亲和：跨 region 传送必须用异步 API（而非同步 teleport）
+        verify(player).teleportAsync(safe);
+        // 完成回调把音效/提示投递到玩家 region 线程。
+        // 注意：不执行回调体——Sound 枚举静态初始化依赖完整注册表，普通 JUnit 环境不可用。
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<ScheduledTask>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(entityScheduler).run(eq(plugin), captor.capture(), any(Runnable.class));
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/whitelist/WhitelistServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/whitelist/WhitelistServiceTest.java
@@ -3,13 +3,20 @@ package com.jokerhub.paper.plugin.orzmc.features.whitelist;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class WhitelistServiceTest {
 
@@ -17,10 +24,12 @@ class WhitelistServiceTest {
     private Server server;
     private OfflinePlayer player1;
     private OfflinePlayer player2;
+    private JavaPlugin plugin;
 
     @BeforeEach
     void setUp() {
-        service = WhitelistService.defaultImpl();
+        plugin = mock(JavaPlugin.class);
+        service = WhitelistService.defaultImpl(plugin);
         server = mock(Server.class);
         player1 = mock(OfflinePlayer.class);
         player2 = mock(OfflinePlayer.class);
@@ -76,5 +85,47 @@ class WhitelistServiceTest {
 
         assertTrue(removed.contains("Bob"), "removed: " + removed);
         verify(player2).setWhitelisted(false);
+    }
+
+    @Test
+    void cleanupInactivePlayers_kicksOnlinePlayerInPlayerRegion() {
+        when(player2.getLastSeen()).thenReturn(0L); // never seen → 过期
+        when(player2.isWhitelisted()).thenReturn(true);
+        when(player2.getName()).thenReturn("Bob");
+        when(server.getWhitelistedPlayers()).thenReturn(Set.of(player2));
+        Player online = mock(Player.class);
+        when(server.getPlayer(player2.getUniqueId())).thenReturn(online);
+        EntityScheduler entityScheduler = mock(EntityScheduler.class);
+        when(online.getScheduler()).thenReturn(entityScheduler);
+
+        service.cleanupInactivePlayers(server, 30);
+
+        // Folia 区域亲和：kick 必须经 EntityScheduler 投递到玩家 region 线程
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<ScheduledTask>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(entityScheduler).run(eq(plugin), captor.capture(), any(Runnable.class));
+        captor.getValue().accept(mock(ScheduledTask.class));
+        verify(online).kick();
+    }
+
+    @Test
+    void removePlayers_kicksOnlinePlayerInPlayerRegion() {
+        when(player1.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(player1.getName()).thenReturn("Alice");
+        when(player1.isWhitelisted()).thenReturn(true);
+        when(server.getOfflinePlayer("Alice")).thenReturn(player1);
+        when(server.getWhitelistedPlayers()).thenReturn(Set.of(player1));
+        Player online = mock(Player.class);
+        when(server.getPlayer(player1.getUniqueId())).thenReturn(online);
+        EntityScheduler entityScheduler = mock(EntityScheduler.class);
+        when(online.getScheduler()).thenReturn(entityScheduler);
+
+        service.removePlayers(server, Set.of("Alice"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<ScheduledTask>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(entityScheduler).run(eq(plugin), captor.capture(), any(Runnable.class));
+        captor.getValue().accept(mock(ScheduledTask.class));
+        verify(online).kick();
     }
 }


### PR DESCRIPTION
## 背景
Folia 适配 PR-2（见 docs/folia-migration.md D3）：实体操作（踢人/传送）在 region 线程模型下必须投递到实体所属 region，直接跨 region 调用会抛「not the correct region」异常。

## 改动
- **WhitelistService**：`defaultImpl(JavaPlugin)` 注入插件；新增 `kickInPlayerRegion()`，把 `onlinePlayer.kick()` 经 `Player.getScheduler().run(...)` 投递到玩家 region 线程（cleanupInactivePlayers / removePlayers 两处）
- **BotCommandService**：3 处 `WhitelistService.defaultImpl()` 调用点传入 `server.plugin()`
- **WorldMaintenanceService.runExclusive**：踢人改经 entity scheduler；`save-off`/`save-all flush`/`save-on` 控制台命令留在 global region 的 dispatchCommand
- **TeleportBowService**：`player.teleport(safe)` → `teleportAsync`，完成回调把音效/提示投递到玩家 region 线程（抽取包私有 `teleportAndFeedback()`）

Paper 上语义不变：`getScheduler().run` 即主线程下 tick 执行，`teleportAsync` 在主线程完成。

## 测试
- WhitelistServiceTest：新增 2 个「kick 经 EntityScheduler 投递」断言（捕获 Consumer<ScheduledTask> 并执行验证 kick 生效）
- TeleportBowServiceTest：新增 `teleportAndFeedback` 直接断言 `teleportAsync` + `EntityScheduler.run` 投递目标
- 注：`Sound.\<clinit\>` 依赖完整注册表、`Material.isSolid()` 依赖服务端注册表，普通 JUnit 不可用 → 测试不执行回调体、不走 `findNearestSafe` 成功路径（已记入 docs/folia-migration.md D6）

## 验收
- [x] `./gradlew check` 全绿（spotless + test + integrationTest + jacoco + shadowJar）
- [ ] runFolia 冒烟踢人/传送（PR-5 配置 runFolia 后验证）