### PR TITLE
feat(folia): 方块/区块操作区域亲和（Portal + ForceLoad 经 RegionScheduler 投递）

### DIFF
--- a/docs/folia-migration.md
+++ b/docs/folia-migration.md
@@ -88,6 +88,18 @@ orzmc-api 是纯 Java 零 Bukkit 依赖子模块，`ScheduledTask` 是 Paper 类
   - `ExploitHardeningEventService` **无需改**（EntitySpawnEvent 本就在 region 线程，加注释说明）
 - **跨 chunk 方块操作风险**：一期基线按 anchor chunk 投递 + 跨界 warning 降级，
   二期按 chunk 分解（见 §7 分期）。
+- **PR-3 落地情况（2026-08，已合并）**：抽象 `RegionSchedulerProvider`（`run(world, cx, cz, task)`，
+  `@FunctionalInterface`）包住 `Bukkit.getRegionScheduler().execute(plugin, w, cx, cz, task)`，
+  生产注入（`PortalModule`/`TeleportBowService` 传 `new BukkitRegionSchedulerProvider(plugin)`），
+  测试注入 inline（同步直跑）或 capture（记录投递坐标）实现：
+  - `PortalCleaner.clear` 改为**按足迹覆盖的 chunk 逐个投递**（只投递与传送门足迹相交的 chunk，
+    避免无谓加载/生成），方块清理在每个 chunk 的 region 线程内先 `getChunkAt` 再按足迹交集过滤；
+    实体清理抽成共享的 `ArmorStandCleanup`（3×3 chunk，`isChunkLoaded` 守卫 + `chunk.getEntities()`
+    限定本 chunk + 与旧 `getNearbyEntities` 等价的立方体范围过滤，供 Cleaner 与 LabelRenderer 复用）。
+  - `PortalLabelRenderer.spawnLabel/placeInfoSign` 投递到 anchor chunk（`cx>>4, cz>>4`）；
+  - `ForceLoadedChunkLease.acquire/release` 计数与 force-load/unload 全部投递到所属 chunk 的
+    region 线程（同一 chunk 的 acquire/release 经 region FIFO 天然串行）；
+  - `PortalBuilder.build` 保持同步（玩家命令所在 region 线程内即可），仅对跨 chunk 足迹记 warning 降级。
 
 ### D4 主线程判定替换
 
@@ -144,19 +156,26 @@ runPaper.folia.registerTask {
    **直接调包私有的投递方法**（如 `teleportAndFeedback`），断言 `teleportAsync` +
    `EntityScheduler.run` 被调用，不执行回调体；踢人验证直接调 `kickInPlayerRegion` 类似。
    PR-3/PR-6 写 portal/区块相关断言时同样避开 `isSolid()`/`Sound`。
+5. **⚠ Mockito 对 chunk/array 的坑（实测，PR-3 发现）**：`Chunk.getEntities()` 返回 `Entity[]`
+   而非 `List`（编译期注意）；且本仓库 Mockito 版本的 `ReturnsEmptyValues` **不会**为数组类型
+   返回空数组（返回 null）→ 生产代码需对 `chunk.getEntities()` 判空防御，mock 侧要
+   `thenReturn(new Entity[]{...})` 显式造。另 **「最后匹配的 stub 胜出」**：`when(world.getChunkAt(anyInt(), anyInt()))`
+   的泛化 stub 若注册在 `when(world.getChunkAt(0, 0))` 之后会遮蔽具体 stub → 必须**先泛化后具体**。
+   `RegionSchedulerProvider` 用 capture 实现（记录 `{w, cx, cz}` 并选择同步/不执行任务体）
+   即可在普通 JUnit 中断言「方块/区块操作投递到正确 chunk」。
 
 **真实 Folia 验收**：`./gradlew runFolia` 手动冒烟（启动加载 → 白名单 `$w` → TNT 爆炸 →
 传送弓 → 建门/拆门 → `/orzbackup`），无 `IllegalThreadStateException`/死锁。
 
 ### D7 并发安全（Folia 下事件按 region 并发暴露的共享状态）
 
-| 位置 | 改法 |
-|---|---|
-| `TntEventService.pendingAlerts`（HashMap get→put 非原子） | `ConcurrentHashMap` + `compute` |
-| `PlayerEventAggregator.batch`（enqueue/flush 跨线程） | 加 `synchronized` |
-| `ForceLoadedChunkLease.counts` | `ConcurrentHashMap` |
-| `TeleportBowFlightTracker.acquired/pending` | `ConcurrentHashMap.newKeySet()` |
-| `PortalService.interiorTargets` | `ConcurrentHashMap` |
+| 位置 | 改法 | 落地 |
+|---|---|---|
+| `TntEventService.pendingAlerts`（HashMap get→put 非原子） | `ConcurrentHashMap` + `compute` | PR-4 |
+| `PlayerEventAggregator.batch`（enqueue/flush 跨线程） | 加 `synchronized` | PR-4 |
+| `ForceLoadedChunkLease.counts` | `ConcurrentHashMap` | **PR-3 提前落地**（region 投递使跨 region 读写真实化） |
+| `TeleportBowFlightTracker.acquired/pending` | `ConcurrentHashMap.newKeySet()` | PR-4 |
+| `PortalService.interiorTargets` | `ConcurrentHashMap` | **PR-3 提前落地**（同上，含 `portalCenters`） |
 
 ### D8 CI 自动化（是否需要补 Folia 处理）
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/PortalModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/PortalModule.java
@@ -2,6 +2,7 @@ package com.jokerhub.paper.plugin.orzmc.assembly;
 
 import com.jokerhub.paper.plugin.orzmc.core.ports.portal.PortalPort;
 import com.jokerhub.paper.plugin.orzmc.infra.portal.PortalService;
+import com.jokerhub.paper.plugin.orzmc.infra.server.BukkitRegionSchedulerProvider;
 
 /**
  * 传送门模块。
@@ -13,7 +14,10 @@ public final class PortalModule implements ServiceModule {
     private final PortalService portalService;
 
     public PortalModule(PlatformModule platform) {
-        this.portalService = new PortalService(platform.configService());
+        // Folia：方块/标签操作经 region scheduler 投递到目标 chunk 的 region 线程
+        this.portalService = new PortalService(
+                platform.configService(),
+                new BukkitRegionSchedulerProvider(platform.serverFacade().plugin()));
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/ForceLoadedChunkLease.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/ForceLoadedChunkLease.java
@@ -1,7 +1,8 @@
 package com.jokerhub.paper.plugin.orzmc.features.teleport;
 
-import java.util.HashMap;
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -17,31 +18,40 @@ import org.bukkit.entity.Player;
  * <p>最后一个引用释放后主动卸载区块（立即回收内存，不必等 unload 计时），
  * 但仅卸载「由本注册表 force-load」且「无玩家在内」的区块：
  * 既不会撤销其他插件持有的 force-load，也不会把玩家脚下区块卸掉。</p>
+ *
+ * <p>Folia：force-load/unload 是区块操作，必须投递到该区块所属的 region 线程执行；
+ * 同一区块的 acquire/release 经 region 队列天然串行，计数更新因此被逐区块串行化。
+ * Paper 上 region 调度即主线程执行，语义不变。</p>
  */
 final class ForceLoadedChunkLease {
 
-    private final Map<World, Map<Long, LeaseRef>> counts = new HashMap<>();
+    private final RegionSchedulerProvider regionScheduler;
+    private final Map<World, Map<Long, LeaseRef>> counts = new ConcurrentHashMap<>();
+
+    ForceLoadedChunkLease(RegionSchedulerProvider regionScheduler) {
+        this.regionScheduler = regionScheduler;
+    }
 
     /**
      * 持有一个区块的 force-load 引用。计数 0→1 时仅在区块原本未被 force-load 时
      * 才真正 force-load（不覆盖其他插件已有的 force-load），并记录是否需要我们在释放时清除。
-     *
-     * <p>仅应在主线程调用（tracker tick / 异步加载回调均在主线程）。</p>
      */
     void acquire(World world, int cx, int cz) {
-        Map<Long, LeaseRef> perWorld = counts.computeIfAbsent(world, w -> new HashMap<>());
-        long key = key(cx, cz);
-        LeaseRef ref = perWorld.get(key);
-        if (ref == null) {
-            Chunk chunk = world.getChunkAt(cx, cz);
-            boolean alreadyForced = chunk.isForceLoaded();
-            if (!alreadyForced) {
-                chunk.setForceLoaded(true);
+        regionScheduler.run(world, cx, cz, () -> {
+            Map<Long, LeaseRef> perWorld = counts.computeIfAbsent(world, w -> new ConcurrentHashMap<>());
+            long key = key(cx, cz);
+            LeaseRef ref = perWorld.get(key);
+            if (ref == null) {
+                Chunk chunk = world.getChunkAt(cx, cz);
+                boolean alreadyForced = chunk.isForceLoaded();
+                if (!alreadyForced) {
+                    chunk.setForceLoaded(true);
+                }
+                perWorld.put(key, new LeaseRef(1, !alreadyForced));
+            } else {
+                ref.refs++;
             }
-            perWorld.put(key, new LeaseRef(1, !alreadyForced));
-        } else {
-            ref.refs++;
-        }
+        });
     }
 
     /**
@@ -49,31 +59,33 @@ final class ForceLoadedChunkLease {
      * 随后在无玩家在内时主动 {@code unloadChunk} 回收内存（已卸载则跳过，避免 {@code getChunkAt} 重新加载）。
      */
     void release(World world, int cx, int cz) {
-        Map<Long, LeaseRef> perWorld = counts.get(world);
-        if (perWorld == null) {
-            return;
-        }
-        long key = key(cx, cz);
-        LeaseRef ref = perWorld.get(key);
-        if (ref == null || ref.refs <= 0) {
-            return;
-        }
-        if (ref.refs == 1) {
-            if (world.isChunkLoaded(cx, cz)) {
-                if (ref.weForced) {
-                    world.getChunkAt(cx, cz).setForceLoaded(false);
-                    if (noPlayerInChunk(world, cx, cz)) {
-                        world.unloadChunk(cx, cz, true);
+        regionScheduler.run(world, cx, cz, () -> {
+            Map<Long, LeaseRef> perWorld = counts.get(world);
+            if (perWorld == null) {
+                return;
+            }
+            long key = key(cx, cz);
+            LeaseRef ref = perWorld.get(key);
+            if (ref == null || ref.refs <= 0) {
+                return;
+            }
+            if (ref.refs == 1) {
+                if (world.isChunkLoaded(cx, cz)) {
+                    if (ref.weForced) {
+                        world.getChunkAt(cx, cz).setForceLoaded(false);
+                        if (noPlayerInChunk(world, cx, cz)) {
+                            world.unloadChunk(cx, cz, true);
+                        }
                     }
                 }
+                perWorld.remove(key);
+                if (perWorld.isEmpty()) {
+                    counts.remove(world);
+                }
+            } else {
+                ref.refs--;
             }
-            perWorld.remove(key);
-            if (perWorld.isEmpty()) {
-                counts.remove(world);
-            }
-        } else {
-            ref.refs--;
-        }
+        });
     }
 
     /** 区块内是否没有在线玩家：有玩家则不主动卸载，避免把玩家脚下区块卸掉造成回弹/加载屏。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTracker.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTracker.java
@@ -127,6 +127,8 @@ final class TeleportBowFlightTracker {
         if (acquired.contains(key) || pending.contains(key)) {
             return;
         }
+        // Folia：force-load 投递由 lease 内部经 region scheduler 转到目标 chunk 的 region 线程；
+        // 本线程（tracker tick 所在 region）只维护乐观的 acquired 集合，不触碰区块。
         if (world.isChunkLoaded(cx, cz)) {
             lease.acquire(world, cx, cz);
             acquired.add(key);

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowService.java
@@ -1,6 +1,7 @@
 package com.jokerhub.paper.plugin.orzmc.features.teleport;
 
 import com.jokerhub.paper.plugin.orzmc.infra.core.OrzConstants;
+import com.jokerhub.paper.plugin.orzmc.infra.server.BukkitRegionSchedulerProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import net.kyori.adventure.text.Component;
@@ -19,13 +20,15 @@ public final class TeleportBowService {
     private final OrzTextStyles styles;
     private final TeleportBowTexts texts;
     private final NamespacedKey keyTpBow;
-    private final ForceLoadedChunkLease chunkLease = new ForceLoadedChunkLease();
+    private final ForceLoadedChunkLease chunkLease;
 
     public TeleportBowService(ServerFacade server, OrzTextStyles styles) {
         this.server = server;
         this.styles = styles;
         this.texts = new TeleportBowTexts(styles);
         this.keyTpBow = server.key(OrzConstants.TPBOW_KEY);
+        // Folia：force-load 是区块操作，经 region scheduler 投递到目标 chunk 的 region 线程
+        this.chunkLease = new ForceLoadedChunkLease(new BukkitRegionSchedulerProvider(server.plugin()));
     }
 
     public TextComponent prefix() {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/ArmorStandCleanup.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/ArmorStandCleanup.java
@@ -1,0 +1,62 @@
+package com.jokerhub.paper.plugin.orzmc.infra.portal;
+
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+
+/**
+ * 按区块扫描清理传送门附近的装甲架标签。
+ *
+ * <p>Folia 下 {@code getNearbyEntities} 只能返回当前 region 内的实体，跨区块的标签会漏掉；
+ * 因此改为以中心所在 chunk 为中心的 3×3 chunk 逐个投递到各 chunk 的 region 线程，
+ * 用 {@code chunk.getEntities()} 限定本 chunk，再按与原 {@code getNearbyEntities} 一致的
+ * 立方体范围过滤。Paper 上 region 调度即主线程执行，行为不变。</p>
+ */
+final class ArmorStandCleanup {
+
+    private ArmorStandCleanup() {}
+
+    /** 移除中心 {@code (cx+range)} 立方体内的、名称匹配 {@code target} 或含「跨服传送」的装甲架。 */
+    static void removeMatchingInChunks(
+            World world, Location center, double range, String target, RegionSchedulerProvider regionScheduler) {
+        int ccx = center.getBlockX() >> 4;
+        int ccz = center.getBlockZ() >> 4;
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                int cx = ccx + dx;
+                int cz = ccz + dz;
+                regionScheduler.run(world, cx, cz, () -> {
+                    if (!world.isChunkLoaded(cx, cz)) {
+                        return; // 不主动加载区块仅为了找标签
+                    }
+                    Entity[] entities = world.getChunkAt(cx, cz).getEntities();
+                    if (entities == null) {
+                        return; // 防御：真实 Bukkit 恒非 null，仅 mock 环境可能为 null
+                    }
+                    for (Entity e : entities) {
+                        if (e instanceof ArmorStand as && withinRange(e.getLocation(), center, range)) {
+                            String plain = as.customName() == null
+                                    ? ""
+                                    : PlainTextComponentSerializer.plainText().serialize(as.customName());
+                            if (!plain.isEmpty() && (plain.contains(target) || plain.contains("跨服传送"))) {
+                                e.remove();
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    private static boolean withinRange(Location loc, Location center, double range) {
+        if (loc == null) {
+            return false;
+        }
+        return Math.abs(loc.getX() - center.getX()) <= range
+                && Math.abs(loc.getY() - center.getY()) <= range
+                && Math.abs(loc.getZ() - center.getZ()) <= range;
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalBuilder.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalBuilder.java
@@ -1,6 +1,7 @@
 package com.jokerhub.paper.plugin.orzmc.infra.portal;
 
 import java.util.Map;
+import java.util.logging.Logger;
 import org.bukkit.Axis;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -14,6 +15,10 @@ import org.bukkit.util.Vector;
  * 传送门方块构建器。
  *
  * <p>负责检测合适位置、放置黑曜石框架和下界传送门方块、计算方向。</p>
+ *
+ * <p>Folia：build 由玩家命令触发，运行在玩家所属 region 线程，方块读写在 anchor chunk
+ * （传送门主体所在 chunk）内即可直接执行。框架/底座沿轴向宽 6 格，若跨越 chunk 边界
+ * 二期需按区块分解（一期仅记录 warning 降级）。</p>
  */
 public final class PortalBuilder {
 
@@ -22,9 +27,11 @@ public final class PortalBuilder {
     private static final int MAX_ATTEMPTS = 16;
 
     private final Map<String, String> interiorTargets;
+    private final Logger logger;
 
-    public PortalBuilder(Map<String, String> interiorTargets) {
+    public PortalBuilder(Map<String, String> interiorTargets, Logger logger) {
         this.interiorTargets = interiorTargets;
+        this.logger = logger;
     }
 
     /**
@@ -44,6 +51,7 @@ public final class PortalBuilder {
         if (baseY > maxY) baseY = Math.max(2, maxY);
 
         baseY = findClearSpace(world, baseX, baseY, baseZ, axisX, maxY);
+        warnIfCrossesChunkBoundary(world, baseX, baseZ, axisX);
         placeFrame(world, baseX, baseY, baseZ, axisX, target);
         placePad(world, baseX, baseY, baseZ, axisX);
 
@@ -99,6 +107,21 @@ public final class PortalBuilder {
                     interiorTargets.put(keyPrefix + x + ":" + y + ":" + z, target);
                 }
             }
+        }
+    }
+
+    /**
+     * 一期降级：传送门足迹沿轴向宽 6 格，若跨 chunk 边界，Folia 下相邻 chunk 的方块写入
+     * 需要在各自 region 执行（二期按区块分解）；本方法仅记录 warning，不阻塞 Paper 侧。
+     */
+    private void warnIfCrossesChunkBoundary(World world, int baseX, int baseZ, boolean axisX) {
+        int c0x = axisX ? baseX >> 4 : (baseX - 1) >> 4;
+        int c1x = axisX ? baseX >> 4 : (baseX + FRAME_WIDTH) >> 4;
+        int c0z = axisX ? (baseZ - 1) >> 4 : baseZ >> 4;
+        int c1z = axisX ? (baseZ + FRAME_WIDTH) >> 4 : baseZ >> 4;
+        if (c0x != c1x || c0z != c1z) {
+            logger.warning(
+                    "传送门跨越 chunk 边界（" + c0x + "," + c0z + " .. " + c1x + "," + c1z + "），Folia 下需按区块分解后才能在跨界处正确放置");
         }
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalCleaner.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalCleaner.java
@@ -1,34 +1,38 @@
 package com.jokerhub.paper.plugin.orzmc.infra.portal;
 
 import com.jokerhub.paper.plugin.orzmc.core.ports.portal.WorldProvider;
-import java.util.Collection;
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
 import java.util.logging.Logger;
-import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Axis;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.Entity;
 
 /**
  * 传送门方块和标签清理器。
  *
  * <p>负责在传送门移除时清理黑曜石框架、下界传送门方块和附近的装甲架标签。</p>
+ *
+ * <p>Folia：方块写入与实体遍历都是区块级操作，必须投递到所属 chunk 的 region 线程。
+ * 传送门足迹跨至多 4 个 chunk，按 3×3 chunk 网格逐个投递、任务内只访问该 chunk 区域；
+ * 实体清理改用 {@code chunk.getEntities()} 限定本 chunk（Folia 下 {@code getNearbyEntities}
+ * 只能看到当前 region 的实体，会漏掉相邻 chunk 的标签）。Paper 上 region 调度即主线程执行。</p>
  */
 public final class PortalCleaner {
 
     private static final int FRAME_WIDTH = 4;
     private static final int FRAME_HEIGHT = 5;
-    private static final double LABEL_SEARCH_RANGE = 2.5;
+    private static final double LABEL_SEARCH_RANGE = 3.0;
 
     private final WorldProvider worldProvider;
     private final Logger logger;
+    private final RegionSchedulerProvider regionScheduler;
 
-    public PortalCleaner(WorldProvider worldProvider, Logger logger) {
+    public PortalCleaner(WorldProvider worldProvider, Logger logger, RegionSchedulerProvider regionScheduler) {
         this.worldProvider = worldProvider;
         this.logger = logger;
+        this.regionScheduler = regionScheduler;
     }
 
     /**
@@ -42,69 +46,79 @@ public final class PortalCleaner {
             logger.warning("clearPortalBlocks: 世界 " + def.world() + " 不存在，跳过");
             return;
         }
-        preloadChunks(w, def);
-        clearBlocks(w, def);
-        clearNearbyLabels(w, def);
+        clearBlocksPerChunk(w, def);
+        clearNearbyLabelsPerChunk(w, def);
     }
 
-    private void preloadChunks(World w, PortalService.PortalDef def) {
+    /** 只向足迹实际跨越的 chunk 逐个投递方块清理（避免生成无关区块）。 */
+    private void clearBlocksPerChunk(World w, PortalService.PortalDef def) {
+        int cx0, cx1, cz0, cz1;
         if (def.axis() == Axis.X) {
-            w.getChunkAt(def.cx() >> 4, (def.cz() - 1) >> 4);
-            w.getChunkAt(def.cx() >> 4, def.cz() >> 4);
-            w.getChunkAt(def.cx() >> 4, (def.cz() + 1) >> 4);
+            cx0 = (def.cx() - 2) >> 4;
+            cx1 = (def.cx() + 3) >> 4;
+            cz0 = (def.cz() - 1) >> 4;
+            cz1 = (def.cz() + 1) >> 4;
         } else {
-            w.getChunkAt((def.cx() - 1) >> 4, def.cz() >> 4);
-            w.getChunkAt(def.cx() >> 4, def.cz() >> 4);
-            w.getChunkAt((def.cx() + 1) >> 4, def.cz() >> 4);
+            cx0 = (def.cx() - 1) >> 4;
+            cx1 = (def.cx() + 1) >> 4;
+            cz0 = (def.cz() - 2) >> 4;
+            cz1 = (def.cz() + 3) >> 4;
+        }
+        for (int cx = cx0; cx <= cx1; cx++) {
+            for (int cz = cz0; cz <= cz1; cz++) {
+                final int fx = cx;
+                final int fz = cz;
+                regionScheduler.run(w, cx, cz, () -> clearBlocksInChunk(w, def, fx, fz));
+            }
         }
     }
 
-    private void clearBlocks(World w, PortalService.PortalDef def) {
+    /** 只清理落在 (ccx, ccz) 区块内的传送门足迹方块；先加载区块保证 getBlockAt 生效。 */
+    private void clearBlocksInChunk(World w, PortalService.PortalDef def, int ccx, int ccz) {
+        w.getChunkAt(ccx, ccz);
+        int minX = ccx << 4;
+        int maxX = minX + 15;
+        int minZ = ccz << 4;
+        int maxZ = minZ + 15;
         int baseY = def.cy() - 2;
-        if (def.axis() == Axis.X) {
-            int z = def.cz();
-            int xBase = def.cx() - 1;
-            for (int i = -1; i <= FRAME_WIDTH; i++) {
-                for (int j = -2; j <= FRAME_HEIGHT; j++) {
-                    removeIfPortalBlock(w.getBlockAt(xBase + i, baseY + j, z));
+        // 足迹：轴 X → x∈[cx-2,cx+3] z∈[cz-1,cz+1]；轴 Z → z∈[cz-2,cz+3] x∈[cx-1,cx+1]；y∈[cy-4,cy+3]
+        int runStart = def.axis() == Axis.X ? def.cz() - 1 : def.cx() - 1;
+        int runEnd = def.axis() == Axis.X ? def.cz() + 1 : def.cx() + 1;
+        for (int i = -1; i <= FRAME_WIDTH; i++) {
+            for (int j = -2; j <= FRAME_HEIGHT; j++) {
+                int y = baseY + j;
+                int along = def.axis() == Axis.X ? def.cx() - 1 + i : def.cz() - 1 + i;
+                boolean inAlongChunk;
+                if (def.axis() == Axis.X) {
+                    inAlongChunk = along >= minX && along <= maxX;
+                } else {
+                    inAlongChunk = along >= minZ && along <= maxZ;
                 }
-            }
-            for (int i = -1; i <= FRAME_WIDTH; i++) {
-                for (int j = -2; j <= FRAME_HEIGHT; j++) {
-                    removeIfPortalBlock(w.getBlockAt(xBase + i, baseY + j, z + 1));
-                    removeIfPortalBlock(w.getBlockAt(xBase + i, baseY + j, z - 1));
+                if (!inAlongChunk) {
+                    continue;
                 }
-            }
-        } else {
-            int x = def.cx();
-            int zBase = def.cz() - 1;
-            for (int i = -1; i <= FRAME_WIDTH; i++) {
-                for (int j = -2; j <= FRAME_HEIGHT; j++) {
-                    removeIfPortalBlock(w.getBlockAt(x, baseY + j, zBase + i));
-                }
-            }
-            for (int i = -1; i <= FRAME_WIDTH; i++) {
-                for (int j = -2; j <= FRAME_HEIGHT; j++) {
-                    removeIfPortalBlock(w.getBlockAt(x + 1, baseY + j, zBase + i));
-                    removeIfPortalBlock(w.getBlockAt(x - 1, baseY + j, zBase + i));
+                for (int r = runStart; r <= runEnd; r++) {
+                    int x;
+                    int z;
+                    if (def.axis() == Axis.X) {
+                        x = along;
+                        z = r;
+                    } else {
+                        x = r;
+                        z = along;
+                    }
+                    if (x >= minX && x <= maxX && z >= minZ && z <= maxZ) {
+                        removeIfPortalBlock(w.getBlockAt(x, y, z));
+                    }
                 }
             }
         }
     }
 
-    private void clearNearbyLabels(World w, PortalService.PortalDef def) {
+    /** 以中心 chunk 为心的 3×3 网格逐个投递标签清理（实体经 chunk.getEntities() 限定本 chunk）。 */
+    private void clearNearbyLabelsPerChunk(World w, PortalService.PortalDef def) {
         Location c = new Location(w, def.cx() + 0.5, def.cy() + 2.0, def.cz() + 0.5);
-        Collection<Entity> nearby = w.getNearbyEntities(c, 3.0, 3.0, 3.0);
-        for (Entity e : nearby) {
-            if (e instanceof ArmorStand as) {
-                String plain = as.customName() == null
-                        ? ""
-                        : PlainTextComponentSerializer.plainText().serialize(as.customName());
-                if (!plain.isEmpty() && (plain.contains(def.target()) || plain.contains("跨服传送"))) {
-                    e.remove();
-                }
-            }
-        }
+        ArmorStandCleanup.removeMatchingInChunks(w, c, LABEL_SEARCH_RANGE, def.target(), regionScheduler);
     }
 
     private void removeIfPortalBlock(Block b) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalLabelRenderer.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalLabelRenderer.java
@@ -1,6 +1,7 @@
 package com.jokerhub.paper.plugin.orzmc.infra.portal;
 
 import com.jokerhub.paper.plugin.orzmc.core.ports.portal.WorldProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
 import java.util.Collection;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
@@ -24,6 +25,10 @@ import org.bukkit.entity.EntityType;
  * 传送门标签渲染器。
  *
  * <p>负责在传送门附近生成/清理装甲架标签和壁挂标牌。</p>
+ *
+ * <p>Folia：生成实体/放置标牌是区块级操作，必须投递到目标 chunk 所属 region 线程
+ * （以传送门中心所在 chunk 为 anchor）。跨区块的标签清理经 {@link ArmorStandCleanup}
+ * 按 chunk 逐个投递。Paper 上 region 调度即主线程执行，语义不变。</p>
  */
 public final class PortalLabelRenderer {
 
@@ -32,10 +37,12 @@ public final class PortalLabelRenderer {
 
     private final WorldProvider worldProvider;
     private final Logger logger;
+    private final RegionSchedulerProvider regionScheduler;
 
-    public PortalLabelRenderer(WorldProvider worldProvider, Logger logger) {
+    public PortalLabelRenderer(WorldProvider worldProvider, Logger logger, RegionSchedulerProvider regionScheduler) {
         this.worldProvider = worldProvider;
         this.logger = logger;
+        this.regionScheduler = regionScheduler;
     }
 
     /**
@@ -45,6 +52,10 @@ public final class PortalLabelRenderer {
     public void spawnLabel(String worldName, int cx, int cy, int cz, String target) {
         World w = worldProvider.getWorld(worldName);
         if (w == null) return;
+        regionScheduler.run(w, cx >> 4, cz >> 4, () -> doSpawnLabel(w, cx, cy, cz, target));
+    }
+
+    private void doSpawnLabel(World w, int cx, int cy, int cz, String target) {
         Location base = new Location(w, cx + 0.5, cy + 1.9, cz + 0.5);
         if (hasExistingLabel(w, base, target)) return;
         ArmorStand title = (ArmorStand) w.spawnEntity(base.clone().add(0, 0.3, 0), EntityType.ARMOR_STAND);
@@ -69,7 +80,7 @@ public final class PortalLabelRenderer {
             return;
         }
         Location base = new Location(w, cx + 0.5, cy + 1.9, cz + 0.5);
-        removeMatchingArmorStands(w, base, 2.5, target);
+        ArmorStandCleanup.removeMatchingInChunks(w, base, 2.5, target, regionScheduler);
     }
 
     /** 在传送门侧面放置壁挂标牌。 */
@@ -77,6 +88,10 @@ public final class PortalLabelRenderer {
         int sx = center.getBlockX() + dx;
         int sz = center.getBlockZ() + dz;
         int sy = center.getBlockY();
+        regionScheduler.run(world, sx >> 4, sz >> 4, () -> doPlaceInfoSign(world, sx, sy, sz, dx, dz, host, port));
+    }
+
+    private void doPlaceInfoSign(World world, int sx, int sy, int sz, int dx, int dz, String host, int port) {
         Block signBlock = world.getBlockAt(sx, sy, sz);
         if (!signBlock.getType().isAir()) return;
         signBlock.setType(Material.OAK_WALL_SIGN, false);
@@ -96,7 +111,7 @@ public final class PortalLabelRenderer {
 
     /** 在清除传送门方块后清理附近的装甲架（含在 clearPortalBlocks 中使用）。 */
     public void clearNearbyArmorStands(World w, Location center, double range, String target) {
-        removeMatchingArmorStands(w, center, range, target);
+        ArmorStandCleanup.removeMatchingInChunks(w, center, range, target, regionScheduler);
     }
 
     private boolean hasExistingLabel(World w, Location base, String target) {
@@ -113,20 +128,5 @@ public final class PortalLabelRenderer {
             }
         }
         return false;
-    }
-
-    private void removeMatchingArmorStands(World w, Location base, double range, String target) {
-        Collection<Entity> nearby = w.getNearbyEntities(base, range, range, range);
-        for (Entity e : nearby) {
-            if (e instanceof ArmorStand as) {
-                Component name = as.customName();
-                String plain = name == null
-                        ? ""
-                        : PlainTextComponentSerializer.plainText().serialize(name);
-                if (!plain.isEmpty() && (plain.contains(target) || plain.contains("跨服传送"))) {
-                    e.remove();
-                }
-            }
-        }
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalService.java
@@ -5,10 +5,11 @@ import com.jokerhub.paper.plugin.orzmc.core.ports.portal.PortalPort;
 import com.jokerhub.paper.plugin.orzmc.core.ports.portal.WorldProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
 import com.jokerhub.paper.plugin.orzmc.infra.portal.PortalBuilder.PortalBuildResult;
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 import org.bukkit.Axis;
 import org.bukkit.Location;
@@ -21,6 +22,10 @@ import org.bukkit.entity.Player;
  * <p>协调传送门的构建、查找、拆除和持久化。
  * 实际工作委派给 {@link PortalBuilder}（方块构建）、{@link PortalLabelRenderer}（标签渲染）、
  * {@link PortalCleaner}（方块清理）和 {@link PortalPersistence}（数据持久化）。</p>
+ *
+ * <p>Folia：createPortal 由玩家命令触发（玩家 region 线程），方块构建直接执行；
+ * 标签渲染/方块清理经 {@link RegionSchedulerProvider} 投递到目标 chunk 的 region 线程。
+ * {@code interiorTargets}/{@code portalCenters} 在 Folia 下会被不同 region 并发读写，故用线程安全 Map。</p>
  */
 public class PortalService implements PortalPort {
 
@@ -31,19 +36,30 @@ public class PortalService implements PortalPort {
     private final PortalCleaner portalCleaner;
     private final PortalPersistence persistence;
 
-    private final Map<String, String> interiorTargets = new HashMap<>();
-    private final Map<String, PortalDef> portalCenters = new HashMap<>();
+    private final Map<String, String> interiorTargets = new ConcurrentHashMap<>();
+    private final Map<String, PortalDef> portalCenters = new ConcurrentHashMap<>();
 
+    /** 测试兜底构造：同步直跑（不投递 region）。生产使用注入 {@link RegionSchedulerProvider} 的构造。 */
     public PortalService(ConfigService configService) {
-        this(configService, new BukkitWorldProvider());
+        this(configService, RegionSchedulerProvider.inline());
+    }
+
+    /** 生产入口：方块/标签操作经 region scheduler 投递到目标 chunk 的 region 线程。 */
+    public PortalService(ConfigService configService, RegionSchedulerProvider regionScheduler) {
+        this(configService, new BukkitWorldProvider(), regionScheduler);
     }
 
     public PortalService(ConfigService configService, WorldProvider worldProvider) {
+        this(configService, worldProvider, RegionSchedulerProvider.inline());
+    }
+
+    public PortalService(
+            ConfigService configService, WorldProvider worldProvider, RegionSchedulerProvider regionScheduler) {
         this.configService = configService;
         this.logger = Logger.getLogger("PortalService");
-        this.portalBuilder = new PortalBuilder(interiorTargets);
-        this.labelRenderer = new PortalLabelRenderer(worldProvider, logger);
-        this.portalCleaner = new PortalCleaner(worldProvider, logger);
+        this.portalBuilder = new PortalBuilder(interiorTargets, logger);
+        this.labelRenderer = new PortalLabelRenderer(worldProvider, logger, regionScheduler);
+        this.portalCleaner = new PortalCleaner(worldProvider, logger, regionScheduler);
         this.persistence = new PortalPersistence(configService, logger);
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/server/BukkitRegionSchedulerProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/server/BukkitRegionSchedulerProvider.java
@@ -1,0 +1,20 @@
+package com.jokerhub.paper.plugin.orzmc.infra.server;
+
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/** 基于 {@link Bukkit#getRegionScheduler()} 的真实投递实现（Paper 上为主线程执行，Folia 上为 chunk 所属 region 线程）。 */
+public final class BukkitRegionSchedulerProvider implements RegionSchedulerProvider {
+
+    private final JavaPlugin plugin;
+
+    public BukkitRegionSchedulerProvider(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void run(World world, int chunkX, int chunkZ, Runnable task) {
+        Bukkit.getRegionScheduler().execute(plugin, world, chunkX, chunkZ, task);
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/server/RegionSchedulerProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/server/RegionSchedulerProvider.java
@@ -1,0 +1,23 @@
+package com.jokerhub.paper.plugin.orzmc.infra.server;
+
+import org.bukkit.World;
+
+/**
+ * 把任务投递到指定区块所属的 region 线程执行。
+ *
+ * <p>Folia 的区域化线程模型要求方块/区块操作必须在拥有该区块的 region 线程上执行；
+ * Paper 上 region 调度器即主线程执行，语义等价。抽象成可注入端口是为了在普通 JUnit
+ * 测试中直接断言「方块/区块操作投递到了正确的 chunk 坐标」（{@code verify(provider).run(world, cx, cz, task)}），
+ * 而不必启动真实 Folia。</p>
+ */
+@FunctionalInterface
+public interface RegionSchedulerProvider {
+
+    /** 将 {@code task} 投递到 {@code (chunkX, chunkZ)} 所属 region 线程；实现应返回前不保证已执行。 */
+    void run(World world, int chunkX, int chunkZ, Runnable task);
+
+    /** 同步直跑（不投递）：仅用于测试与仅支持单线程的构造兜底，生产路径使用 {@link BukkitRegionSchedulerProvider}。 */
+    static RegionSchedulerProvider inline() {
+        return (world, chunkX, chunkZ, task) -> task.run();
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/ForceLoadedChunkLeaseTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/ForceLoadedChunkLeaseTest.java
@@ -1,8 +1,11 @@
 package com.jokerhub.paper.plugin.orzmc.features.teleport;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
+import java.util.ArrayList;
 import java.util.List;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -16,6 +19,9 @@ class ForceLoadedChunkLeaseTest extends ServiceTestBase {
     private World world;
     private Chunk chunk;
 
+    /** 默认同步直跑（不投递），让既有断言在任务体内即时执行；投递目标用 captureProvider 单独验证。 */
+    private RegionSchedulerProvider provider;
+
     private ForceLoadedChunkLease lease;
 
     @BeforeEach
@@ -23,7 +29,51 @@ class ForceLoadedChunkLeaseTest extends ServiceTestBase {
         world = mock(World.class);
         chunk = mock(Chunk.class);
         when(world.getChunkAt(anyInt(), anyInt())).thenReturn(chunk);
-        lease = new ForceLoadedChunkLease();
+        provider = (w, cx, cz, task) -> task.run();
+        lease = new ForceLoadedChunkLease(provider);
+    }
+
+    /** 捕获每次投递的 (world, cx, cz, task) 并同步执行任务体的 provider。 */
+    private RegionSchedulerProvider capturingProvider(List<Object[]> dispatches) {
+        return (w, cx, cz, task) -> {
+            dispatches.add(new Object[] {w, cx, cz, task});
+            task.run();
+        };
+    }
+
+    // ---- Folia 区域亲和：force-load 操作必须投递到目标 chunk 的 region ----
+
+    @Test
+    void acquire_dispatchesToOwningChunkRegion() {
+        List<Object[]> dispatches = new ArrayList<>();
+        lease = new ForceLoadedChunkLease(capturingProvider(dispatches));
+
+        lease.acquire(world, 10, 7);
+
+        assertEquals(1, dispatches.size());
+        assertEquals(world, dispatches.get(0)[0]);
+        assertEquals(10, dispatches.get(0)[1]);
+        assertEquals(7, dispatches.get(0)[2]);
+        // 任务体在投递后同步执行，force-load 仍生效
+        verify(chunk).setForceLoaded(true);
+    }
+
+    @Test
+    void release_dispatchesToOwningChunkRegion() {
+        List<Object[]> dispatches = new ArrayList<>();
+        lease = new ForceLoadedChunkLease(capturingProvider(dispatches));
+        when(world.isChunkLoaded(1, 2)).thenReturn(true);
+        lease.acquire(world, 1, 2);
+
+        clearInvocations(world, chunk);
+        dispatches.clear();
+        lease.release(world, 1, 2);
+
+        assertEquals(1, dispatches.size());
+        assertEquals(world, dispatches.get(0)[0]);
+        assertEquals(1, dispatches.get(0)[1]);
+        assertEquals(2, dispatches.get(0)[2]);
+        verify(chunk).setForceLoaded(false);
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalBuilderTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalBuilderTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
+import java.util.logging.Logger;
 import org.bukkit.Axis;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -22,6 +23,7 @@ class PortalBuilderTest {
     private Player player;
     private World world;
     private HashMap<String, String> interiorTargets;
+    private Logger logger;
     private PortalBuilder builder;
 
     @BeforeEach
@@ -29,7 +31,8 @@ class PortalBuilderTest {
         player = mock(Player.class);
         world = mock(World.class);
         interiorTargets = new HashMap<>();
-        builder = new PortalBuilder(interiorTargets);
+        logger = mock(Logger.class);
+        builder = new PortalBuilder(interiorTargets, logger);
 
         when(player.getWorld()).thenReturn(world);
         when(world.getMaxHeight()).thenReturn(320);
@@ -143,6 +146,28 @@ class PortalBuilderTest {
 
         assertNotNull(result);
         assertTrue(result.cy() > 60, "Should find space above blocked y=60");
+    }
+
+    @Test
+    void build_footprintCrossesChunkBoundary_logsWarning() {
+        // 朝东（轴 X）：z∈[baseZ-1, baseZ+4]=[13,18] 跨 chunk(0) 与 chunk(1) → 一期降级 warning
+        mockLocation(new Vector(1, 0, 0), 100, 64, 14);
+        mockBlocks(Material.AIR);
+
+        builder.build(player, "warn:25565");
+
+        verify(logger).warning(contains("跨"));
+    }
+
+    @Test
+    void build_singleChunkFootprint_noWarning() {
+        // 朝东（轴 X）：z∈[19,24] 落在同一个 chunk → 无跨区块 warning
+        mockLocation(new Vector(1, 0, 0), 100, 64, 20);
+        mockBlocks(Material.AIR);
+
+        builder.build(player, "ok:25565");
+
+        verify(logger, never()).warning(anyString());
     }
 
     private void mockBlocks(Material type) {

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalCleanerTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalCleanerTest.java
@@ -5,15 +5,19 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.core.ports.portal.WorldProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Axis;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +26,7 @@ class PortalCleanerTest {
     private WorldProvider worldProvider;
     private World world;
     private Logger logger;
+    private RegionSchedulerProvider provider;
     private PortalCleaner cleaner;
 
     @BeforeEach
@@ -29,7 +34,9 @@ class PortalCleanerTest {
         worldProvider = mock(WorldProvider.class);
         world = mock(World.class);
         logger = mock(Logger.class);
-        cleaner = new PortalCleaner(worldProvider, logger);
+        // 默认同步直跑（不投递）：让既有断言在任务体内即时执行；投递目标用 captureProvider 单独验证
+        provider = (w, cx, cz, task) -> task.run();
+        cleaner = new PortalCleaner(worldProvider, logger, provider);
 
         when(worldProvider.getWorld("world")).thenReturn(world);
     }
@@ -65,12 +72,17 @@ class PortalCleanerTest {
         Block airBlock = mock(Block.class);
         when(airBlock.getType()).thenReturn(Material.AIR);
         when(world.getBlockAt(anyInt(), anyInt(), anyInt())).thenReturn(airBlock);
-        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(null);
 
         ArmorStand matchingStand = mock(ArmorStand.class);
         when(matchingStand.customName()).thenReturn(Component.text("跨服传送 target:25565"));
-        when(world.getNearbyEntities(any(Location.class), anyDouble(), anyDouble(), anyDouble()))
-                .thenReturn(List.of(matchingStand));
+        when(matchingStand.getLocation()).thenReturn(new Location(world, 0.5, 66.0, 0.5));
+
+        // Folia：实体清理走 chunk.getEntities()，标签在 chunk(0,0) 内
+        when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(true);
+        Chunk standChunk = mock(Chunk.class);
+        when(standChunk.getEntities()).thenReturn(new Entity[] {matchingStand});
+        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(mock(Chunk.class));
+        when(world.getChunkAt(0, 0)).thenReturn(standChunk);
 
         PortalService.PortalDef def = new PortalService.PortalDef("world", 0, 64, 0, Axis.X, "target:25565");
         cleaner.clear(def);
@@ -83,12 +95,16 @@ class PortalCleanerTest {
         Block airBlock = mock(Block.class);
         when(airBlock.getType()).thenReturn(Material.AIR);
         when(world.getBlockAt(anyInt(), anyInt(), anyInt())).thenReturn(airBlock);
-        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(null);
 
         ArmorStand nonMatching = mock(ArmorStand.class);
         when(nonMatching.customName()).thenReturn(Component.text("Some other label"));
-        when(world.getNearbyEntities(any(Location.class), anyDouble(), anyDouble(), anyDouble()))
-                .thenReturn(List.of(nonMatching));
+        when(nonMatching.getLocation()).thenReturn(new Location(world, 0.5, 66.0, 0.5));
+
+        when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(true);
+        Chunk standChunk = mock(Chunk.class);
+        when(standChunk.getEntities()).thenReturn(new Entity[] {nonMatching});
+        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(mock(Chunk.class));
+        when(world.getChunkAt(0, 0)).thenReturn(standChunk);
 
         PortalService.PortalDef def = new PortalService.PortalDef("world", 0, 64, 0, Axis.X, "target:25565");
         cleaner.clear(def);
@@ -101,12 +117,16 @@ class PortalCleanerTest {
         Block airBlock = mock(Block.class);
         when(airBlock.getType()).thenReturn(Material.AIR);
         when(world.getBlockAt(anyInt(), anyInt(), anyInt())).thenReturn(airBlock);
-        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(null);
 
         ArmorStand nullNameStand = mock(ArmorStand.class);
         when(nullNameStand.customName()).thenReturn(null);
-        when(world.getNearbyEntities(any(Location.class), anyDouble(), anyDouble(), anyDouble()))
-                .thenReturn(List.of(nullNameStand));
+        when(nullNameStand.getLocation()).thenReturn(new Location(world, 0.5, 66.0, 0.5));
+
+        when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(true);
+        Chunk standChunk = mock(Chunk.class);
+        when(standChunk.getEntities()).thenReturn(new Entity[] {nullNameStand});
+        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(mock(Chunk.class));
+        when(world.getChunkAt(0, 0)).thenReturn(standChunk);
 
         PortalService.PortalDef def = new PortalService.PortalDef("world", 0, 64, 0, Axis.X, "target:25565");
         cleaner.clear(def);
@@ -149,5 +169,33 @@ class PortalCleanerTest {
 
             verify(block, atLeastOnce()).setType(eq(Material.AIR), eq(false));
         }
+    }
+
+    // ---- Folia 区域亲和：方块/实体清理必须投递到足迹覆盖的 chunk ----
+
+    @Test
+    void clear_dispatchesToChunksCoveringFootprint() {
+        // cx=14（轴 X）→ 足迹 x∈[12,17] 跨 chunk(0,*) 与 chunk(1,*)；z∈[19,21] 落在 chunk 1
+        List<Object[]> dispatches = new ArrayList<>();
+        cleaner = new PortalCleaner(worldProvider, logger, (w, cx, cz, task) -> {
+            dispatches.add(new Object[] {cx, cz});
+            task.run();
+        });
+        when(world.getBlockAt(anyInt(), anyInt(), anyInt())).thenReturn(mock(Block.class));
+        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(mock(Chunk.class));
+        when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(true);
+
+        PortalService.PortalDef def = new PortalService.PortalDef("world", 14, 64, 20, Axis.X, "target:25565");
+        cleaner.clear(def);
+
+        List<Long> dispatchedKeys =
+                dispatches.stream().map(d -> key((int) d[0], (int) d[1])).toList();
+        // 方块足迹 chunk：(14-2)>>4=0..(14+3)>>4=1，z 方向 (20-1)>>4=1..(20+1)>>4=1
+        assertTrue(dispatchedKeys.contains(key(0, 1)), "应投递 chunk(0,1)，实际: " + dispatchedKeys);
+        assertTrue(dispatchedKeys.contains(key(1, 1)), "应投递 chunk(1,1)，实际: " + dispatchedKeys);
+    }
+
+    private static long key(int cx, int cz) {
+        return (((long) cx) << 32) | (cz & 0xffffffffL);
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalLabelRendererTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalLabelRendererTest.java
@@ -5,10 +5,12 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.core.ports.portal.WorldProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
 import java.util.List;
 import java.util.logging.Logger;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Axis;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -18,6 +20,7 @@ import org.bukkit.block.data.type.WallSign;
 import org.bukkit.block.sign.Side;
 import org.bukkit.block.sign.SignSide;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +30,7 @@ class PortalLabelRendererTest {
     private WorldProvider worldProvider;
     private World world;
     private Logger logger;
+    private RegionSchedulerProvider provider;
     private PortalLabelRenderer renderer;
 
     @BeforeEach
@@ -34,7 +38,9 @@ class PortalLabelRendererTest {
         worldProvider = mock(WorldProvider.class);
         world = mock(World.class);
         logger = mock(Logger.class);
-        renderer = new PortalLabelRenderer(worldProvider, logger);
+        // 默认同步直跑（不投递）：让既有断言在任务体内即时执行；投递目标用 captureProvider 单独验证
+        provider = (w, cx, cz, task) -> task.run();
+        renderer = new PortalLabelRenderer(worldProvider, logger, provider);
 
         when(worldProvider.getWorld("world")).thenReturn(world);
     }
@@ -89,8 +95,14 @@ class PortalLabelRendererTest {
     void clearLabels_removesMatchingArmorStands() {
         ArmorStand matchingStand = mock(ArmorStand.class);
         when(matchingStand.customName()).thenReturn(Component.text("跨服传送 target:25565"));
-        when(world.getNearbyEntities(any(Location.class), anyDouble(), anyDouble(), anyDouble()))
-                .thenReturn(List.of(matchingStand));
+        when(matchingStand.getLocation()).thenReturn(new Location(world, 100.5, 65.9, 200.5));
+
+        // Folia：标签清理走 chunk.getEntities()，标签在 chunk(6,12) 内
+        when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(true);
+        Chunk standChunk = mock(Chunk.class);
+        when(standChunk.getEntities()).thenReturn(new Entity[] {matchingStand});
+        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(mock(Chunk.class));
+        when(world.getChunkAt(6, 12)).thenReturn(standChunk);
 
         renderer.clearLabels("world", 100, 64, 200, "target:25565");
 
@@ -101,11 +113,16 @@ class PortalLabelRendererTest {
     void clearLabels_removesOnlyMatchingStands() {
         ArmorStand matching = mock(ArmorStand.class);
         when(matching.customName()).thenReturn(Component.text("target:25565"));
+        when(matching.getLocation()).thenReturn(new Location(world, 100.5, 65.9, 200.5));
         ArmorStand nonMatching = mock(ArmorStand.class);
         when(nonMatching.customName()).thenReturn(Component.text("other_label"));
+        when(nonMatching.getLocation()).thenReturn(new Location(world, 100.5, 65.9, 200.5));
 
-        when(world.getNearbyEntities(any(Location.class), anyDouble(), anyDouble(), anyDouble()))
-                .thenReturn(List.of(matching, nonMatching));
+        when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(true);
+        Chunk standChunk = mock(Chunk.class);
+        when(standChunk.getEntities()).thenReturn(new Entity[] {matching, nonMatching});
+        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(mock(Chunk.class));
+        when(world.getChunkAt(6, 12)).thenReturn(standChunk);
 
         renderer.clearLabels("world", 100, 64, 200, "target:25565");
 
@@ -154,8 +171,13 @@ class PortalLabelRendererTest {
     void clearNearbyArmorStands_removesMatchingStands() {
         ArmorStand matching = mock(ArmorStand.class);
         when(matching.customName()).thenReturn(Component.text("跨服传送 target:25565"));
-        when(world.getNearbyEntities(any(Location.class), anyDouble(), anyDouble(), anyDouble()))
-                .thenReturn(List.of(matching));
+        when(matching.getLocation()).thenReturn(new Location(world, 100.5, 66.0, 200.5));
+
+        when(world.isChunkLoaded(anyInt(), anyInt())).thenReturn(true);
+        Chunk standChunk = mock(Chunk.class);
+        when(standChunk.getEntities()).thenReturn(new Entity[] {matching});
+        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(mock(Chunk.class));
+        when(world.getChunkAt(6, 12)).thenReturn(standChunk);
 
         Location center = new Location(world, 100, 64, 200);
         renderer.clearNearbyArmorStands(world, center, 3.0, "target:25565");

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/portal/PortalServiceTest.java
@@ -5,6 +5,9 @@ import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.core.ports.portal.WorldProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
+import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
+import java.util.ArrayList;
+import java.util.List;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -16,6 +19,7 @@ class PortalServiceTest {
 
     private ConfigService configService;
     private PortalService portalService;
+    private WorldProvider worldProvider;
     private World world;
 
     private FileConfiguration portalCfg;
@@ -30,7 +34,8 @@ class PortalServiceTest {
 
         // WorldProvider returns null by default (mock), so spawnLabel/clearPortalBlocks
         // short-circuit on null world check — tests focus on map/state logic only.
-        portalService = new PortalService(configService, mock(WorldProvider.class));
+        worldProvider = mock(WorldProvider.class);
+        portalService = new PortalService(configService, worldProvider);
     }
 
     // ---- findTarget ----
@@ -119,6 +124,45 @@ class PortalServiceTest {
     void removeByTarget_noMatch_returnsZero() {
         int removed = portalService.removeByTarget("nonexistent:25565");
         assertEquals(0, removed);
+    }
+
+    // ---- Folia 区域亲和：标签渲染经 region scheduler 投递到传送门中心所在 chunk ----
+
+    @Test
+    void setup_dispatchesLabelSpawnToPortalChunk() {
+        when(worldProvider.getWorld("world")).thenReturn(world);
+        List<Object[]> dispatches = new ArrayList<>();
+        // 只记录不执行任务体，避免 spawnEntity 返回 null 的模拟噪音
+        portalService = new PortalService(configService, worldProvider, (RegionSchedulerProvider)
+                (w, cx, cz, task) -> dispatches.add(new Object[] {cx, cz}));
+
+        loadPortal("world:100:64:200", "host:25565", "X");
+        portalService.setup();
+
+        // spawnLabel 投递到传送门中心 (100,200) 所在 chunk(6,12)
+        boolean spawned = dispatches.stream().anyMatch(d -> (int) d[0] == 6 && (int) d[1] == 12);
+        assertTrue(spawned, "应投递 spawnLabel 到 chunk(6,12)，实际: " + dispatchKeys(dispatches));
+    }
+
+    @Test
+    void removeByTarget_dispatchesCleanupToPortalChunks() {
+        when(worldProvider.getWorld("world")).thenReturn(world);
+        List<Object[]> dispatches = new ArrayList<>();
+        portalService = new PortalService(configService, worldProvider, (RegionSchedulerProvider)
+                (w, cx, cz, task) -> dispatches.add(new Object[] {cx, cz}));
+
+        loadPortal("world:100:64:200", "host:25565", "X");
+        portalService.setup();
+        dispatches.clear();
+
+        portalService.removeByTarget("host:25565");
+
+        // cleaner.clear（3×3 标签网格）与 labelRenderer.clearLabels 都经 region scheduler 投递
+        assertFalse(dispatches.isEmpty(), "拆除应触发方块/标签清理的 region 投递");
+    }
+
+    private static String dispatchKeys(List<Object[]> dispatches) {
+        return dispatches.stream().map(d -> d[0] + "," + d[1]).toList().toString();
     }
 
     // ---- helper: inject portal data into YAML config and reload ----

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/server/BukkitRegionSchedulerProviderTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/server/BukkitRegionSchedulerProviderTest.java
@@ -1,0 +1,29 @@
+package com.jokerhub.paper.plugin.orzmc.infra.server;
+
+import static org.mockito.Mockito.*;
+
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class BukkitRegionSchedulerProviderTest {
+
+    @Test
+    void run_delegatesToBukkitRegionScheduler() {
+        JavaPlugin plugin = mock(JavaPlugin.class);
+        World world = mock(World.class);
+        Runnable task = mock(Runnable.class);
+        RegionScheduler regionScheduler = mock(RegionScheduler.class);
+
+        try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+            bukkit.when(Bukkit::getRegionScheduler).thenReturn(regionScheduler);
+
+            new BukkitRegionSchedulerProvider(plugin).run(world, 3, 4, task);
+
+            verify(regionScheduler).execute(plugin, world, 3, 4, task);
+        }
+    }
+}


### PR DESCRIPTION
Folia 适配 PR 序列之三：方块/区块操作迁移到目标 chunk 所属 region 线程。引入 RegionSchedulerProvider 抽象（生产=BukkitRegionSchedulerProvider 委托 Bukkit.getRegionScheduler().execute，测试=inline/capture）。PortalCleaner 按足迹覆盖 chunk 逐个投递、ArmorStandCleanup 3x3 chunk 实体清理、PortalLabelRenderer 投递 anchor chunk、ForceLoadedChunkLease acquire/release 投递所属 chunk region 且 counts 改 ConcurrentHashMap、PortalBuilder build 保持同步 + 跨 chunk warning 降级、PortalService 地图改 ConcurrentHashMap（D7 提前落地）。区域亲和单测：capture provider 断言投递坐标。check 全绿。