### PR TITLE
refactor(bot): 抽离 BotCommandContext 共享基类（E3 Step 0）

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandContext.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandContext.java
@@ -1,0 +1,104 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Bot 命令共享上下文（从 BotCommandService 抽离的基类）。
+ *
+ * <p>承载所有 $cmd 处理器共用的依赖（server/configs/feedbackService）与辅助方法
+ * （emit/usage/admin 提示/权限守卫/参数解析），供 BotCommandService 及各处理器继承，
+ * 消除 God class 内的大段重复样板。</p>
+ */
+abstract class BotCommandContext {
+
+    protected final ServerFacade server;
+    protected final TypedConfigProvider configs;
+    protected final BotCommandFeedbackService feedbackService = new BotCommandFeedbackService();
+
+    BotCommandContext(ServerFacade server, TypedConfigProvider configs) {
+        this.server = server;
+        this.configs = configs;
+    }
+
+    protected BotConfig botConfig() {
+        try {
+            return configs.bot();
+        } catch (Exception e) {
+            server.logger().warning("读取 botConfig 失败，使用默认值: " + e.getMessage());
+            return new BotConfig("$", null, null);
+        }
+    }
+
+    protected void emitAdminRequired(Consumer<MessageEnvelope> callback, String tip) {
+        emit(callback, "command_admin_required", Map.of("message", tip), tip);
+    }
+
+    protected void emitUsage(Consumer<MessageEnvelope> callback, String tip) {
+        emit(callback, "command_usage", Map.of("message", tip), tip);
+    }
+
+    protected void emit(
+            Consumer<MessageEnvelope> callback, String templateKey, Map<String, String> vars, String fallback) {
+        MessageEnvelope env = configs.renderTemplate(templateKey, vars, fallback);
+        callback.accept(env);
+    }
+
+    protected boolean guardAdminCommand(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback) {
+        if (isAdmin) return true;
+        emitAdminRequired(
+                callback, feedbackService.adminRequiredTip(cmd, botConfig().cmdPromptChar()));
+        return false;
+    }
+
+    protected boolean guardWhitelistCommand(
+            OrzUserCmd cmd, boolean isAdmin, Set<String> userNames, Consumer<MessageEnvelope> callback) {
+        if (!isAdmin) {
+            emitAdminRequired(
+                    callback, feedbackService.adminRequiredTip(cmd, botConfig().cmdPromptChar()));
+            return false;
+        }
+        if (userNames.isEmpty()) {
+            emitUsage(callback, feedbackService.usageTip(cmd, botConfig().cmdPromptChar()));
+            return false;
+        }
+        return true;
+    }
+
+    protected boolean guardOptimizeEnabled(Consumer<MessageEnvelope> callback) {
+        boolean enabled = false;
+        try {
+            enabled = configs.maintenance().optimizeEnabled();
+        } catch (Exception e) {
+            server.logger().warning("读取 optimizeEnabled 配置失败: " + e.getMessage());
+        }
+        if (!enabled) {
+            emit(callback, "command_optimize_disabled", Map.of("message", "地图优化功能已禁用"), "地图优化功能已禁用");
+            return false;
+        }
+        return true;
+    }
+
+    protected Integer parsePageArg(String rawArgs) {
+        if (rawArgs.isBlank()) return null;
+        String token = rawArgs.split("[, ]+")[0];
+        try {
+            return Integer.parseInt(token);
+        } catch (Exception e) {
+            server.logger().warning("白名单页码解析失败: " + token + " - " + e.getMessage());
+            return null;
+        }
+    }
+
+    protected Set<String> parseArgs(String rawArgs) {
+        if (rawArgs.isBlank()) return new HashSet<>();
+        return new HashSet<>(Arrays.asList(rawArgs.split("[, ]+")));
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -5,7 +5,6 @@ import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
 import com.jokerhub.paper.plugin.orzmc.features.rank.RankService;
-import com.jokerhub.paper.plugin.orzmc.features.review.ReviewService;
 import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandAuditService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandGuardService;
@@ -36,6 +35,8 @@ public final class BotCommandService extends BotCommandContext implements BotInb
     private CommandGuardService commandGuardService;
     /** 命令审计日志（安全加固 P0-4）：$e 路径记录 bot 来源审计。 */
     private CommandAuditService commandAuditService;
+    /** $v 群审核命令处理器（Supplier 注入 reviewService/rankService，调用时读取最新值）。 */
+    private final ReviewCommandHandler reviewCommandHandler;
 
     /** $e 日志收集窗口：40 tick ≈ 2 秒（按 20 TPS 推算，覆盖大多数插件异步命令输出）。 */
     private static final long CONSOLE_OUTPUT_COLLECT_TICKS = 40L;
@@ -58,6 +59,7 @@ public final class BotCommandService extends BotCommandContext implements BotInb
     public BotCommandService(ServerFacade server, TypedConfigProvider configs) {
         super(server, configs);
         this.listFeedbackService = new BotCommandListFeedbackService(server, configs);
+        this.reviewCommandHandler = new ReviewCommandHandler(server, configs, () -> reviewService, () -> rankService);
         this.handlers = Map.ofEntries(
                 Map.entry(OrzUserCmd.SHOW_PLAYERS, (c, a, s, cb, r) -> handleShowPlayers(c, a, cb, r)),
                 Map.entry(OrzUserCmd.SHOW_WHITELIST, (c, a, s, cb, r) -> handleShowWhitelist(c, a, cb, r)),
@@ -69,7 +71,7 @@ public final class BotCommandService extends BotCommandContext implements BotInb
                 Map.entry(OrzUserCmd.BACKUP, (c, a, s, cb, r) -> handleBackup(c, a, cb, r)),
                 Map.entry(OrzUserCmd.OPTIMIZE_WORLD, (c, a, s, cb, r) -> handleOptimize(c, a, cb, r)),
                 Map.entry(OrzUserCmd.BLACKLIST, (c, a, s, cb, r) -> handleBlacklist(c, a, cb, r)),
-                Map.entry(OrzUserCmd.REVIEW, (c, a, s, cb, r) -> handleReview(c, a, s, cb, r)),
+                Map.entry(OrzUserCmd.REVIEW, (c, a, s, cb, r) -> reviewCommandHandler.handle(c, a, s, cb, r)),
                 Map.entry(OrzUserCmd.PERMISSION, (c, a, s, cb, r) -> handlePermission(c, a, cb, r)),
                 Map.entry(
                         OrzUserCmd.EXECUTE_CONSOLE_COMMAND,
@@ -446,147 +448,6 @@ public final class BotCommandService extends BotCommandContext implements BotInb
                         "已将 " + playerName + (upgrade ? " 升级为" : " 降级为") + RankService.groupDisplayName(target) + "。");
             }
         });
-    }
-
-    // ---- Review command ($v l|y|n) ----
-
-    private void handleReview(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        handleReview(cmd, isAdmin, null, callback, rawArgs);
-    }
-
-    private void handleReview(
-            OrzUserCmd cmd, boolean isAdmin, String senderName, Consumer<MessageEnvelope> callback, String rawArgs) {
-        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
-        if (reviewService == null) {
-            emit(callback, "command_review_error", Map.of("message", "审核服务不可用"), "审核服务不可用");
-            return;
-        }
-        if (rawArgs.isBlank()) {
-            emitReviewUsage(callback);
-            return;
-        }
-        String[] parts = rawArgs.split("\\s+", 2);
-        String sub = parts[0].toLowerCase();
-        String rest = parts.length > 1 ? parts[1].trim() : "";
-        switch (sub) {
-            case "l" -> handleReviewList(callback, rest);
-            case "y", "yes" -> handleReviewDecision(callback, rest, true, senderName);
-            case "n", "no" -> handleReviewDecision(callback, rest, false, senderName);
-            default -> emitReviewUsage(callback);
-        }
-    }
-
-    private void handleReviewList(Consumer<MessageEnvelope> callback, String pageArg) {
-        var pending = reviewService.listPending();
-        if (pending.isEmpty()) {
-            emit(callback, "command_review_list_empty", Map.of(), "当前没有待审核的申请。");
-            return;
-        }
-        Integer page = parsePageArg(pageArg);
-        List<String> lines = new ArrayList<>();
-        for (var r : pending) {
-            String typeName =
-                    reviewService.typeById(r.typeId()).map(t -> t.displayName()).orElse(r.typeId());
-            String playerName = playerNameOf(r);
-            String group = rankService == null
-                    ? ""
-                    : "（当前组：" + RankService.groupDisplayName(rankService.currentGroup(r.applicantId())) + "）";
-            String summary = reviewService
-                    .typeById(r.typeId())
-                    .map(t -> t.summarize(r.data()))
-                    .orElse("");
-            lines.add(
-                    "[%s] %s%s：%s（%s 提交）".formatted(typeName, playerName, group, summary, relativeTime(r.createdAt())));
-        }
-        Paginator.paginate(
-                server,
-                text -> emit(callback, "command_review_list", Map.of("message", text), text),
-                "------待审核申请------",
-                lines,
-                5,
-                page);
-    }
-
-    private void handleReviewDecision(
-            Consumer<MessageEnvelope> callback, String rest, boolean approved, String senderName) {
-        if (rest.isBlank()) {
-            emitReviewUsage(callback);
-            return;
-        }
-        // 审核人：优先群发送者身份（网关透传昵称）；未透传时兜底「群管理员」
-        String reviewer = (senderName == null || senderName.isBlank()) ? "群管理员" : senderName;
-        // 支持：$v y <玩家>  或  $v y <typeId> <玩家>
-        String[] parts = rest.split("\\s+", 2);
-        String first = parts[0];
-        String second = parts.length > 1 ? parts[1].trim() : "";
-
-        // 定位 + 发起审核在同步调度线程执行（Bukkit.getOfflinePlayer 需全局线程），
-        // 但不 join 等待——审核通过时的授权（LP 晋升）在非服务器线程执行，结果经 CF
-        // 回调发出（落状态回同步线程）。服务器调度线程绝不同步等待 LP future（自锁超时）。
-        final boolean byType = reviewService.typeById(first).isPresent() && !second.isBlank();
-        final String playerOrType = first;
-        final String playerName = second;
-        server.runSync(() -> {
-            try {
-                java.util.concurrent.CompletableFuture<
-                                com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.Result>
-                        future;
-                if (byType) {
-                    var request = reviewService.pendingFor(playerOrType, playerName);
-                    if (request.isEmpty()) {
-                        future = java.util.concurrent.CompletableFuture.completedFuture(
-                                ReviewService.Result.fail("找不到待审申请: " + rest));
-                    } else {
-                        future = reviewService.review(request.get().id(), approved, reviewer);
-                    }
-                } else {
-                    future = reviewService.reviewByApplicantName(playerOrType, approved, reviewer);
-                }
-                future.whenComplete((result, err) -> {
-                    if (err != null) {
-                        result = ReviewService.Result.fail(
-                                "审核处理异常: " + (err.getMessage() == null ? "未知错误" : err.getMessage()));
-                    }
-                    emit(
-                            callback,
-                            result.success() ? "command_review_result" : "command_review_error",
-                            Map.of("message", result.message()),
-                            result.message());
-                });
-            } catch (Throwable t) {
-                emit(
-                        callback,
-                        "command_review_error",
-                        Map.of("message", "审核处理异常: " + (t.getMessage() == null ? "未知错误" : t.getMessage())),
-                        "审核处理异常: " + (t.getMessage() == null ? "未知错误" : t.getMessage()));
-            }
-        });
-    }
-
-    private String playerNameOf(com.jokerhub.paper.plugin.orzmc.features.review.ReviewRequest r) {
-        // 通过 reviewService 的玩家解析端口获取名字（不可用则回退短 UUID）
-        try {
-            var name = org.bukkit.Bukkit.getOfflinePlayer(r.applicantId()).getName();
-            return name == null ? r.applicantId().toString().substring(0, 8) : name;
-        } catch (Exception e) {
-            return r.applicantId().toString().substring(0, 8);
-        }
-    }
-
-    private static String relativeTime(long epochMillis) {
-        long diff = System.currentTimeMillis() - epochMillis;
-        long minutes = diff / 60000L;
-        if (minutes < 1) return "刚刚";
-        if (minutes < 60) return minutes + "分钟前";
-        long hours = minutes / 60;
-        return hours < 24 ? hours + "小时前" : (hours / 24) + "天前";
-    }
-
-    private void emitReviewUsage(Consumer<MessageEnvelope> callback) {
-        // 与 $v ? 同一套内容（统一 usageTip 模板），保证 fallback 与主动查询一致
-        emitUsage(
-                callback,
-                feedbackService.usageTip(OrzUserCmd.REVIEW, botConfig().cmdPromptChar()));
     }
 
     // ---- Helper ----

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -17,8 +17,6 @@ import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
 import com.jokerhub.paper.plugin.orzmc.infra.paging.Paginator;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,11 +24,8 @@ import java.util.function.Consumer;
 import java.util.logging.Level;
 import org.bukkit.entity.Player;
 
-public final class BotCommandService implements BotInboundHandler {
-    private final BotCommandFeedbackService feedbackService = new BotCommandFeedbackService();
+public final class BotCommandService extends BotCommandContext implements BotInboundHandler {
     private BotCommandListFeedbackService listFeedbackService;
-    private final ServerFacade server;
-    private final TypedConfigProvider configs;
     private final Map<OrzUserCmd, CmdHandler> handlers;
     private WorldMaintenanceService maintenanceService;
     private BlacklistService blacklistService;
@@ -61,8 +56,7 @@ public final class BotCommandService implements BotInboundHandler {
     }
 
     public BotCommandService(ServerFacade server, TypedConfigProvider configs) {
-        this.server = server;
-        this.configs = configs;
+        super(server, configs);
         this.listFeedbackService = new BotCommandListFeedbackService(server, configs);
         this.handlers = Map.ofEntries(
                 Map.entry(OrzUserCmd.SHOW_PLAYERS, (c, a, s, cb, r) -> handleShowPlayers(c, a, cb, r)),
@@ -178,15 +172,6 @@ public final class BotCommandService implements BotInboundHandler {
         emit(callback, "command_help", Map.of("help", help), help);
     }
 
-    private BotConfig botConfig() {
-        try {
-            return configs.bot();
-        } catch (Exception e) {
-            server.logger().warning("读取 botConfig 失败，使用默认值: " + e.getMessage());
-            return new BotConfig("$", null, null);
-        }
-    }
-
     private boolean matchesCommandPrefix(String message, String fullCmd) {
         return message.equals(fullCmd)
                 || (message.startsWith(fullCmd)
@@ -232,17 +217,6 @@ public final class BotCommandService implements BotInboundHandler {
                 server.logger().log(Level.SEVERE, "whiteListInfo 异步任务异常", e);
             }
         });
-    }
-
-    private Integer parsePageArg(String rawArgs) {
-        if (rawArgs.isBlank()) return null;
-        String token = rawArgs.split("[, ]+")[0];
-        try {
-            return Integer.parseInt(token);
-        } catch (Exception e) {
-            server.logger().warning("白名单页码解析失败: " + token + " - " + e.getMessage());
-            return null;
-        }
     }
 
     private void handleShowHelp(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
@@ -617,11 +591,6 @@ public final class BotCommandService implements BotInboundHandler {
 
     // ---- Helper ----
 
-    private Set<String> parseArgs(String rawArgs) {
-        if (rawArgs.isBlank()) return new HashSet<>();
-        return new HashSet<>(Arrays.asList(rawArgs.split("[, ]+")));
-    }
-
     // ---- Whitelist rendering ----
 
     private void renderWhitelistWithCleanup(
@@ -680,54 +649,6 @@ public final class BotCommandService implements BotInboundHandler {
 
     // ---- Guards ----
 
-    private boolean guardAdminCommand(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback) {
-        if (isAdmin) return true;
-        emitAdminRequired(
-                callback, feedbackService.adminRequiredTip(cmd, botConfig().cmdPromptChar()));
-        return false;
-    }
-
-    private boolean guardWhitelistCommand(
-            OrzUserCmd cmd, boolean isAdmin, Set<String> userNames, Consumer<MessageEnvelope> callback) {
-        if (!isAdmin) {
-            emitAdminRequired(
-                    callback, feedbackService.adminRequiredTip(cmd, botConfig().cmdPromptChar()));
-            return false;
-        }
-        if (userNames.isEmpty()) {
-            emitUsage(callback, feedbackService.usageTip(cmd, botConfig().cmdPromptChar()));
-            return false;
-        }
-        return true;
-    }
-
-    private boolean guardOptimizeEnabled(Consumer<MessageEnvelope> callback) {
-        boolean enabled = false;
-        try {
-            enabled = configs.maintenance().optimizeEnabled();
-        } catch (Exception e) {
-            server.logger().warning("读取 optimizeEnabled 配置失败: " + e.getMessage());
-        }
-        if (!enabled) {
-            emit(callback, "command_optimize_disabled", Map.of("message", "地图优化功能已禁用"), "地图优化功能已禁用");
-            return false;
-        }
-        return true;
-    }
-
     // ---- Emitters ----
 
-    private void emitAdminRequired(Consumer<MessageEnvelope> callback, String tip) {
-        emit(callback, "command_admin_required", Map.of("message", tip), tip);
-    }
-
-    private void emitUsage(Consumer<MessageEnvelope> callback, String tip) {
-        emit(callback, "command_usage", Map.of("message", tip), tip);
-    }
-
-    private void emit(
-            Consumer<MessageEnvelope> callback, String templateKey, Map<String, String> vars, String fallback) {
-        MessageEnvelope env = configs.renderTemplate(templateKey, vars, fallback);
-        callback.accept(env);
-    }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -4,7 +4,6 @@ import com.jokerhub.paper.plugin.orzmc.core.bot.BotInboundHandler;
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
-import com.jokerhub.paper.plugin.orzmc.features.rank.RankService;
 import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandAuditService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandGuardService;
@@ -37,12 +36,10 @@ public final class BotCommandService extends BotCommandContext implements BotInb
     private CommandAuditService commandAuditService;
     /** $v 群审核命令处理器（Supplier 注入 reviewService/rankService，调用时读取最新值）。 */
     private final ReviewCommandHandler reviewCommandHandler;
-
-    /** $e 日志收集窗口：40 tick ≈ 2 秒（按 20 TPS 推算，覆盖大多数插件异步命令输出）。 */
-    private static final long CONSOLE_OUTPUT_COLLECT_TICKS = 40L;
-
-    /** $e 输出最大行数，超过截断防刷群。 */
-    private static final int CONSOLE_OUTPUT_MAX_LINES = 30;
+    /** $p 群权限升降级命令处理器（Supplier 注入 rankService）。 */
+    private final PermissionCommandHandler permissionCommandHandler;
+    /** $e 控制台命令执行处理器（Supplier 注入 guard/audit/logCapture）。 */
+    private final ConsoleCommandHandler consoleCommandHandler;
 
     @FunctionalInterface
     private interface CmdHandler {
@@ -60,6 +57,9 @@ public final class BotCommandService extends BotCommandContext implements BotInb
         super(server, configs);
         this.listFeedbackService = new BotCommandListFeedbackService(server, configs);
         this.reviewCommandHandler = new ReviewCommandHandler(server, configs, () -> reviewService, () -> rankService);
+        this.permissionCommandHandler = new PermissionCommandHandler(server, configs, () -> rankService);
+        this.consoleCommandHandler = new ConsoleCommandHandler(
+                server, configs, () -> commandGuardService, () -> commandAuditService, () -> logCaptureService);
         this.handlers = Map.ofEntries(
                 Map.entry(OrzUserCmd.SHOW_PLAYERS, (c, a, s, cb, r) -> handleShowPlayers(c, a, cb, r)),
                 Map.entry(OrzUserCmd.SHOW_WHITELIST, (c, a, s, cb, r) -> handleShowWhitelist(c, a, cb, r)),
@@ -72,10 +72,10 @@ public final class BotCommandService extends BotCommandContext implements BotInb
                 Map.entry(OrzUserCmd.OPTIMIZE_WORLD, (c, a, s, cb, r) -> handleOptimize(c, a, cb, r)),
                 Map.entry(OrzUserCmd.BLACKLIST, (c, a, s, cb, r) -> handleBlacklist(c, a, cb, r)),
                 Map.entry(OrzUserCmd.REVIEW, (c, a, s, cb, r) -> reviewCommandHandler.handle(c, a, s, cb, r)),
-                Map.entry(OrzUserCmd.PERMISSION, (c, a, s, cb, r) -> handlePermission(c, a, cb, r)),
+                Map.entry(OrzUserCmd.PERMISSION, (c, a, s, cb, r) -> permissionCommandHandler.handle(c, a, cb, r)),
                 Map.entry(
                         OrzUserCmd.EXECUTE_CONSOLE_COMMAND,
-                        (c, a, s, cb, r) -> handleExecuteConsoleCommand(c, a, s, cb, r)));
+                        (c, a, s, cb, r) -> consoleCommandHandler.handle(c, a, s, cb, r)));
     }
 
     public void setMaintenanceService(WorldMaintenanceService maintenanceService) {
@@ -270,65 +270,6 @@ public final class BotCommandService extends BotCommandContext implements BotInb
         }
     }
 
-    // ---- Console command ----
-
-    private void handleExecuteConsoleCommand(
-            OrzUserCmd cmd, boolean isAdmin, String senderName, Consumer<MessageEnvelope> callback, String rawArgs) {
-        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
-        if (rawArgs.isBlank()) {
-            emitUsage(
-                    callback,
-                    feedbackService.usageTip(
-                            OrzUserCmd.EXECUTE_CONSOLE_COMMAND, botConfig().cmdPromptChar()));
-            return;
-        }
-        // 安全加固 P0-5：$e 控制台执行前过 guard。BLOCK → 拦截 + 审计 blocked，不执行；
-        // WARN/ALLOW → 审计 executed 后照常执行。guard 未注入时直接执行（测试向后兼容）。
-        String auditSender = senderName == null ? CommandAuditService.SOURCE_BOT : senderName;
-        CommandGuardService.GuardDecision decision = commandGuardService == null
-                ? CommandGuardService.GuardDecision.allow()
-                : commandGuardService.guard(rawArgs);
-        if (decision.blocked()) {
-            if (commandAuditService != null) {
-                commandAuditService.record(CommandAuditService.SOURCE_BOT, auditSender, rawArgs, true);
-            }
-            emit(callback, "command_output", Map.of("message", decision.reason()), decision.reason());
-            return;
-        }
-        if (commandAuditService != null) {
-            commandAuditService.record(CommandAuditService.SOURCE_BOT, auditSender, rawArgs, false);
-        }
-        server.runSync(() -> {
-            if (logCaptureService == null) {
-                // 未注入日志窗口服务：退化为仅返回执行状态
-                ServerFacade.ConsoleCommandResult result = server.executeConsoleCommand(rawArgs);
-                emit(callback, "command_output", Map.of("message", result.message()), result.message());
-                return;
-            }
-            // 先取水位再执行，命令执行期间的日志行才能落入窗口
-            long watermark = logCaptureService.watermark();
-            ServerFacade.ConsoleCommandResult result = server.executeConsoleCommand(rawArgs);
-            // 延迟一个收集窗口后取日志增量：覆盖异步命令输出（LuckPerms 等回调式输出）。
-            // 日志窗口是「尽力而为」兜底：窗口内可能混入服务器其他活动日志（已过滤
-            // 命令回显/玩家聊天），缓冲溢出时输出头部提示可能缺失
-            server.runLater(
-                    () -> {
-                        List<String> windowLogLines = logCaptureService.drainSince(watermark);
-                        String assembled = CommandOutputAssembler.assemble(
-                                result.outputLines(), windowLogLines, CONSOLE_OUTPUT_MAX_LINES);
-                        // 缺口检测独立于输出内容：即使窗口内有效行全被驱逐/过滤也要提示
-                        String message;
-                        if (logCaptureService.hasGapSince(watermark)) {
-                            message = assembled.isEmpty() ? "⚠️ 日志缓冲溢出，输出可能不完整" : "⚠️ 日志缓冲溢出，输出可能不完整\n" + assembled;
-                        } else {
-                            message = assembled.isEmpty() ? result.message() : assembled;
-                        }
-                        emit(callback, "command_output", Map.of("message", message), message);
-                    },
-                    CONSOLE_OUTPUT_COLLECT_TICKS);
-        });
-    }
-
     // ---- Blacklist command ----
 
     private void handleBlacklist(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
@@ -361,93 +302,6 @@ public final class BotCommandService extends BotCommandContext implements BotInb
             blacklistService.add(rawArgs);
             emit(callback, "command_blacklist_add", Map.of("message", "已添加: " + rawArgs), "已添加: " + rawArgs);
         }
-    }
-
-    // ---- Permission command ($p u|d) ----
-
-    /** $p u <玩家> / $p d <玩家> — 权限升级/降级一级（钳位：default→member→builder→admin）。 */
-    private void handlePermission(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
-        if (rankService == null) {
-            emit(callback, "command_review_error", Map.of("message", "权限服务不可用"), "权限服务不可用");
-            return;
-        }
-        if (!rankService.isLuckPermsAvailable()) {
-            emit(
-                    callback,
-                    "command_review_error",
-                    Map.of("message", "未检测到 LuckPerms，权限管理功能不可用"),
-                    "未检测到 LuckPerms，权限管理功能不可用");
-            return;
-        }
-        if (rawArgs.isBlank()) {
-            emitUsage(
-                    callback,
-                    feedbackService.usageTip(OrzUserCmd.PERMISSION, botConfig().cmdPromptChar()));
-            return;
-        }
-        String[] parts = rawArgs.split("\\s+", 2);
-        String sub = parts[0].toLowerCase();
-        String playerName = parts.length > 1 ? parts[1].trim() : "";
-        if (playerName.isBlank()) {
-            emitUsage(
-                    callback,
-                    feedbackService.usageTip(OrzUserCmd.PERMISSION, botConfig().cmdPromptChar()));
-            return;
-        }
-        boolean upgrade;
-        switch (sub) {
-            case "u", "up" -> upgrade = true;
-            case "d", "down" -> upgrade = false;
-            default -> {
-                emitUsage(
-                        callback,
-                        feedbackService.usageTip(
-                                OrzUserCmd.PERMISSION, botConfig().cmdPromptChar()));
-                return;
-            }
-        }
-        var playerId = rankService.resolvePlayerId(playerName);
-        if (playerId == null) {
-            emit(callback, "command_review_error", Map.of("message", "找不到玩家: " + playerName), "找不到玩家: " + playerName);
-            return;
-        }
-        final var id = playerId;
-        // 异步升降级：LP 操作（loadUser/saveUser 等待）在非服务器线程执行，绝不 runSync+join
-        // （服务器调度线程同步等待 LP future 会自锁超时，Folia LP 适配器行为）
-        java.util.concurrent.CompletableFuture<String> future =
-                upgrade ? rankService.promoteAsync(id) : rankService.demoteAsync(id);
-        future.whenComplete((target, err) -> {
-            if (err != null) {
-                emit(
-                        callback,
-                        "command_review_error",
-                        Map.of("message", playerName + " 权限操作异常（详见服务器日志）。"),
-                        playerName + " 权限操作异常（详见服务器日志）。");
-                return;
-            }
-            if (target == null) {
-                emit(
-                        callback,
-                        "command_review_error",
-                        Map.of(
-                                "message",
-                                playerName
-                                        + (upgrade
-                                                ? " 无法升级：已达最高等级或权限数据异常（详见服务器日志）。"
-                                                : " 无法降级：已达最低等级或权限数据异常（详见服务器日志）。")),
-                        playerName + (upgrade ? " 无法升级：已达最高等级或权限数据异常（详见服务器日志）。" : " 无法降级：已达最低等级或权限数据异常（详见服务器日志）。"));
-            } else {
-                emit(
-                        callback,
-                        "command_review_result",
-                        Map.of(
-                                "message",
-                                "已将 " + playerName + (upgrade ? " 升级为" : " 降级为") + RankService.groupDisplayName(target)
-                                        + "。"),
-                        "已将 " + playerName + (upgrade ? " 升级为" : " 降级为") + RankService.groupDisplayName(target) + "。");
-            }
-        });
     }
 
     // ---- Helper ----

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/ConsoleCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/ConsoleCommandHandler.java
@@ -1,0 +1,103 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.features.security.CommandAuditService;
+import com.jokerhub.paper.plugin.orzmc.features.security.CommandGuardService;
+import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * $e 控制台命令执行处理器（从 BotCommandService 抽离）。
+ *
+ * <p>{@code commandGuardService}/{@code commandAuditService}/{@code logCaptureService} 通过
+ * {@link Supplier} 注入（setter 二阶段注入），调用时读取最新值；未注入时退化为直接执行/无审计
+ * （测试向后兼容）。</p>
+ */
+final class ConsoleCommandHandler extends BotCommandContext {
+
+    /** $e 日志收集窗口：40 tick ≈ 2 秒（按 20 TPS 推算，覆盖大多数插件异步命令输出）。 */
+    private static final long CONSOLE_OUTPUT_COLLECT_TICKS = 40L;
+
+    /** $e 输出最大行数，超过截断防刷群。 */
+    private static final int CONSOLE_OUTPUT_MAX_LINES = 30;
+
+    private final Supplier<CommandGuardService> commandGuardService;
+    private final Supplier<CommandAuditService> commandAuditService;
+    private final Supplier<LogCaptureService> logCaptureService;
+
+    ConsoleCommandHandler(
+            ServerFacade server,
+            TypedConfigProvider configs,
+            Supplier<CommandGuardService> commandGuardService,
+            Supplier<CommandAuditService> commandAuditService,
+            Supplier<LogCaptureService> logCaptureService) {
+        super(server, configs);
+        this.commandGuardService = commandGuardService;
+        this.commandAuditService = commandAuditService;
+        this.logCaptureService = logCaptureService;
+    }
+
+    void handle(
+            OrzUserCmd cmd, boolean isAdmin, String senderName, Consumer<MessageEnvelope> callback, String rawArgs) {
+        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
+        if (rawArgs.isBlank()) {
+            emitUsage(
+                    callback,
+                    feedbackService.usageTip(
+                            OrzUserCmd.EXECUTE_CONSOLE_COMMAND, botConfig().cmdPromptChar()));
+            return;
+        }
+        // 安全加固 P0-5：$e 控制台执行前过 guard。BLOCK → 拦截 + 审计 blocked，不执行；
+        // WARN/ALLOW → 审计 executed 后照常执行。guard 未注入时直接执行（测试向后兼容）。
+        CommandGuardService guard = commandGuardService.get();
+        CommandAuditService audit = commandAuditService.get();
+        String auditSender = senderName == null ? CommandAuditService.SOURCE_BOT : senderName;
+        CommandGuardService.GuardDecision decision =
+                guard == null ? CommandGuardService.GuardDecision.allow() : guard.guard(rawArgs);
+        if (decision.blocked()) {
+            if (audit != null) {
+                audit.record(CommandAuditService.SOURCE_BOT, auditSender, rawArgs, true);
+            }
+            emit(callback, "command_output", Map.of("message", decision.reason()), decision.reason());
+            return;
+        }
+        if (audit != null) {
+            audit.record(CommandAuditService.SOURCE_BOT, auditSender, rawArgs, false);
+        }
+        server.runSync(() -> {
+            LogCaptureService capture = logCaptureService.get();
+            if (capture == null) {
+                // 未注入日志窗口服务：退化为仅返回执行状态
+                ServerFacade.ConsoleCommandResult result = server.executeConsoleCommand(rawArgs);
+                emit(callback, "command_output", Map.of("message", result.message()), result.message());
+                return;
+            }
+            // 先取水位再执行，命令执行期间的日志行才能落入窗口
+            long watermark = capture.watermark();
+            ServerFacade.ConsoleCommandResult result = server.executeConsoleCommand(rawArgs);
+            // 延迟一个收集窗口后取日志增量：覆盖异步命令输出（LuckPerms 等回调式输出）。
+            // 日志窗口是「尽力而为」兜底：窗口内可能混入服务器其他活动日志（已过滤
+            // 命令回显/玩家聊天），缓冲溢出时输出头部提示可能缺失
+            server.runLater(
+                    () -> {
+                        List<String> windowLogLines = capture.drainSince(watermark);
+                        String assembled = CommandOutputAssembler.assemble(
+                                result.outputLines(), windowLogLines, CONSOLE_OUTPUT_MAX_LINES);
+                        // 缺口检测独立于输出内容：即使窗口内有效行全被驱逐/过滤也要提示
+                        String message;
+                        if (capture.hasGapSince(watermark)) {
+                            message = assembled.isEmpty() ? "⚠️ 日志缓冲溢出，输出可能不完整" : "⚠️ 日志缓冲溢出，输出可能不完整\n" + assembled;
+                        } else {
+                            message = assembled.isEmpty() ? result.message() : assembled;
+                        }
+                        emit(callback, "command_output", Map.of("message", message), message);
+                    },
+                    CONSOLE_OUTPUT_COLLECT_TICKS);
+        });
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/PermissionCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/PermissionCommandHandler.java
@@ -1,0 +1,110 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.features.rank.RankService;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * $p u|d 群权限升降级命令处理器（从 BotCommandService 抽离）。
+ *
+ * <p>{@code rankService} 通过 {@link Supplier} 注入——组合根在 BotCommandService 构造后经
+ * setter 二阶段注入，处理器调用时读取最新值。升降级走 {@code promoteAsync/demoteAsync}
+ * 异步（LP 操作在非服务器线程），绝不 runSync+join（自锁超时，见 folia-luckperms-gotchas.md）。</p>
+ */
+final class PermissionCommandHandler extends BotCommandContext {
+
+    private final Supplier<RankService> rankService;
+
+    PermissionCommandHandler(ServerFacade server, TypedConfigProvider configs, Supplier<RankService> rankService) {
+        super(server, configs);
+        this.rankService = rankService;
+    }
+
+    void handle(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
+        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
+        RankService rank = rankService.get();
+        if (rank == null) {
+            emit(callback, "command_review_error", Map.of("message", "权限服务不可用"), "权限服务不可用");
+            return;
+        }
+        if (!rank.isLuckPermsAvailable()) {
+            emit(
+                    callback,
+                    "command_review_error",
+                    Map.of("message", "未检测到 LuckPerms，权限管理功能不可用"),
+                    "未检测到 LuckPerms，权限管理功能不可用");
+            return;
+        }
+        if (rawArgs.isBlank()) {
+            emitUsage(
+                    callback,
+                    feedbackService.usageTip(OrzUserCmd.PERMISSION, botConfig().cmdPromptChar()));
+            return;
+        }
+        String[] parts = rawArgs.split("\\s+", 2);
+        String sub = parts[0].toLowerCase();
+        String playerName = parts.length > 1 ? parts[1].trim() : "";
+        if (playerName.isBlank()) {
+            emitUsage(
+                    callback,
+                    feedbackService.usageTip(OrzUserCmd.PERMISSION, botConfig().cmdPromptChar()));
+            return;
+        }
+        boolean upgrade;
+        switch (sub) {
+            case "u", "up" -> upgrade = true;
+            case "d", "down" -> upgrade = false;
+            default -> {
+                emitUsage(
+                        callback,
+                        feedbackService.usageTip(
+                                OrzUserCmd.PERMISSION, botConfig().cmdPromptChar()));
+                return;
+            }
+        }
+        var playerId = rank.resolvePlayerId(playerName);
+        if (playerId == null) {
+            emit(callback, "command_review_error", Map.of("message", "找不到玩家: " + playerName), "找不到玩家: " + playerName);
+            return;
+        }
+        final var id = playerId;
+        // 异步升降级：LP 操作（loadUser/saveUser 等待）在非服务器线程执行，绝不 runSync+join
+        // （服务器调度线程同步等待 LP future 会自锁超时，Folia LP 适配器行为）
+        java.util.concurrent.CompletableFuture<String> future = upgrade ? rank.promoteAsync(id) : rank.demoteAsync(id);
+        future.whenComplete((target, err) -> {
+            if (err != null) {
+                emit(
+                        callback,
+                        "command_review_error",
+                        Map.of("message", playerName + " 权限操作异常（详见服务器日志）。"),
+                        playerName + " 权限操作异常（详见服务器日志）。");
+                return;
+            }
+            if (target == null) {
+                emit(
+                        callback,
+                        "command_review_error",
+                        Map.of(
+                                "message",
+                                playerName
+                                        + (upgrade
+                                                ? " 无法升级：已达最高等级或权限数据异常（详见服务器日志）。"
+                                                : " 无法降级：已达最低等级或权限数据异常（详见服务器日志）。")),
+                        playerName + (upgrade ? " 无法升级：已达最高等级或权限数据异常（详见服务器日志）。" : " 无法降级：已达最低等级或权限数据异常（详见服务器日志）。"));
+            } else {
+                emit(
+                        callback,
+                        "command_review_result",
+                        Map.of(
+                                "message",
+                                "已将 " + playerName + (upgrade ? " 升级为" : " 降级为") + RankService.groupDisplayName(target)
+                                        + "。"),
+                        "已将 " + playerName + (upgrade ? " 升级为" : " 降级为") + RankService.groupDisplayName(target) + "。");
+            }
+        });
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/ReviewCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/ReviewCommandHandler.java
@@ -1,0 +1,175 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.features.rank.RankService;
+import com.jokerhub.paper.plugin.orzmc.features.review.ReviewRequest;
+import com.jokerhub.paper.plugin.orzmc.features.review.ReviewService;
+import com.jokerhub.paper.plugin.orzmc.infra.paging.Paginator;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * $v 群审核命令处理器（从 BotCommandService 抽离）。
+ *
+ * <p>依赖 {@code reviewService}/{@code rankService} 通过 {@link Supplier} 注入——二者由组合根
+ * 在 BotCommandService 构造之后经 setter 二阶段注入（且 setReviewService 先于 setRankService），
+ * 处理器在调用时读取最新值，避免陈旧引用。</p>
+ */
+final class ReviewCommandHandler extends BotCommandContext {
+
+    private final Supplier<ReviewService> reviewService;
+    private final Supplier<RankService> rankService;
+
+    ReviewCommandHandler(
+            ServerFacade server,
+            TypedConfigProvider configs,
+            Supplier<ReviewService> reviewService,
+            Supplier<RankService> rankService) {
+        super(server, configs);
+        this.reviewService = reviewService;
+        this.rankService = rankService;
+    }
+
+    void handle(
+            OrzUserCmd cmd, boolean isAdmin, String senderName, Consumer<MessageEnvelope> callback, String rawArgs) {
+        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
+        if (reviewService.get() == null) {
+            emit(callback, "command_review_error", Map.of("message", "审核服务不可用"), "审核服务不可用");
+            return;
+        }
+        if (rawArgs.isBlank()) {
+            emitReviewUsage(callback);
+            return;
+        }
+        String[] parts = rawArgs.split("\\s+", 2);
+        String sub = parts[0].toLowerCase();
+        String rest = parts.length > 1 ? parts[1].trim() : "";
+        switch (sub) {
+            case "l" -> handleReviewList(callback, rest);
+            case "y", "yes" -> handleReviewDecision(callback, rest, true, senderName);
+            case "n", "no" -> handleReviewDecision(callback, rest, false, senderName);
+            default -> emitReviewUsage(callback);
+        }
+    }
+
+    private void handleReviewList(Consumer<MessageEnvelope> callback, String pageArg) {
+        var pending = reviewService.get().listPending();
+        if (pending.isEmpty()) {
+            emit(callback, "command_review_list_empty", Map.of(), "当前没有待审核的申请。");
+            return;
+        }
+        Integer page = parsePageArg(pageArg);
+        List<String> lines = new ArrayList<>();
+        for (var r : pending) {
+            String typeName = reviewService
+                    .get()
+                    .typeById(r.typeId())
+                    .map(t -> t.displayName())
+                    .orElse(r.typeId());
+            String playerName = playerNameOf(r);
+            RankService rank = rankService.get();
+            String group = rank == null
+                    ? ""
+                    : "（当前组：" + RankService.groupDisplayName(rank.currentGroup(r.applicantId())) + "）";
+            String summary = reviewService
+                    .get()
+                    .typeById(r.typeId())
+                    .map(t -> t.summarize(r.data()))
+                    .orElse("");
+            lines.add(
+                    "[%s] %s%s：%s（%s 提交）".formatted(typeName, playerName, group, summary, relativeTime(r.createdAt())));
+        }
+        Paginator.paginate(
+                server,
+                text -> emit(callback, "command_review_list", Map.of("message", text), text),
+                "------待审核申请------",
+                lines,
+                5,
+                page);
+    }
+
+    private void handleReviewDecision(
+            Consumer<MessageEnvelope> callback, String rest, boolean approved, String senderName) {
+        if (rest.isBlank()) {
+            emitReviewUsage(callback);
+            return;
+        }
+        // 审核人：优先群发送者身份（网关透传昵称）；未透传时兜底「群管理员」
+        String reviewer = (senderName == null || senderName.isBlank()) ? "群管理员" : senderName;
+        // 支持：$v y <玩家>  或  $v y <typeId> <玩家>
+        String[] parts = rest.split("\\s+", 2);
+        String first = parts[0];
+        String second = parts.length > 1 ? parts[1].trim() : "";
+
+        // 定位 + 发起审核在同步调度线程执行（Bukkit.getOfflinePlayer 需全局线程），
+        // 但不 join 等待——审核通过时的授权（LP 晋升）在非服务器线程执行，结果经 CF
+        // 回调发出（落状态回同步线程）。服务器调度线程绝不同步等待 LP future（自锁超时）。
+        final boolean byType = reviewService.get().typeById(first).isPresent() && !second.isBlank();
+        final String playerOrType = first;
+        final String playerName = second;
+        server.runSync(() -> {
+            try {
+                java.util.concurrent.CompletableFuture<ReviewService.Result> future;
+                if (byType) {
+                    var request = reviewService.get().pendingFor(playerOrType, playerName);
+                    if (request.isEmpty()) {
+                        future = java.util.concurrent.CompletableFuture.completedFuture(
+                                ReviewService.Result.fail("找不到待审申请: " + rest));
+                    } else {
+                        future = reviewService.get().review(request.get().id(), approved, reviewer);
+                    }
+                } else {
+                    future = reviewService.get().reviewByApplicantName(playerOrType, approved, reviewer);
+                }
+                future.whenComplete((result, err) -> {
+                    if (err != null) {
+                        result = ReviewService.Result.fail(
+                                "审核处理异常: " + (err.getMessage() == null ? "未知错误" : err.getMessage()));
+                    }
+                    emit(
+                            callback,
+                            result.success() ? "command_review_result" : "command_review_error",
+                            Map.of("message", result.message()),
+                            result.message());
+                });
+            } catch (Throwable t) {
+                emit(
+                        callback,
+                        "command_review_error",
+                        Map.of("message", "审核处理异常: " + (t.getMessage() == null ? "未知错误" : t.getMessage())),
+                        "审核处理异常: " + (t.getMessage() == null ? "未知错误" : t.getMessage()));
+            }
+        });
+    }
+
+    private String playerNameOf(ReviewRequest r) {
+        // 通过 reviewService 的玩家解析端口获取名字（不可用则回退短 UUID）
+        try {
+            var name = org.bukkit.Bukkit.getOfflinePlayer(r.applicantId()).getName();
+            return name == null ? r.applicantId().toString().substring(0, 8) : name;
+        } catch (Exception e) {
+            return r.applicantId().toString().substring(0, 8);
+        }
+    }
+
+    private static String relativeTime(long epochMillis) {
+        long diff = System.currentTimeMillis() - epochMillis;
+        long minutes = diff / 60000L;
+        if (minutes < 1) return "刚刚";
+        if (minutes < 60) return minutes + "分钟前";
+        long hours = minutes / 60;
+        return hours < 24 ? hours + "小时前" : (hours / 24) + "天前";
+    }
+
+    private void emitReviewUsage(Consumer<MessageEnvelope> callback) {
+        // 与 $v ? 同一套内容（统一 usageTip 模板），保证 fallback 与主动查询一致
+        emitUsage(
+                callback,
+                feedbackService.usageTip(OrzUserCmd.REVIEW, botConfig().cmdPromptChar()));
+    }
+}


### PR DESCRIPTION
## 概述

E3（BotCommandService God class 拆分）的第一步：把 11 个 `$cmd` handler 共享的依赖与辅助方法抽到 `BotCommandContext` 基类。

## 改动

- 新增 `BotCommandContext`（104 行）：承载 `server`/`configs`/`feedbackService` + `emit`/`emitUsage`/`emitAdminRequired`/`guardAdminCommand`/`guardWhitelistCommand`/`guardOptimizeEnabled`/`botConfig`/`parsePageArg`/`parseArgs`
- `BotCommandService` 改为 `extends BotCommandContext`，handler 调用点零改动（继承成员名不变）
- BotCommandService 735 → 654 行

## 验证

`spotlessCheck + test + integrationTest` 全绿。

## 后续（E3 Step 1，未包含）

抽 review/permission/execute-console 三个大 handler（~250 行）为独立类。它们依赖 setter 二阶段注入的可变服务（`reviewService`/`rankService`/`commandGuardService` 等），需先改 `Supplier` 或批量注入容器，属更深一次重构，见 `docs/code-quality-roadmap.md` §4 E3。