### PR TITLE
fix(e2e): run-all.sh 日志路径双核心适配（Paper 25566 推断 papermc-test 日志）

### DIFF
--- a/e2e/buglog.md
+++ b/e2e/buglog.md
@@ -53,3 +53,9 @@
 | O2 | Paper 测试服线程名 `Folia Async Scheduler Thread` | Paper 26.2 实现了 Folia 调度 API，OrzMC 统一调度器代码路径，线程名相同属正常 |
 | O3 | Paper 测试服备份目录 retention=1 | 旧 zip 被清理，E2E 断言须用文件名差异而非数量 |
 | O4 | shadowJar 12 个编译警告 | Predicate 泛型 raw type（P3，CI 会标 ##[warning]，建议清零） |
+
+## E2E 套件双核心适配（PR #199，2026-08-19）
+
+- **问题**：Paper 测试服（25566）跑 E2E 时 01/02/03 用例 waitLog 默认读 Folia 日志路径（lib/rcon.js `DEFAULT_LOG_PATH`）→ 断言等待超时 FAIL；04 备份用例与备份锁冲突（备份进行中 bot 被踢、$b 被锁拒绝）会连带后续用例零输出
+- **修复**：run-all.sh 按 `ORZMC_TEST_PORT` 推断 `ORZMC_LOG_PATH` 并 export（25565→folia-test、25566→papermc-test，可显式覆盖）
+- **验证**：**Folia 32/32 + Paper 32/32 全绿**（Paper 需等备份完成后再跑全套，避免与 $b 备份锁冲突）

--- a/e2e/run-all.sh
+++ b/e2e/run-all.sh
@@ -51,6 +51,15 @@ if ! nc -z 127.0.0.1 "$ORZMC_TEST_PORT" 2>/dev/null; then
   echo "❌ 测试服未在线（127.0.0.1:${ORZMC_TEST_PORT}）——Paper 用 ORZMC_TEST_PORT=25566 等" >&2
   exit 1
 fi
+# 日志路径按端口推断（双核心适配：25565=Folia，25566=Paper，其余可 ORZMC_LOG_PATH 覆盖）
+if [ -z "${ORZMC_LOG_PATH:-}" ]; then
+  case "$ORZMC_TEST_PORT" in
+    25565) ORZMC_LOG_PATH="$HOME/folia-test/logs/latest.log" ;;
+    25566) ORZMC_LOG_PATH="$HOME/papermc-test/logs/latest.log" ;;
+    *) ORZMC_LOG_PATH="" ;; # 未知端口：交给用例默认值
+  esac
+fi
+export ORZMC_LOG_PATH
 if [ ! -d "$NODE_PATH" ]; then
   echo "❌ 缺少 mineflayer 依赖: $NODE_PATH（请确认 ~/minecraft-bot/node_modules 存在）" >&2
   exit 1


### PR DESCRIPTION
Paper 测试服跑 E2E 时 01/02/03 用例 waitLog 默认读 Folia 日志路径（lib/rcon.js DEFAULT_LOG_PATH）→ 断言等待超时 FAIL。

修复：run-all.sh 按 ORZMC_TEST_PORT 推断 ORZMC_LOG_PATH 并 export（25565→folia-test、25566→papermc-test、其他端口可显式覆盖），lib 与用例的 DEFAULT_LOG_PATH 自动生效。

验证：Paper 32/32 + Folia 32/32 全绿。