### PR TITLE
feat(folia): 并发安全化（TNT 聚合 / 上下线聚合 / 传送箭租约镜像）

### DIFF
--- a/docs/folia-migration.md
+++ b/docs/folia-migration.md
@@ -171,11 +171,19 @@ runPaper.folia.registerTask {
 
 | 位置 | 改法 | 落地 |
 |---|---|---|
-| `TntEventService.pendingAlerts`（HashMap get→put 非原子） | `ConcurrentHashMap` + `compute` | PR-4 |
-| `PlayerEventAggregator.batch`（enqueue/flush 跨线程） | 加 `synchronized` | PR-4 |
-| `ForceLoadedChunkLease.counts` | `ConcurrentHashMap` | **PR-3 提前落地**（region 投递使跨 region 读写真实化） |
-| `TeleportBowFlightTracker.acquired/pending` | `ConcurrentHashMap.newKeySet()` | PR-4 |
-| `PortalService.interiorTargets` | `ConcurrentHashMap` | **PR-3 提前落地**（同上，含 `portalCenters`） |
+| `TntEventService.pendingAlerts`（HashMap get→put 非原子） | `ConcurrentHashMap` + `compute` | **PR-4 已合并** |
+| `PlayerEventAggregator.batch`（enqueue/flush 跨线程） | 加 `synchronized` | **PR-4 已合并** |
+| `ForceLoadedChunkLease.counts` | `ConcurrentHashMap` | **PR-3 已合并**（region 投递使跨 region 读写真实化） |
+| `TeleportBowFlightTracker.acquired/pending` | `ConcurrentHashMap.newKeySet()` | **PR-4 已合并** |
+| `PortalService.interiorTargets` | `ConcurrentHashMap` | **PR-3 已合并**（同上，含 `portalCenters`） |
+
+- **PR-4 落地情况（2026-08，已合并）**：`TntEventService.aggregateNotify` 的建表/调度/计数
+  全部收进 `pendingAlerts.compute` 映射函数（按 key 原子化；调度在 compute 返回入表前完成，
+  保留「不留孤儿批次」不变量）；`PlayerEventAggregator` 的 `enqueue`/`flushPending`/`flushAndRender`
+  加 `synchronized` 串行化 region 入队与 global 冲刷；`TeleportBowFlightTracker.acquired/pending`
+  改 `ConcurrentHashMap.newKeySet()`（tick 与异步回调并发读写）。并发单测：64 线程同 key 爆炸
+  计数精确 ×64 且单次调度；50 线程并发入队单批计数精确；tick×3 与回调并发无
+  `ConcurrentModificationException` 且停时释放不泄漏。
 
 ### D8 CI 自动化（是否需要补 Folia 处理）
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregator.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregator.java
@@ -31,9 +31,12 @@ import org.bukkit.entity.Player;
  * 要么进入摘要被精确计数。渲染失败（模板/通知异常）时保留批次并在下一窗口重试
  * （连续失败上限 {@link #MAX_RENDER_RETRIES} 后放弃并告警，避免无限重试/批次无限增长）。</p>
  *
- * <p>事件（Bukkit 事件监听器）与冲刷（{@code runLater} 同步任务）都在主线程，
- * 无并发竞态。配置每次 {@link #enqueue} 时实时读取，热重载立即生效；冲刷时也会
- * 按最新配置过滤（窗口内被关闭的类型不再发送，属于配置性忽略而非运行时丢消息）。</p>
+ * <p>Paper：事件（Bukkit 事件监听器）与冲刷（{@code runLater} 同步任务）都在主线程，无并发竞态。
+ * Folia：{@link #enqueue} 在当事人所在 chunk 的 region 线程触发，不同玩家可并发入队；
+ * 冲刷在 global region 线程运行，与入队可能同时发生——{@code batch} 的读写由
+ * {@code synchronized} 串行化（enqueue/flush 在同一把锁上互斥），窗口尾部调度仍在锁内发起，
+ * 保证「先调度后入表」的不变量不受并发破坏。配置每次 {@link #enqueue} 时实时读取，热重载立即生效；
+ * 冲刷时也会按最新配置过滤（窗口内被关闭的类型不再发送，属于配置性忽略而非运行时丢消息）。</p>
  *
  * <p>当事人属性（玩家名/显示行/坐标/UUID）在 {@link #enqueue} 时快照：冲刷可能发生在
  * 当事人已离线之后，避免读取离线玩家的属性（null 坐标 / null 显示名）。</p>
@@ -67,7 +70,11 @@ public final class PlayerEventAggregator {
     private final Notifier notifier;
     private final OnlineListFormatter listFormatter;
 
-    /** 当前聚合窗口批次（仅主线程访问）；null 表示无待冲刷批次。 */
+    /**
+     * 当前聚合窗口批次；null 表示无待冲刷批次。
+     * 仅通过 {@code synchronized} 方法（{@link #enqueue}/{@link #flushAndRender}）访问，
+     * 串行化 Folia 下 region 线程入队与 global region 线程冲刷的并发读写。
+     */
     private PendingBatch batch;
 
     public PlayerEventAggregator(
@@ -84,7 +91,7 @@ public final class PlayerEventAggregator {
      * @param player 事件当事人
      * @param state  事件类型
      */
-    public void enqueue(Player player, PlayerEventService.PlayerState state) {
+    public synchronized void enqueue(Player player, PlayerEventService.PlayerState state) {
         PlayerNotifyConfig cfg = configs.playerNotify();
         if (!enabled(cfg, state)) {
             // 管理员显式关闭该类型通知：配置性忽略，不属于运行时丢消息
@@ -122,7 +129,7 @@ public final class PlayerEventAggregator {
      * <p>插件禁用/重载时由组合根调用：Bukkit 会取消插件待执行任务，窗口尾部调度可能来不及
      * 运行，此入口保证最后一个窗口的事件在卸载前交付。禁用场景下渲染失败不再重排，仅告警。</p>
      */
-    public void flushPending() {
+    public synchronized void flushPending() {
         flushAndRender(false);
     }
 
@@ -132,7 +139,7 @@ public final class PlayerEventAggregator {
     }
 
     /** 窗口尾部冲刷：按最新配置过滤被关闭的类型；单发走原模板，多发走聚合摘要。 */
-    private void flushAndRender(boolean retryOnFailure) {
+    private synchronized void flushAndRender(boolean retryOnFailure) {
         PendingBatch current = batch;
         batch = null;
         if (current == null || current.total() == 0) {
@@ -292,7 +299,7 @@ public final class PlayerEventAggregator {
         }
     }
 
-    /** 一个聚合窗口内的待发批次（仅主线程访问）。 */
+    /** 一个聚合窗口内的待发批次（仅持有 {@link PlayerEventAggregator} 锁时访问）。 */
     private static final class PendingBatch {
         private final List<PendingEvent> joins = new ArrayList<>();
         private final List<PendingEvent> quits = new ArrayList<>();

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTracker.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTracker.java
@@ -2,8 +2,8 @@ package com.jokerhub.paper.plugin.orzmc.features.teleport;
 
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Arrow;
@@ -35,8 +35,14 @@ final class TeleportBowFlightTracker {
     private final ServerFacade server;
     private final ForceLoadedChunkLease lease;
 
-    private final Set<Long> acquired = new HashSet<>();
-    private final Set<Long> pending = new HashSet<>();
+    /**
+     * Folia 线程模型：{@code acquired}/{@code pending} 由 tick（global region 线程）与
+     * {@code getChunkAtAsync} 回调（目标 chunk 的 region 线程）并发读写，故用并发集合。
+     * 它们是租约注册表的乐观本地镜像（非唯一状态来源），停时据此释放已 acquire 的引用。
+     */
+    private final Set<Long> acquired = ConcurrentHashMap.newKeySet();
+
+    private final Set<Long> pending = ConcurrentHashMap.newKeySet();
 
     private Arrow arrow;
     private Player player;

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/tnt/TntEventService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/tnt/TntEventService.java
@@ -11,7 +11,6 @@ import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
 import com.jokerhub.paper.plugin.orzmc.infra.templates.CoordFormatter;
 import io.papermc.paper.event.block.BlockPreDispenseEvent;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -60,8 +59,15 @@ public final class TntEventService {
     private final OrzTextStyles styles;
     private final Notifier notifier;
     private final ServerScheduler scheduler;
-    /** 突发聚合状态：key=world|区域|消息类型 → 批次计数/首事件坐标。仅主线程访问（Bukkit 事件与 runLater 均同步）。 */
-    private final Map<String, PendingAlert> pendingAlerts = new HashMap<>();
+    /**
+     * 突发聚合状态：key=world|区域|消息类型 → 批次计数/首事件坐标。
+     *
+     * <p>Paper：事件与 runLater 均同步，单线程访问。Folia：爆炸/引燃事件在爆炸所在 chunk 的
+     * region 线程触发，而聚合区域 128×128×64 方块跨越多个 chunk——不同 region 可并发命中同一 key，
+     * 故用 {@code ConcurrentHashMap} + {@link #aggregateNotify} 内的 {@code compute} 原子化建表/计数，
+     * 避免 get-then-put 竞态丢计数或建多个批次。</p>
+     */
+    private final Map<String, PendingAlert> pendingAlerts = new ConcurrentHashMap<>();
 
     public TntEventService(
             TypedConfigProvider configs, OrzTextStyles styles, Notifier notifier, ServerScheduler scheduler) {
@@ -182,20 +188,26 @@ public final class TntEventService {
      */
     private void aggregateNotify(Location location, String message, String blockType, boolean explosionPrefix) {
         String key = aggregateKey(location, message);
-        PendingAlert alert = pendingAlerts.get(key);
-        if (alert == null) {
-            alert = new PendingAlert();
-            alert.epicenter = location;
-            alert.message = message;
-            alert.blockType = blockType;
-            alert.explosionPrefix = explosionPrefix;
-            long windowMs = currentPolicy().getNotifyAggregateMs();
-            long ticks = Math.max(1, windowMs / 50);
-            scheduler.runLater(() -> flushTail(key), ticks);
-            // 尾部调度成功后才入表：中途抛异常不留孤儿条目，避免该 key 永久静默且 map 无界增长
-            pendingAlerts.put(key, alert);
-        }
-        alert.count++;
+        // compute 原子化建表/计数：Folia 下不同 region 并发命中同一 key 时，
+        // 首次创建（含调度窗口尾部冲刷）或累计计数均只执行一次，不丢计数。
+        pendingAlerts.compute(key, (k, existing) -> {
+            if (existing == null) {
+                PendingAlert created = new PendingAlert();
+                created.epicenter = location;
+                created.message = message;
+                created.blockType = blockType;
+                created.explosionPrefix = explosionPrefix;
+                created.count = 1;
+                // 调度在 compute 返回（入表可见）之前完成：中途抛异常不落表，
+                // 不留「无调度冲刷的孤儿条目」，避免该 key 永久静默且 map 无界增长。
+                long windowMs = currentPolicy().getNotifyAggregateMs();
+                long ticks = Math.max(1, windowMs / 50);
+                scheduler.runLater(() -> flushTail(key), ticks);
+                return created;
+            }
+            existing.count++;
+            return existing;
+        });
     }
 
     /** 窗口尾部冲刷：批次内事件统一补发一条（多事件带 ×N，单发不带次数）。 */
@@ -272,7 +284,7 @@ public final class TntEventService {
         return world + "|" + rx + "|" + ry + "|" + rz + "|" + message;
     }
 
-    /** 一批待聚合的 TNT/爆炸告警。仅主线程访问。 */
+    /** 一批待聚合的 TNT/爆炸告警。字段仅在 {@code pendingAlerts.compute} 的映射函数内读写（按 key 串行）。 */
     private static final class PendingAlert {
         int count;
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregatorTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/player/PlayerEventAggregatorTest.java
@@ -18,9 +18,14 @@ import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.bukkit.GameMode;
 import org.bukkit.Server;
@@ -489,5 +494,47 @@ class PlayerEventAggregatorTest extends ServiceTestBase {
         aggregator.enqueue(mockPlayer("B"), PlayerEventService.PlayerState.JOIN);
         runTail();
         verify(notifier).event(eq("player_join"), any(MessageEnvelope.class));
+    }
+
+    // ---- Folia 并发：region 线程并发入队被锁串行化 → 单一批次、计数精确 ----
+
+    @Test
+    void concurrentEnqueue_serializedIntoOneBatch_exactCounts() throws Exception {
+        when(configs.playerNotify()).thenReturn(new PlayerNotifyConfig(true, true, true, 3000L, 6, false));
+        doReturn(List.of()).when(bukkitServer).getOnlinePlayers();
+        when(bukkitServer.getMaxPlayers()).thenReturn(100);
+        when(configs.renderEvent(eq("player_digest"), anyMap())).thenReturn(MessageEnvelope.publicMessage("digest"));
+
+        // Folia 下不同玩家的 JOIN 事件在各自 chunk 的 region 线程触发，可并发入队。
+        // synchronized 必须把所有事件串行收进同一批次，恰好一次窗口调度、摘要计数精确无丢失。
+        int threads = 50;
+        List<Player> players = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            players.add(mockPlayer("P" + i));
+        }
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        for (Player p : players) {
+            pool.submit(() -> {
+                try {
+                    barrier.await();
+                } catch (InterruptedException | java.util.concurrent.BrokenBarrierException e) {
+                    Thread.currentThread().interrupt();
+                }
+                aggregator.enqueue(p, PlayerEventService.PlayerState.JOIN);
+            });
+        }
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS), "并发入队应在超时内完成");
+
+        verify(server, times(1)).runLater(any(Runnable.class), anyLong());
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> vars = ArgumentCaptor.forClass(Map.class);
+        verify(configs).renderEvent(eq("player_digest"), vars.capture());
+        assertTrue(
+                vars.getValue().get("join_summary").startsWith("🟢 +" + threads + " 上线"),
+                "got: " + vars.getValue().get("join_summary"));
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTrackerTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowFlightTrackerTest.java
@@ -1,11 +1,19 @@
 package com.jokerhub.paper.plugin.orzmc.features.teleport;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -260,5 +268,57 @@ class TeleportBowFlightTrackerTest extends ServiceTestBase {
         tracker.stop();
 
         verify(task, times(1)).cancel();
+    }
+
+    // ---- Folia 并发：tick（global region）与 getChunkAtAsync 回调（目标 chunk region）并发读写集合 ----
+
+    @Test
+    void concurrentTickAndAsyncCallback_noCorruptionOrLeak() throws Exception {
+        when(location.getBlockX()).thenReturn(16);
+        when(location.getBlockZ()).thenReturn(16);
+        when(world.isChunkLoaded(1, 1)).thenReturn(false);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer> callback = ArgumentCaptor.forClass(Consumer.class);
+        tracker.start(arrow, player);
+        tracker.tick();
+        verify(world).getChunkAtAsync(eq(1), eq(1), eq(true), eq(true), callback.capture());
+
+        // Folia：tick 跑在 global region 线程，异步加载回调跑在目标 chunk 的 region 线程，
+        // acquired/pending 被并发读写。3 × 100 tick < MAX_FLIGHT_TICKS，shouldStop 保持 false。
+        int tickThreads = 3;
+        CyclicBarrier barrier = new CyclicBarrier(tickThreads + 1);
+        ExecutorService pool = Executors.newFixedThreadPool(tickThreads + 1);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < tickThreads; i++) {
+            futures.add(pool.submit(() -> {
+                awaitBarrier(barrier);
+                for (int j = 0; j < 100; j++) {
+                    tracker.tick();
+                }
+            }));
+        }
+        futures.add(pool.submit(() -> {
+            awaitBarrier(barrier);
+            callback.getValue().accept(mock(Chunk.class));
+        }));
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS), "并发 tick/回调应在超时内完成");
+        for (Future<?> f : futures) {
+            f.get(); // 任一线程抛异常（如 ConcurrentModificationException）即测试失败
+        }
+
+        tracker.stop();
+        // 回调 acquire 的引用被 stop 完整释放，不泄漏；tick 因 pending 去重不重复 acquire
+        verify(lease, times(1)).acquire(world, 1, 1);
+        verify(lease).release(world, 1, 1);
+    }
+
+    private static void awaitBarrier(CyclicBarrier barrier) {
+        try {
+            barrier.await();
+        } catch (InterruptedException | java.util.concurrent.BrokenBarrierException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/tnt/TntEventServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/tnt/TntEventServiceTest.java
@@ -2,6 +2,7 @@ package com.jokerhub.paper.plugin.orzmc.features.tnt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -19,6 +20,10 @@ import com.jokerhub.paper.plugin.orzmc.infra.templates.TemplateResolvers;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
 import io.papermc.paper.event.block.BlockPreDispenseEvent;
 import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -464,6 +469,37 @@ class TntEventServiceTest extends ServiceTestBase {
 
         verify(notifier, never()).event(eq("tnt_alert"), any(MessageEnvelope.class));
         verify(scheduler, times(2)).runLater(any(Runnable.class), anyLong());
+    }
+
+    // ---- Folia 并发：同一聚合 key 被不同 region 线程并发命中 → compute 原子化建表/计数 ----
+
+    @Test
+    void concurrentAggregate_sameKey_countExactSingleFlush() throws Exception {
+        // 聚合区域 128×128×64 跨越多个 chunk，Folia 下爆炸事件分布在多个 region 线程上
+        // 可同时命中同一 key。并发 64 发必须：恰好调度一次窗口尾部、计数精确 ×64（无丢失/无双表）。
+        int threads = 64;
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        for (int i = 0; i < threads; i++) {
+            pool.submit(() -> {
+                try {
+                    barrier.await();
+                } catch (InterruptedException | java.util.concurrent.BrokenBarrierException e) {
+                    Thread.currentThread().interrupt();
+                }
+                service.onEntityExplode(entityExplodeAt(10, 64, 20, EntityType.TNT));
+            });
+        }
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS), "并发事件应在超时内完成");
+
+        verify(scheduler, times(1)).runLater(any(Runnable.class), anyLong());
+        runTail();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<java.util.Map<String, String>> vars = ArgumentCaptor.forClass(java.util.Map.class);
+        verify(configs, times(1)).renderEvent(eq("tnt_alert"), vars.capture());
+        assertEquals("TNT爆炸 ×64", vars.getAllValues().get(0).get("msg"));
     }
 
     /** 执行已捕获的尾部冲刷任务（模拟调度器在窗口到期后运行）。仅适用于恰好调度了一次的场景。 */


### PR DESCRIPTION
Folia 适配 PR 序列之四：把 Folia 下按 region 并发暴露的共享状态线程安全化（D7）。TntEventService.pendingAlerts→ConcurrentHashMap+compute（建表/调度/计数原子化，保留不留孤儿批次不变量）；PlayerEventAggregator.batch 加 synchronized 串行化 region 入队与 global 冲刷；TeleportBowFlightTracker.acquired/pending→ConcurrentHashMap.newKeySet（tick 与异步回调并发读写）。新增 3 个真实多线程并发单测（64 线程爆炸精确 ×64、50 线程入队单批精确计数、tick×3 与回调并发无异常且释放不泄漏）。check 全绿。