### PR TITLE
feat(folia): 声明 folia-supported + runFolia + foliaSmoke 冒烟 + Modrinth folia loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,8 @@ buildNumber.properties
 
 # Common working directory
 run/
+run-folia/
+run-folia-smoke/
 .gradle/
 build/
 .idea/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,9 @@ import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.yaml.snakeyaml.Yaml
 import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
 
 buildscript {
     repositories {
@@ -115,6 +118,26 @@ fun latestCommitMessage(): String {
         .getOrElse { "OrzMC ${project.version} build" }
 }
 
+/** 轮询日志文件直到命中 pattern，返回已等待毫秒数；超时返回 -1。 */
+private fun waitForLog(logFile: File, pattern: Regex, timeoutMs: Long): Long {
+    val start = System.nanoTime()
+    while ((System.nanoTime() - start) < timeoutMs * 1_000_000L) {
+        if (logFile.exists() && pattern.containsMatchIn(logFile.readText(Charsets.UTF_8))) {
+            return (System.nanoTime() - start) / 1_000_000L
+        }
+        Thread.sleep(250)
+    }
+    return -1
+}
+
+/** 读取日志尾部若干行，用于失败诊断。 */
+private fun logTail(logFile: File, lines: Int = 40): String {
+    if (!logFile.exists()) {
+        return "(smoke.log 不存在)"
+    }
+    return logFile.readText(Charsets.UTF_8).split("\n").takeLast(lines).joinToString("\n")
+}
+
 val githubRunNumber: String? = System.getenv("GITHUB_RUN_NUMBER")
 val githubRefType: String? = System.getenv("GITHUB_REF_TYPE")
 val githubEventName: String? = System.getenv("GITHUB_EVENT_NAME")
@@ -183,6 +206,10 @@ modrinth {
             .split(",").map { it.trim() }
     )
     loaders.add("paper")
+    // Folia 运行时与 Paper 共用同一 shadowJar（paper-plugin.yml 声明 folia-supported），
+    // Modrinth 单独声明 loader 让 Folia 服务器玩家可见。
+    // 注：Hangar 无 FOLIA 平台（仅 PAPER/VELOCITY/WATERFALL），兼容性由 PAPER 平台条目承载。
+    loaders.add("folia")
 
     // 同步 README.md 到 Modrinth 项目主页
     syncBodyFrom.set(project.file("README.md").readText())
@@ -227,6 +254,129 @@ tasks {
         // 以离线模式启动服务端
         args("--nojline", "--nogui", "--online-mode=false")
         dependsOn(agreeEula)
+    }
+    // ---- Folia：runFolia（run-paper 3.1.0） + foliaSmoke 无头冒烟 ----
+    val agreeFoliaEula = register("agreeFoliaEula") {
+        doLast {
+            val runDir = file("run-folia")
+            if (!runDir.exists()) {
+                runDir.mkdirs()
+            }
+            file("$runDir/eula.txt").writeText("eula=true\n")
+        }
+    }
+    runPaper.folia.registerTask {
+        // runDirectory 隔离到 run-folia/，避免 Folia 尝试加载 run/plugins 下
+        // Paper 专属的 Vault/EssentialsX 等不兼容插件；shadowJar 由 run-paper 自动检测加入
+        minecraftVersion(debugServerVersion)
+        args("--nojline", "--nogui", "--online-mode=false")
+        runDirectory.set(layout.projectDirectory.dir("run-folia"))
+        dependsOn(agreeFoliaEula)
+    }
+
+    // foliaSmoke：真实 Folia 无头冒烟（评估文档 D8）。下载与启动拆成两个任务：
+    // downloadFoliaJar 有缓存（build/folia-smoke/），foliaSmoke 每次执行都真实启动不跳过。
+    // 注意：不能嵌套调用 gradlew 下载/启动（会死锁在项目锁上），故自行解析 Fill API v3 + 直接 java -jar。
+    val foliaSmokeJar = layout.buildDirectory.file("folia-smoke/folia-$debugServerVersion.jar")
+    register("downloadFoliaJar") {
+        group = "verification"
+        description = "下载 Folia 服务端 jar（Paper Fill API v3，SnakeYAML 解析 JSON 响应）"
+        inputs.property("foliaVersion", debugServerVersion)
+        outputs.file(foliaSmokeJar)
+        // 下载中途被杀留下的残缺 jar 不应被视为"已就绪"：按文件大小兜底
+        outputs.upToDateWhen { foliaSmokeJar.get().asFile.takeIf { it.exists() }?.length() ?: 0L > 50_000_000L }
+        doLast {
+            val jarFile = foliaSmokeJar.get().asFile
+            val apiUrl = "https://fill.papermc.io/v3/projects/folia/versions/$debugServerVersion/builds/latest"
+            // Fill API 返回 JSON，而 JSON ⊂ YAML，直接复用 buildscript 已有的 SnakeYAML 解析
+            val response = URI(apiUrl).toURL().openStream().bufferedReader(Charsets.UTF_8).use { it.readText() }
+            val data = Yaml().load(response) as Map<*, *>
+            val serverDefault = (data["downloads"] as Map<*, *>)["server:default"] as Map<*, *>
+            val downloadUrl = serverDefault["url"] as String
+            val expectedSha = (serverDefault["checksums"] as Map<*, *>)["sha256"] as String
+            jarFile.parentFile.mkdirs()
+            val conn = URI(downloadUrl).toURL().openConnection()
+            conn.setRequestProperty("User-Agent", "OrzMC/folia-smoke")
+            conn.connect()
+            val digest = MessageDigest.getInstance("SHA-256")
+            conn.getInputStream().use { input ->
+                jarFile.outputStream().use { out ->
+                    val buf = ByteArray(128 * 1024)
+                    while (true) {
+                        val n = input.read(buf)
+                        if (n < 0) break
+                        digest.update(buf, 0, n)
+                        out.write(buf, 0, n)
+                    }
+                }
+            }
+            val actualSha = digest.digest().joinToString("") { "%02x".format(it) }
+            if (!actualSha.equals(expectedSha, ignoreCase = true)) {
+                jarFile.delete()
+                throw GradleException("Folia jar SHA256 校验失败: expected=$expectedSha actual=$actualSha")
+            }
+            logger.lifecycle("已下载 Folia $debugServerVersion → ${jarFile.absolutePath}")
+        }
+    }
+    register("foliaSmoke") {
+        group = "verification"
+        description = "真实 Folia 无头冒烟：启动服务端 → 校验 OrzMC 加载 → stop → 断言干净退出"
+        dependsOn("downloadFoliaJar", project.tasks.shadowJar)
+        outputs.upToDateWhen { false } // 每次执行都真实启动，不因缓存跳过
+        // 配置期解析（避免 doLast 内 Task.project 的执行期弃用告警 / 配置缓存不兼容）
+        val runDir = project.layout.projectDirectory.dir("run-folia-smoke").asFile
+        val shadowJarFile = project.tasks.shadowJar.get().archiveFile.get().asFile
+        val javaBin = project.javaToolchains.launcherFor(project.java.toolchain).get().executablePath.asFile.absolutePath
+        doLast {
+            val serverJar = foliaSmokeJar.get().asFile
+            runDir.mkdirs()
+            File(runDir, "eula.txt").writeText("eula=true\n")
+            val pluginsDir = File(runDir, "plugins").apply { mkdirs() }
+            shadowJarFile.copyTo(File(pluginsDir, "OrzMC.jar"), overwrite = true)
+            // OrzMC 默认 deny-list 拦截 stop/reload 等危险命令（安全加固）；冒烟测试需要干净退出，
+            // 故在隔离的 run-folia-smoke/ 内放一份空 deny-list 配置（仅影响本次冒烟，不触碰真实配置）
+            val orzmcDataDir = File(pluginsDir, "OrzMC").apply { mkdirs() }
+            File(orzmcDataDir, "config.yml").writeText("guard:\n  blocked_commands: []\n")
+
+            val logFile = File(runDir, "smoke.log").apply { if (exists()) delete() }
+            // 用 Java 25 toolchain 启动（Folia 26.2 最低要求 Java 25），不依赖 Gradle 守护进程 JDK
+            val cmd = listOf(
+                javaBin, "-Xmx2G", "-Ddisable.watchdog=true",
+                "-jar", serverJar.absolutePath,
+                "--nogui", "--nojline", "--online-mode=false", "--port", "25580"
+            )
+            logger.lifecycle("启动 Folia 冒烟服务器: ${cmd.joinToString(" ")}")
+            val proc = ProcessBuilder(cmd)
+                .directory(runDir)
+                .redirectErrorStream(true)
+                .redirectOutput(logFile)
+                .start()
+
+            val startedMs = waitForLog(logFile, Regex("Done \\(.*\\)"), 240_000)
+            if (startedMs < 0) {
+                proc.destroyForcibly()
+                proc.waitFor(30, TimeUnit.SECONDS)
+                throw GradleException("Folia 服务器 240s 内未完成启动。日志尾部:\n${logTail(logFile)}")
+            }
+            logger.lifecycle("Folia 已启动（${startedMs}ms）。校验 OrzMC 加载...")
+            // 插件加载后日志会出现 [OrzMC] 前缀行；plugins 命令响应列表也含 OrzMC
+            if (waitForLog(logFile, Regex("OrzMC"), 15_000) < 0) {
+                proc.destroyForcibly()
+                proc.waitFor(30, TimeUnit.SECONDS)
+                throw GradleException("OrzMC 插件未加载。日志尾部:\n${logTail(logFile)}")
+            }
+            logger.lifecycle("OrzMC 已加载。发送 stop...")
+            proc.outputStream.write("stop\n".toByteArray(Charsets.UTF_8))
+            proc.outputStream.flush()
+            if (!proc.waitFor(90, TimeUnit.SECONDS)) {
+                proc.destroyForcibly()
+                throw GradleException("Folia 在 stop 后 90s 内未退出。日志尾部:\n${logTail(logFile)}")
+            }
+            if (proc.exitValue() != 0) {
+                throw GradleException("Folia 退出码非零: ${proc.exitValue()}。日志尾部:\n${logTail(logFile)}")
+            }
+            logger.lifecycle("Folia 冒烟通过：干净退出（exit 0）")
+        }
     }
     jar {
         enabled = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -278,13 +278,14 @@ tasks {
     // downloadFoliaJar 有缓存（build/folia-smoke/），foliaSmoke 每次执行都真实启动不跳过。
     // 注意：不能嵌套调用 gradlew 下载/启动（会死锁在项目锁上），故自行解析 Fill API v3 + 直接 java -jar。
     val foliaSmokeJar = layout.buildDirectory.file("folia-smoke/folia-$debugServerVersion.jar")
+    val foliaSmokeMarker = layout.buildDirectory.file("folia-smoke/.folia-$debugServerVersion.ok")
     register("downloadFoliaJar") {
         group = "verification"
         description = "下载 Folia 服务端 jar（Paper Fill API v3，SnakeYAML 解析 JSON 响应）"
         inputs.property("foliaVersion", debugServerVersion)
         outputs.file(foliaSmokeJar)
-        // 下载中途被杀留下的残缺 jar 不应被视为"已就绪"：按文件大小兜底
-        outputs.upToDateWhen { foliaSmokeJar.get().asFile.takeIf { it.exists() }?.length() ?: 0L > 50_000_000L }
+        // 下载成功且 SHA256 通过才写标记文件；中途被杀留下的残缺 jar 因标记缺失会被判 out-of-date 重下
+        outputs.file(foliaSmokeMarker)
         doLast {
             val jarFile = foliaSmokeJar.get().asFile
             val apiUrl = "https://fill.papermc.io/v3/projects/folia/versions/$debugServerVersion/builds/latest"
@@ -315,6 +316,7 @@ tasks {
                 jarFile.delete()
                 throw GradleException("Folia jar SHA256 校验失败: expected=$expectedSha actual=$actualSha")
             }
+            foliaSmokeMarker.get().asFile.writeText("sha256=$actualSha\n")
             logger.lifecycle("已下载 Folia $debugServerVersion → ${jarFile.absolutePath}")
         }
     }

--- a/docs/folia-migration.md
+++ b/docs/folia-migration.md
@@ -210,9 +210,10 @@ runPaper.folia.registerTask {
   **不进真实服务器**，保持不变。
 - **新增独立 `folia-smoke` CI job**（Java 25，独立 job 不拖慢主构建，PR-6 落地）：
   - **PR-5 已实现 `foliaSmoke` Gradle 自定义任务**（build.gradle.kts，PR-6 接进 CI）：
-    - 拆成 `downloadFoliaJar`（有缓存：`inputs.property(foliaVersion)` + `outputs.file(jar)` +
-      大小兜底，输出到 `build/folia-smoke/folia-{ver}.jar`，SHA256 校验）+ `foliaSmoke`（每次
-      真实启动不跳过，`outputs.upToDateWhen { false }`）。
+    - 拆成 `downloadFoliaJar`（有缓存：`inputs.property(foliaVersion)` + `outputs.file(jar)`
+      + 成功标记文件 `.folia-{ver}.ok`——校验通过才写，中断残留判 out-of-date 重下，
+      输出到 `build/folia-smoke/`，SHA256 校验）+ `foliaSmoke`（每次真实启动不跳过，
+      `outputs.upToDateWhen { false }`）。
     - 启动用 **Java 25 toolchain**（`javaToolchains.launcherFor(java.toolchain)`），不依赖
       Gradle 守护进程 JDK；参数 `--nogui --nojline --online-mode=false --port 25580` +
       `-Ddisable.watchdog=true`。

--- a/docs/folia-migration.md
+++ b/docs/folia-migration.md
@@ -131,6 +131,25 @@ runPaper.folia.registerTask {
 | 手动下载 Folia jar + 手写启动脚本 | 每次冒烟要手动放 jar/配置 | 性价比低 |
 | Docker 起 Folia | 需要镜像维护 + 端口映射，冒烟改代码要重建 | 性价比低 |
 
+- **PR-5 落地情况（2026-08，本 PR）**：
+  - `paper-plugin.yml`：`folia-supported: false` → `true`（Folia 现可加载本插件）
+  - `build.gradle.kts`：新增 `agreeFoliaEula`（写 `run-folia/eula.txt`）+ `runPaper.folia.registerTask`
+    （`runFolia`，`minecraftVersion(debugServerVersion)`、`args("--nojline","--nogui","--online-mode=false")`、
+    `runDirectory` 隔离到 `run-folia/`）。实测 26.2 可用。
+  - **发布 loader**：Modrinth `loaders` 加 `folia`（与 `paper` 共用同一 shadowJar）；
+    **Hangar 无 FOLIA 平台**（`PlatformContainer`/`Platforms` 仅有 PAPER/VELOCITY/WATERFALL，
+    0.1.4 与 master 均无，Folia 兼容由 PAPER 平台条目 + `folia-supported` 声明承载）。
+  - `foliaSmoke` 无头冒烟任务（D8 详述）：实测**通过**——Folia 26.2 约 7s 启动、
+    OrzMC 全部配置加载成功、`stop` 干净退出 exit 0。
+  - **关键坑 1（下载源）**：旧的 `api.papermc.io/v2` 已下线，现为 **Paper Fill API v3**
+    （`https://fill.papermc.io/v3/projects/folia/versions/{ver}/builds/latest`，响应
+    `downloads["server:default"].url` 即直链）。JSON ⊂ YAML，`foliaSmoke` 直接复用 buildscript
+    已有的 SnakeYAML 解析，零新增依赖。
+  - **关键坑 2（自阻断）**：OrzMC 安全加固 deny-list 默认拦截 `stop`/`reload` 等危险命令，
+    冒烟发送 `stop` 会被拦截、服务器不退出 → `foliaSmoke` 在隔离的 `run-folia-smoke/plugins/OrzMC/config.yml`
+    写 `guard.blocked_commands: []` 放行（仅影响冒烟目录，不触碰真实配置）。开发机手动
+    `runFolia`/`runServer` 亦会被拦截，属插件既有安全设计。
+
 ### D6 测试策略（单元/集成测试是否需要单独 Folia 处理）
 
 **单元测试不需要单独 Folia 套件**，三层解释：
@@ -189,10 +208,18 @@ runPaper.folia.registerTask {
 
 - 主 `check` 流水线（spotlessCheck → test → integrationTest → jacoco → shadowJar）
   **不进真实服务器**，保持不变。
-- **新增独立 `folia-smoke` CI job**（Java 25，独立 job 不拖慢主构建）：
-  - 新增 `foliaSmoke` Gradle 自定义任务：用 run-paper 的 folia 下载启动 Folia 无头服务器
-    （`--nogui --noconsole`），安装 shadowJar，轮询日志确认 `Done` + OrzMC 加载标记，
-    发 `stop` 断言干净退出，超时即失败。
+- **新增独立 `folia-smoke` CI job**（Java 25，独立 job 不拖慢主构建，PR-6 落地）：
+  - **PR-5 已实现 `foliaSmoke` Gradle 自定义任务**（build.gradle.kts，PR-6 接进 CI）：
+    - 拆成 `downloadFoliaJar`（有缓存：`inputs.property(foliaVersion)` + `outputs.file(jar)` +
+      大小兜底，输出到 `build/folia-smoke/folia-{ver}.jar`，SHA256 校验）+ `foliaSmoke`（每次
+      真实启动不跳过，`outputs.upToDateWhen { false }`）。
+    - 启动用 **Java 25 toolchain**（`javaToolchains.launcherFor(java.toolchain)`），不依赖
+      Gradle 守护进程 JDK；参数 `--nogui --nojline --online-mode=false --port 25580` +
+      `-Ddisable.watchdog=true`。
+    - 流程：安装 shadowJar → 轮询 `Done (`（240s 超时）→ 校验 `OrzMC` 出现在日志
+      （15s）→ 发 `stop` → 断言 90s 内干净退出 exit 0；任何一步失败抛
+      `GradleException` 并附带日志尾部。
+    - **不嵌套调 gradlew**（项目锁会死锁）：自行解析 Fill API v3 直链下载。
   - 初期若不稳定，job 先 `continue-on-error: true`，稳定后转必须。
   - 备选：文档化手动 `runFolia` 冒烟清单，CI 保持 serverless。**推荐前者**：真实启动回归
     价值高（能抓「插件在 Folia 启动即崩溃」这类集成测试测不出的回归）。

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -7,7 +7,7 @@ authors: [ wangzhizhou ]
 contributors: [ wangzhizhou ]
 website: https://orzmc.jokerhub.cn
 api-version: '26.1.2'
-folia-supported: false
+folia-supported: true
 
 # LuckPerms 软依赖（Paper 26 新格式）：确保 OrzMC 在 LP 之后加载，
 # 且 LP 的类加载器对 OrzMC 可见（LP API 类由其插件提供）；LP 未安装时功能降级


### PR DESCRIPTION
## 概述
Folia 适配第 5 批：声明 `folia-supported: true` + `runFolia` + `foliaSmoke` 无头冒烟 + 发布 loader。

## 变更
- **`paper-plugin.yml`**：`folia-supported: false` → `true`（Folia 现可加载本插件）
- **`build.gradle.kts`**：
  - `runPaper.folia.registerTask`（`runFolia`）：`run-folia/` 隔离目录 + `agreeFoliaEula`
  - `downloadFoliaJar` + `foliaSmoke`：Fill API v3 下载（SHA256 校验、缓存）→ 无头启动 → 校验 OrzMC 加载 → `stop` → 断言干净退出；不嵌套调 gradlew（避免项目锁死锁）
  - Modrinth `loaders` 加 `folia`
- **`docs/folia-migration.md`**：D5/D8 落地情况
- **`.gitignore`**：`run-folia/`、`run-folia-smoke/`

## 实测
- `./gradlew runFolia`：Folia 26.2 启动（11s）→ OrzMC 加载 → `stop` 干净退出，BUILD SUCCESSFUL
- `./gradlew foliaSmoke`：通过（7s 启动，exit 0）
- `./gradlew check` 全绿

## 关键发现
- 旧 `api.papermc.io/v2` 已下线，现为 **Paper Fill API v3**（JSON ⊂ YAML，复用已有 snakeyaml 解析）
- **Hangar 无 FOLIA 平台**（仅 PAPER/VELOCITY/WATERFALL），Folia 兼容由 PAPER 平台条目 + `folia-supported` 声明承载
- OrzMC 安全加固 deny-list 默认拦截 `stop`，`foliaSmoke` 在隔离目录写空 deny-list 配置放行（仅影响冒烟）