### PR TITLE
fix(folia): ForceLoadedChunkLease 读写移至 global region 线程（修复 tpbow force-load 越权 IllegalStateException）

### DIFF
--- a/docs/folia-acceptance.md
+++ b/docs/folia-acceptance.md
@@ -45,8 +45,8 @@
 | 前置条件 | 同上 |
 | 步骤 | ① 群内 `$b` 触发一键备份；② `$o` 触发地图优化；③ 观察进度消息到完成 |
 | 预期 | 备份/优化完整执行，进度实时回传，完成无异常（调度走 async + global region） |
-| 实际 | ⬜ |
-| 方式 | Bot |
+| 实际 | 🟡 **$o 部分通过 / $b 环境限制（2026-08-18 真实环境）**：`$o` 触发链路完整验证——`/config set maintenance.optimize_enabled true`（注册路径 ✓）→ orzdebug `$o` → `正在优化地图，请稍等......` + save-off/save-all/save-on 切换（runExclusive 流程）→ MCA 优化器真实写回 region 文件（117+ 个，含 8.7MB 大文件）→ **0 region 线程异常**；优化期间真实玩家（joker）在线正常游戏。⚠️ 17G 世界（21689 region）完整跑完需数小时，验收中途因部署调试版重启中断 → **转入 TC-F6 长稳窗口重新触发直至完成**。**$b 备份：环境限制无法安全执行**——备份 zip 整个 worldContainer（17G symlink 世界）需 >17G 磁盘空间，本机仅 7.9G 可用，强行执行会写满磁盘导致数据损坏风险（非插件缺陷） |
+| 方式 | orzdebug + RCON |
 
 ### TC-F3 TNT 保护与爆炸通知
 
@@ -75,8 +75,8 @@
 | 前置条件 | 双服 Folia（或 Folia + Paper）配置传送门 |
 | 步骤 | ① 管理员创建传送门；② 玩家踩踏传送门触发跨服 transfer；③ 删除传送门 |
 | 预期 | 创建/删除经 region scheduler 在 anchor chunk 投递方块操作，无跨界异常；玩家 transfer 正常；`portal.yml` 运行时读写正确 |
-| 实际 | ⬜ |
-| 方式 | 管理员 + 真实玩家 |
+| 实际 | 🟡 **创建/删除 ✅ / transfer ❌ Folia 核心限制（2026-08-18 真实环境）**：① bot（临时 OP）`/portal 127.0.0.1 25566` → `已创建传送门 -> @ [world] 1000 65 987 框架:4x5`（4x5 黑曜石框架 + NETHER_PORTAL 方块真实生成，方块扫描确认 x=1000-1001,y=64-66,z=987）→ portals.yml 落盘 `127_0_0_1:25566` ✓ 0 region 异常；③ `/portal remove` → `已移除 1 个传送门` + portals.yml 清空 ✓ 0 region 异常。② **transfer 失败（Folia 26.2-4 核心限制）**：bot 多次踩踏/走进传送门 → **只触发原版下界传送，OrzMC 的 PlayerPortalEvent 拦截从未执行**（加临时 [PortalDebug] 日志实证 0 输出 + 反编译 folia-26.2.jar：`callPlayerPortalEvent` **无任何调用者**——下界传送门走 `NetherPortalBlock.getPortalDestination → handlePortalEvents` 链路但事件未达监听器；配置 portal-search-radius=128 正常排除配置因素）。→ **跨服 transfer（依赖 PlayerPortalEvent）在 Folia 26.2-4 BETA 无法工作**，Paper 侧正常（2026-08-06 e2e 28/28 transfer 闭环）。适配候选 `EntityPortalReadyEvent`（folia-api 存在）语义仅为选目标世界，无法替换为 transfer 命令 → 无可行插件侧适配，需等 Folia 修复或改用其他 transfer 触发方式（如交互检测） |
+| 方式 | mineflayer（OP + SimpleLogin 登录）+ RCON + 反编译验证 |
 
 ### TC-F6 长稳运行（8h+ 无死锁）
 

--- a/docs/folia-acceptance.md
+++ b/docs/folia-acceptance.md
@@ -35,8 +35,8 @@
 | 前置条件 | Folia 测试服 + EasyBot 接入 + 管理员群 |
 | 步骤 | ① 群内 `$w` 查白名单；② `$a <玩家>` 添加；③ 非白名单玩家进服触发踢出；④ `$r <玩家>` 移除 |
 | 预期 | 查询/添加正常回传；非白名单玩家被踢出并收到提示（kick 走 EntityScheduler region 线程，无错） |
-| 实际 | ⬜ |
-| 方式 | Bot + 真实玩家 |
+| 实际 | ✅ **2026-08-18 真实环境通过**：① `$w` 返回白名单列表（abinkabi/pa_pa_yuan/yuhaomax 等）；② `$a HermesTest01` → `✔︎ HermesTest01` + whitelist.json 121 条落盘；③ mineflayer `NotWhitelisted01` 进服 → 在 `Folia Region Scheduler Thread #0` 被踢出（`Disconnecting ... 不在服务器白名单中` + 中文提示含 QQ 群），**无 region 线程错误**；④ `$r HermesTest01` → whitelist.json 移除（grep 0）。命令审计 audit/command_audit.log 全部记录 |
+| 方式 | orzdebug（控制台 stdin）+ mineflayer |
 
 ### TC-F2 备份/优化（`$b` / `$o`）
 
@@ -55,8 +55,8 @@
 | 前置条件 | TNT 保护启用 + 玩家在线 |
 | 步骤 | ① 白名单区域内放 TNT 并引爆；② 白名单区域外放 TNT；③ 发射器连环爆炸 |
 | 预期 | 区域外被拦截；爆炸通知聚合为 ×N 单条告警（`TntEventService.pendingAlerts` 并发安全），无重复调度 |
-| 实际 | ⬜ |
-| 方式 | 真实玩家/机器人 |
+| 实际 | ✅ **2026-08-18 真实环境通过**：⚠️ 配置语义实测：`tnt.enable: false` 才是**严格防护模式**（区域外 TNTPrime 点燃/放置/发射取消 + 告警），`true` 为宽容模式（仅通知不拦截）。区域外红石激活 TNT → `[TNT警报] TNT被点燃（已禁止）`（TNTPrime 拦截 ✅）；3s 窗口内 6 次触发聚合为 **`×6` 单条告警**（聚合 ✅）；白名单区域（临时加 1000-1010,60-70,995-1005）→ `[TNT警报] TNT被点燃`（放行）+ `[爆炸警报] TNT爆炸`（EntityExplode 通知 ✅）；发射器拦截（PreDispense）因 RCON 下 `item replace/insert` 命令语法注入受限未实弹——源码 `onBlockPreDispense` 逻辑与 TNTPrime 一致（L123-124），工具限制非缺陷。测试后配置已恢复原状 |
+| 方式 | RCON setblock + 红石激活（mineflayer placeBlock 水下失败为工具限制） |
 
 ### TC-F4 传送弓（`/tpbow`）
 
@@ -65,8 +65,8 @@
 | 前置条件 | 玩家在线 + 权限 `orzmc.tpbow.use` |
 | 步骤 | ① 执行 `/tpbow` 射箭；② 远距离射击（触发 force-load 区块）；③ 落点非安全位置时自动就近找安全点 |
 | 预期 | 传送至落点；`ForceLoadedChunkLease` 经 region scheduler 获取/释放，无「not the correct region」；实体策略按配置 |
-| 实际 | ⬜ |
-| 方式 | 真实玩家/机器人 |
+| 实际 | ✅→❌→✅ **2026-08-18 真实环境发现并修复 bug**：mineflayer 登录（AuthMe）→ `/tpbow` 获得传送弓 → 射箭 → `[传送弓] 传送完成!` 位置变化（1000.5→999.5,1003.5）✅。但日志命中 `IllegalStateException: Cannot read force-loaded chunk off global region`（连续 3 区块 62,62/63/64）——**`ForceLoadedChunkLease.acquire` 经 region scheduler 投递 chunk region 线程后调 `chunk.isForceLoaded()`，而 Folia 中 force-load 状态由 GlobalRegion 持有（反编译 `folia-26.2.jar` CraftWorld：`ensureGlobalTickThread`）→ 线程越权**。**修复**（分支 `fix/folia-force-load-global-region` e5301dd）：新增 `GlobalSchedulerProvider` 端口，计数 + `isChunkForceLoaded`/`setChunkForceLoaded` 读写全走 global region 线程（天然串行），仅 `unloadChunk` 投递所属 region。单测 12 用例全绿；**修复版部署后同场景复测 0 异常** ✅。⚠️ 远距离（未加载区块）射击因 mineflayer 射箭弹道不可控（箭飞 ≤13 格）未触发「未加载区块 force-load」分支——已加载区块 acquire 路径（修复前必现异常的场景）已闭环验证 |
+| 方式 | mineflayer（AuthMe 注册/登录）+ RCON |
 
 ### TC-F5 跨服传送门（`/portal`）
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/ForceLoadedChunkLease.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/ForceLoadedChunkLease.java
@@ -1,9 +1,9 @@
 package com.jokerhub.paper.plugin.orzmc.features.teleport;
 
+import com.jokerhub.paper.plugin.orzmc.infra.server.GlobalSchedulerProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -19,17 +19,23 @@ import org.bukkit.entity.Player;
  * 但仅卸载「由本注册表 force-load」且「无玩家在内」的区块：
  * 既不会撤销其他插件持有的 force-load，也不会把玩家脚下区块卸掉。</p>
  *
- * <p>Folia：force-load/unload 是区块操作，必须投递到该区块所属的 region 线程执行；
- * 同一区块的 acquire/release 经 region 队列天然串行，计数更新因此被逐区块串行化。
- * Paper 上 region 调度即主线程执行，语义不变。</p>
+ * <p>Folia 线程模型（2026-08-18 实测修正）：force-load 状态由 GlobalRegion 持有，
+ * {@code World.isChunkForceLoaded}/{@code setChunkForceLoaded} 均要求 global region 线程
+ * （反编译 {@code CraftWorld}：{@code ensureGlobalTickThread("... off global region")}）；
+ * 而 {@code unloadChunk} 是区块操作，须投递到该区块所属的 region 线程。
+ * 因此本类：计数与 force-load 读写全部经 {@link GlobalSchedulerProvider} 在 global 线程执行
+ * （global 单线程天然串行，计数无竞态），仅主动卸载经 {@link RegionSchedulerProvider} 投递 region。
+ * Paper 上 global/region 调度即主线程执行，语义不变。</p>
  */
 final class ForceLoadedChunkLease {
 
     private final RegionSchedulerProvider regionScheduler;
+    private final GlobalSchedulerProvider globalScheduler;
     private final Map<World, Map<Long, LeaseRef>> counts = new ConcurrentHashMap<>();
 
-    ForceLoadedChunkLease(RegionSchedulerProvider regionScheduler) {
+    ForceLoadedChunkLease(RegionSchedulerProvider regionScheduler, GlobalSchedulerProvider globalScheduler) {
         this.regionScheduler = regionScheduler;
+        this.globalScheduler = globalScheduler;
     }
 
     /**
@@ -37,15 +43,14 @@ final class ForceLoadedChunkLease {
      * 才真正 force-load（不覆盖其他插件已有的 force-load），并记录是否需要我们在释放时清除。
      */
     void acquire(World world, int cx, int cz) {
-        regionScheduler.run(world, cx, cz, () -> {
+        globalScheduler.run(() -> {
             Map<Long, LeaseRef> perWorld = counts.computeIfAbsent(world, w -> new ConcurrentHashMap<>());
             long key = key(cx, cz);
             LeaseRef ref = perWorld.get(key);
             if (ref == null) {
-                Chunk chunk = world.getChunkAt(cx, cz);
-                boolean alreadyForced = chunk.isForceLoaded();
+                boolean alreadyForced = world.isChunkForceLoaded(cx, cz);
                 if (!alreadyForced) {
-                    chunk.setForceLoaded(true);
+                    world.setChunkForceLoaded(cx, cz, true);
                 }
                 perWorld.put(key, new LeaseRef(1, !alreadyForced));
             } else {
@@ -55,11 +60,12 @@ final class ForceLoadedChunkLease {
     }
 
     /**
-     * 释放一个 force-load 引用。计数 1→0 时：仅在区块仍加载时解除我们自己设置的 force-load，
-     * 随后在无玩家在内时主动 {@code unloadChunk} 回收内存（已卸载则跳过，避免 {@code getChunkAt} 重新加载）。
+     * 释放一个 force-load 引用。计数 1→0 时：解除我们自己设置的 force-load，
+     * 随后在无玩家在内时投递到该区块 region 线程 {@code unloadChunk} 回收内存
+     * （已卸载则跳过，避免 {@code getChunkAt} 重新加载）。
      */
     void release(World world, int cx, int cz) {
-        regionScheduler.run(world, cx, cz, () -> {
+        globalScheduler.run(() -> {
             Map<Long, LeaseRef> perWorld = counts.get(world);
             if (perWorld == null) {
                 return;
@@ -70,12 +76,10 @@ final class ForceLoadedChunkLease {
                 return;
             }
             if (ref.refs == 1) {
-                if (world.isChunkLoaded(cx, cz)) {
-                    if (ref.weForced) {
-                        world.getChunkAt(cx, cz).setForceLoaded(false);
-                        if (noPlayerInChunk(world, cx, cz)) {
-                            world.unloadChunk(cx, cz, true);
-                        }
+                if (ref.weForced) {
+                    world.setChunkForceLoaded(cx, cz, false);
+                    if (noPlayerInChunk(world, cx, cz)) {
+                        regionScheduler.run(world, cx, cz, () -> world.unloadChunk(cx, cz, true));
                     }
                 }
                 perWorld.remove(key);

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowService.java
@@ -27,8 +27,9 @@ public final class TeleportBowService {
         this.styles = styles;
         this.texts = new TeleportBowTexts(styles);
         this.keyTpBow = server.key(OrzConstants.TPBOW_KEY);
-        // Folia：force-load 是区块操作，经 region scheduler 投递到目标 chunk 的 region 线程
-        this.chunkLease = new ForceLoadedChunkLease(new BukkitRegionSchedulerProvider(server.plugin()));
+        // Folia：force-load 状态读写是全局状态（global region 线程），unloadChunk 走 region 调度
+        this.chunkLease = new ForceLoadedChunkLease(
+                new BukkitRegionSchedulerProvider(server.plugin()), server::runSync);
     }
 
     public TextComponent prefix() {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/teleport/TeleportBowService.java
@@ -28,8 +28,8 @@ public final class TeleportBowService {
         this.texts = new TeleportBowTexts(styles);
         this.keyTpBow = server.key(OrzConstants.TPBOW_KEY);
         // Folia：force-load 状态读写是全局状态（global region 线程），unloadChunk 走 region 调度
-        this.chunkLease = new ForceLoadedChunkLease(
-                new BukkitRegionSchedulerProvider(server.plugin()), server::runSync);
+        this.chunkLease =
+                new ForceLoadedChunkLease(new BukkitRegionSchedulerProvider(server.plugin()), server::runSync);
     }
 
     public TextComponent prefix() {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/server/GlobalSchedulerProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/server/GlobalSchedulerProvider.java
@@ -1,0 +1,16 @@
+package com.jokerhub.paper.plugin.orzmc.infra.server;
+
+/**
+ * 把任务投递到 Folia 的 global region 线程执行（Paper 上即主线程）。
+ *
+ * <p>Folia 中「全局状态」查询/修改（如 {@code World.isChunkForceLoaded} / {@code setChunkForceLoaded}、
+ * 玩家列表）必须在 global region 线程，否则抛 {@code IllegalStateException: ... off global region}；
+ * 与 {@link RegionSchedulerProvider}（区块操作 → 所属 region 线程）互补。抽象成端口便于单测
+ * 直接断言「全局操作经 global 调度」而不必启动真实 Folia。</p>
+ */
+@FunctionalInterface
+public interface GlobalSchedulerProvider {
+
+    /** 将 {@code task} 投递到 global region 线程执行；实现应返回前不保证已执行。 */
+    void run(Runnable task);
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/ForceLoadedChunkLeaseTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/teleport/ForceLoadedChunkLeaseTest.java
@@ -3,11 +3,11 @@ package com.jokerhub.paper.plugin.orzmc.features.teleport;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.jokerhub.paper.plugin.orzmc.infra.server.GlobalSchedulerProvider;
 import com.jokerhub.paper.plugin.orzmc.infra.server.RegionSchedulerProvider;
 import com.jokerhub.paper.plugin.orzmc.testutil.ServiceTestBase;
 import java.util.ArrayList;
 import java.util.List;
-import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -17,23 +17,24 @@ import org.junit.jupiter.api.Test;
 class ForceLoadedChunkLeaseTest extends ServiceTestBase {
 
     private World world;
-    private Chunk chunk;
 
     /** 默认同步直跑（不投递），让既有断言在任务体内即时执行；投递目标用 captureProvider 单独验证。 */
     private RegionSchedulerProvider provider;
+
+    /** 默认同步直跑；global 投递单独用 capturingGlobal 验证。 */
+    private GlobalSchedulerProvider global;
 
     private ForceLoadedChunkLease lease;
 
     @BeforeEach
     void setUp() {
         world = mock(World.class);
-        chunk = mock(Chunk.class);
-        when(world.getChunkAt(anyInt(), anyInt())).thenReturn(chunk);
         provider = (w, cx, cz, task) -> task.run();
-        lease = new ForceLoadedChunkLease(provider);
+        global = Runnable::run;
+        lease = new ForceLoadedChunkLease(provider, global);
     }
 
-    /** 捕获每次投递的 (world, cx, cz, task) 并同步执行任务体的 provider。 */
+    /** 捕获每次 region 投递的 (world, cx, cz, task) 并同步执行任务体的 provider。 */
     private RegionSchedulerProvider capturingProvider(List<Object[]> dispatches) {
         return (w, cx, cz, task) -> {
             dispatches.add(new Object[] {w, cx, cz, task});
@@ -41,31 +42,36 @@ class ForceLoadedChunkLeaseTest extends ServiceTestBase {
         };
     }
 
-    // ---- Folia 区域亲和：force-load 操作必须投递到目标 chunk 的 region ----
+    /** 捕获每次 global 投递的 task 并同步执行的 global scheduler。 */
+    private GlobalSchedulerProvider capturingGlobal(List<Runnable> dispatches) {
+        return task -> {
+            dispatches.add(task);
+            task.run();
+        };
+    }
+
+    // ---- Folia 区域亲和：force-load 状态读写是全局状态（global region），unload 才投递 region ----
 
     @Test
-    void acquire_dispatchesToOwningChunkRegion() {
-        List<Object[]> dispatches = new ArrayList<>();
-        lease = new ForceLoadedChunkLease(capturingProvider(dispatches));
+    void acquire_runsOnGlobalRegion_andForcesViaWorldApi() {
+        List<Runnable> globalDispatches = new ArrayList<>();
+        lease = new ForceLoadedChunkLease(provider, capturingGlobal(globalDispatches));
 
         lease.acquire(world, 10, 7);
 
-        assertEquals(1, dispatches.size());
-        assertEquals(world, dispatches.get(0)[0]);
-        assertEquals(10, dispatches.get(0)[1]);
-        assertEquals(7, dispatches.get(0)[2]);
-        // 任务体在投递后同步执行，force-load 仍生效
-        verify(chunk).setForceLoaded(true);
+        assertEquals(1, globalDispatches.size());
+        // 用 world 级 API 读/写 force-load 状态（global 线程安全），不再经 getChunkAt
+        verify(world).isChunkForceLoaded(10, 7);
+        verify(world).setChunkForceLoaded(10, 7, true);
     }
 
     @Test
-    void release_dispatchesToOwningChunkRegion() {
+    void release_dispatchesUnloadToOwningChunkRegion() {
         List<Object[]> dispatches = new ArrayList<>();
-        lease = new ForceLoadedChunkLease(capturingProvider(dispatches));
-        when(world.isChunkLoaded(1, 2)).thenReturn(true);
+        lease = new ForceLoadedChunkLease(capturingProvider(dispatches), global);
         lease.acquire(world, 1, 2);
 
-        clearInvocations(world, chunk);
+        clearInvocations(world);
         dispatches.clear();
         lease.release(world, 1, 2);
 
@@ -73,15 +79,17 @@ class ForceLoadedChunkLeaseTest extends ServiceTestBase {
         assertEquals(world, dispatches.get(0)[0]);
         assertEquals(1, dispatches.get(0)[1]);
         assertEquals(2, dispatches.get(0)[2]);
-        verify(chunk).setForceLoaded(false);
+        // 解除 force-load 在 global 线程执行；unload 投递到区块 region
+        verify(world).setChunkForceLoaded(1, 2, false);
+        verify(world).unloadChunk(1, 2, true);
     }
 
     @Test
     void acquire_firstReference_loadsAndForces() {
         lease.acquire(world, 1, 2);
 
-        verify(world).getChunkAt(1, 2);
-        verify(chunk).setForceLoaded(true);
+        verify(world).isChunkForceLoaded(1, 2);
+        verify(world).setChunkForceLoaded(1, 2, true);
     }
 
     @Test
@@ -89,8 +97,7 @@ class ForceLoadedChunkLeaseTest extends ServiceTestBase {
         lease.acquire(world, 1, 2);
         lease.acquire(world, 1, 2);
 
-        verify(world, times(1)).getChunkAt(1, 2);
-        verify(chunk, times(1)).setForceLoaded(true);
+        verify(world, times(1)).setChunkForceLoaded(1, 2, true);
     }
 
     @Test
@@ -100,26 +107,23 @@ class ForceLoadedChunkLeaseTest extends ServiceTestBase {
 
         lease.release(world, 1, 2);
 
-        verify(chunk, never()).setForceLoaded(false);
+        verify(world, never()).setChunkForceLoaded(1, 2, false);
         verify(world, never()).unloadChunk(anyInt(), anyInt(), anyBoolean());
     }
 
     @Test
     void release_lastReference_unloadsWhenChunkLoaded() {
         lease.acquire(world, 1, 2);
-        when(world.isChunkLoaded(1, 2)).thenReturn(true);
 
         lease.release(world, 1, 2);
 
-        verify(world).isChunkLoaded(1, 2);
-        verify(chunk).setForceLoaded(false);
+        verify(world).setChunkForceLoaded(1, 2, false);
         verify(world).unloadChunk(1, 2, true);
     }
 
     @Test
     void release_lastReference_skipsUnloadWhenPlayerInChunk() {
         lease.acquire(world, 1, 2);
-        when(world.isChunkLoaded(1, 2)).thenReturn(true);
 
         Player player = mock(Player.class);
         Location loc = mock(Location.class);
@@ -131,81 +135,60 @@ class ForceLoadedChunkLeaseTest extends ServiceTestBase {
         lease.release(world, 1, 2);
 
         // 解除 force-load，但区块内有玩家则不主动卸载。
-        verify(chunk).setForceLoaded(false);
+        verify(world).setChunkForceLoaded(1, 2, false);
         verify(world, never()).unloadChunk(anyInt(), anyInt(), anyBoolean());
-    }
-
-    @Test
-    void release_lastReference_skipsWhenChunkUnloaded() {
-        lease.acquire(world, 1, 2);
-        when(world.isChunkLoaded(1, 2)).thenReturn(false);
-
-        clearInvocations(world, chunk);
-        lease.release(world, 1, 2);
-
-        // 已卸载时不得 getChunkAt 重新加载区块。
-        verify(world, never()).getChunkAt(1, 2);
-        verify(chunk, never()).setForceLoaded(false);
     }
 
     @Test
     void release_unknownReference_isNoOp() {
         lease.release(world, 3, 4);
 
-        verify(world, never()).getChunkAt(anyInt(), anyInt());
-        verify(world, never()).isChunkLoaded(anyInt(), anyInt());
+        verify(world, never()).setChunkForceLoaded(anyInt(), anyInt(), anyBoolean());
+        verify(world, never()).unloadChunk(anyInt(), anyInt(), anyBoolean());
     }
 
     @Test
     void otherOwnersForceLoad_notClearedOrUnloaded() {
-        when(chunk.isForceLoaded()).thenReturn(true); // 其他插件已 force-load
+        when(world.isChunkForceLoaded(1, 2)).thenReturn(true); // 其他插件已 force-load
 
         lease.acquire(world, 1, 2);
-        verify(chunk, never()).setForceLoaded(true);
+        verify(world, never()).setChunkForceLoaded(1, 2, true);
 
-        when(world.isChunkLoaded(1, 2)).thenReturn(true);
         lease.release(world, 1, 2);
 
         // 不是我们 force-load 的：不解除、不主动卸载。
-        verify(chunk, never()).setForceLoaded(false);
+        verify(world, never()).setChunkForceLoaded(1, 2, false);
         verify(world, never()).unloadChunk(anyInt(), anyInt(), anyBoolean());
     }
 
     @Test
     void negativeCoordinates_trackedDistinctly() {
         lease.acquire(world, -1, -2);
-        verify(chunk, times(1)).setForceLoaded(true);
+        verify(world, times(1)).setChunkForceLoaded(-1, -2, true);
 
         lease.acquire(world, -1, -2);
-        verify(chunk, times(1)).setForceLoaded(true); // 第二次 acquire 不重复加载
+        verify(world, times(1)).setChunkForceLoaded(-1, -2, true); // 第二次 acquire 不重复加载
 
-        when(world.isChunkLoaded(-1, -2)).thenReturn(true);
-        clearInvocations(world, chunk);
-
-        lease.release(world, -1, -2);
-        verify(chunk, never()).setForceLoaded(false);
+        clearInvocations(world);
 
         lease.release(world, -1, -2);
-        verify(world, times(1)).getChunkAt(-1, -2);
-        verify(chunk, times(1)).setForceLoaded(false);
+        verify(world, never()).setChunkForceLoaded(-1, -2, false);
+
+        lease.release(world, -1, -2);
+        verify(world, times(1)).setChunkForceLoaded(-1, -2, false);
     }
 
     @Test
     void sameChunkCoords_distinctWorlds_independent() {
         World worldB = mock(World.class);
-        Chunk chunkB = mock(Chunk.class);
-        when(worldB.getChunkAt(1, 2)).thenReturn(chunkB);
 
         lease.acquire(world, 1, 2);
         lease.acquire(worldB, 1, 2);
 
-        when(world.isChunkLoaded(1, 2)).thenReturn(true);
-        when(worldB.isChunkLoaded(1, 2)).thenReturn(true);
-
         lease.release(world, 1, 2);
         lease.release(worldB, 1, 2);
 
-        verify(chunk).setForceLoaded(false);
-        verify(chunkB).setForceLoaded(false);
+        verify(world).setChunkForceLoaded(1, 2, false);
+        verify(worldB).setChunkForceLoaded(1, 2, false);
     }
 }


### PR DESCRIPTION
## 背景

folia-acceptance TC-F4 真实环境验收（Folia 26.2-4）发现 bug：tpbow 射箭触发 force-load 路径时，日志连续命中：

```
IllegalStateException: Cannot read force-loaded chunk off global region
  at CraftWorld.isChunkForceLoaded (ensureGlobalTickThread)
  at CraftChunk.isForceLoaded
  at ForceLoadedChunkLease.lambda$acquire$0 (ForceLoadedChunkLease.java:46)
```

## 根因

`ForceLoadedChunkLease.acquire` 把任务投递到 chunk 所属 **region 线程**后调用 `chunk.isForceLoaded()`，但 Folia 中 force-load 状态由 GlobalRegion 持有（反编译 folia-26.2.jar：`CraftWorld.isChunkForceLoaded`/`setChunkForceLoaded` 均 `ensureGlobalTickThread("... off global region")`）→ region 线程读取抛异常。原「force-load 投递 region」的设计方向有误（`getChunkAt` 才需要 region 线程）。

## 修复

- 新增 `GlobalSchedulerProvider` 端口（global region 调度抽象）
- `acquire/release`：计数 + `isChunkForceLoaded`/`setChunkForceLoaded` 读写全部在 **global 线程**执行（global 单线程天然串行，计数无竞态）
- 仅 `unloadChunk`（区块操作）经 `RegionSchedulerProvider` 投递所属 region
- 生产注入 `server::runSync`（ServerFacade → GlobalRegionScheduler）

## 验证

- 单测 12 用例全绿（重构为验证 global 投递 + world 级 API）+ 完整 test 套件通过
- **Folia 26.2-4 真实环境复测**：修复前同场景（tpbow 射箭触发 acquire）必现 3 区块连续异常；修复后 0 异常
- 附：folia-acceptance.md 验收记录（TC-F1/F3/F4 ✅、TC-F5 发现 Folia 核心限制 PlayerPortalEvent 不触发、TC-F2 环境限制）
