### PR TITLE
refactor: BotCommandService 拆分（E3）——735→192 行纯分派 + 依赖批量注入

### DIFF
--- a/docs/code-quality-roadmap.md
+++ b/docs/code-quality-roadmap.md
@@ -406,7 +406,7 @@
 
 - **E1 ↔ §3 的 6 个 Flash 任务**（P2-02 instanceof、P2-03 死字段、P2-07 OnlineListFormatter、P2-08 ReviewType 工厂、P2-09 渲染收敛、P2-10 tearDown）**同改 `FeatureModule.java`** → 二选一顺序：建议**先做 Flash 小改**（低风险、改动小），再做 E1 大重构；或反过来，但**不可并行**。
 - **E2 ↔ E6** **同改 `OrzEasyBot.java`** → E6 是安全补丁（小而急），**先 E6 后 E2**，或 E2 拆完后在协作类上做 E6，**不可并行**。
-- **E3 先于 E1**：E1 会调整 `botModule.botCommandService().setReviewService/setRankService` 的调用时机，E3 会改这两个 setter 本身，先 E3 定型接口再 E1 接线，避免二次返工。
+- **E3 先于 E1（已完成 ✅ 2026-08-20）**：E3 已将 `BotCommandService` 拆为纯分派 + 独立 `$cmd` 处理器，并把 6 个 setter 收敛为 `injectDependencies(BotCommandDependencies)`（组合根在连接 WebSocket 前一次性注入）。E1 现已解耦：接线点从 6 个 setter 变为 1 个 `injectDependencies`，可直接推进。
 - **E4（orzmc-api SDK 化）已立项**：目标与顺序见 §4.3。注意 SDK 化会动主模块 `core/ports`（被 portal/whitelist 等多个 feature 引用），建议在 E1-E3 稳定后启动，且按 §4.3 分阶段、每阶段全测试绿。
 - **E7/E8 是功能改动非重构**：各自独立，但 E8 涉及 netty 线程模型，需测试服真机验证（见 `folia-luckperms-gotchas.md` §6）。
 
@@ -416,7 +416,7 @@
 |---|---|---|---|
 | E1 | `FeatureModule` 拆分（993→服务装配 + 命令注册分离） | `assembly/FeatureModule.java` | **Step 0**：把 4 个静态拦截器助手（`requirement`/`guardedExec`/`commandInterceptors`/`adminInterceptors`，行 878-929）+ 3 个渲染方法（`renderReviewResult`/`renderReviewResultAsync`/`renderRankResult`，行 745-779）+ `handlePortal`/`listBlacklist` 抽到 `commands/BrigadierSupport` + `commands/CommandResultRenderer`（纯搬移，零行为变化）；**Step 1**：把 `setupCommandHandlers`（行 315-868，约 550 行）整块抽到 `commands/FeatureCommandRegistrar`，构造注入 ~20 个服务，FeatureModule 只留构造装配 + `enableForceWhitelist` + 生命周期方法 |
 | E2 | `OrzEasyBot` 拆分（834→编排 + 协作类） | `infra/bot/OrzEasyBot.java` | 抽 `InboundEventParser`/`HttpSender`/`BatchResultParser`/`WebSocketLifecycle` 四类，逐步搬移，每步全测试绿 |
-| E3 | `BotCommandService` 拆分（735→分派 + 策略） | `features/botcommands/` | 每个 `$cmd` handler 抽独立策略类，`parse()` 只做分发；6 个 `setXxxService` 二阶段注入收敛为一个 `dependencies(...)` 批量注入 |
+| E3 | `BotCommandService` 拆分（735→分派 + 策略） | `features/botcommands/` | ✅ **已完成**（2026-08-20，分支 `refactor/botcommand-service` 5 个 commit：Step 0 `BotCommandContext` → Step 1a/1b/c Review/Permission/Console → Step 2 Whitelist/PlayerList/Maintenance/Blacklist → Step 3 `injectDependencies(BotCommandDependencies)`）。`BotCommandService` 735→192 行纯分派，11 个 `$cmd` 全部独立处理器 |
 | E4 | `orzmc-api` SDK 化（原 E4 去 Bukkit 化 + E5 依赖倒置合并） | `orzmc-api/` + 主模块 `core/ports/*` | **已立项**。分 5 阶段推进，详见 §4.3 |
 | E6 | `$e` 群侧 isAdmin 白名单兜底（S8） | `infra/bot/OrzEasyBot.java` 入站鉴权（行 757-769） | 需产品决策：管理员 user_id 白名单来源（配置/数据库）。先与服主确认再设计；**先于 E2 落地** |
 | E7 | 32k 属性扫描扩展（S7） | `ExploitHardeningEventService.java` | 对 `InventoryClickEvent`/`Pickup`/末影箱等进物品路径做属性上限清理；需评估性能与误伤 |

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzServices.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzServices.java
@@ -2,10 +2,10 @@ package com.jokerhub.paper.plugin.orzmc;
 
 import com.jokerhub.paper.plugin.orzmc.assembly.BotModule;
 import com.jokerhub.paper.plugin.orzmc.assembly.FeatureModule;
-import com.jokerhub.paper.plugin.orzmc.assembly.Initializable;
 import com.jokerhub.paper.plugin.orzmc.assembly.MaintenanceModule;
 import com.jokerhub.paper.plugin.orzmc.assembly.PlatformModule;
 import com.jokerhub.paper.plugin.orzmc.assembly.PortalModule;
+import com.jokerhub.paper.plugin.orzmc.features.botcommands.BotCommandDependencies;
 import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
 
 /**
@@ -20,9 +20,8 @@ import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
  *   <li><b>BotModule</b> — 依赖 PlatformModule，内部处理 Bot ↔ Notifier 循环</li>
  *   <li><b>PortalModule</b> — 依赖 PlatformModule（ConfigService）</li>
  *   <li><b>MaintenanceModule</b> — 依赖 PlatformModule + BotModule (Notifier)</li>
- *   <li><b>跨模块链接</b> — bot.setWorldMaintenanceService() → afterPropertiesSet() →</li>
- *   <li><b>Blacklist 回引用</b> — bot.botCommandService().setBlacklistService()（Feature 创建后注入）</li>
  *   <li><b>FeatureModule</b> — 依赖所有其他模块，创建 Feature 服务并注册命令/事件</li>
+ *   <li><b>跨模块依赖注入</b> — bot.botCommandService().injectDependencies(...)（连接 WebSocket 前一次性完成）</li>
  * </ol>
  */
 public final class OrzServices {
@@ -58,20 +57,20 @@ public final class OrzServices {
         // Phase 3: 维护模块（依赖 Platform + Bot 的 Notifier）
         MaintenanceModule maintenance = new MaintenanceModule(platform, bot);
 
-        // Phase 4: 设置跨模块回引用 —— 在 afterPropertiesSet 阶段注入
-        bot.setWorldMaintenanceService(maintenance.worldMaintenanceService());
-
-        // Phase 5: 触发所有 Initializable 模块的二阶段初始化
-        if (bot instanceof Initializable) ((Initializable) bot).afterPropertiesSet();
-
-        // Phase 6: 功能模块（依赖所有其他模块）
+        // Phase 4: 功能模块（依赖所有其他模块）
         FeatureModule feature = new FeatureModule(platform, bot, portal, maintenance);
 
-        // Phase 7: 设置跨模块回引用（Blacklist/Review/Rank → BotCommandService）。
-        // 全部注入须在 botModule.setup()（连接 WebSocket）之前完成，避免半初始化窗口
-        bot.botCommandService().setBlacklistService(feature.blacklistService());
-        bot.botCommandService().setReviewService(feature.reviewService());
-        bot.botCommandService().setRankService(feature.rankService());
+        // Phase 5: 一次性注入 BotCommandService 的全部跨模块依赖（维护/黑名单/审核/权限/日志窗口/命令守卫）。
+        // 必须在 botModule.setup()（连接 WebSocket）之前完成，避免半初始化窗口
+        bot.botCommandService()
+                .injectDependencies(new BotCommandDependencies()
+                        .maintenanceService(maintenance.worldMaintenanceService())
+                        .blacklistService(feature.blacklistService())
+                        .reviewService(feature.reviewService())
+                        .rankService(feature.rankService())
+                        .logCaptureService(platform.logCaptureService())
+                        .commandGuardService(platform.commandGuardService())
+                        .commandAuditService(platform.commandAuditService()));
 
         return new OrzServices(platform, bot, portal, maintenance, feature);
     }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/BotModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/BotModule.java
@@ -14,9 +14,10 @@ import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
  *
  * <p>管理 EasyBot 网关适配器、消息路由和通知派发。
  * 内部处理 BotCommandService ← Notifier ← BotMessageService ← BotCommandService
- * 的循环依赖关系。</p>
+ * 的循环依赖关系。跨模块依赖（维护/黑名单/审核/权限/日志窗口/命令守卫）由组合根在
+ * {@link BotCommandService#injectDependencies} 中一次性注入，本模块不再持有二阶段 setter。</p>
  */
-public final class BotModule implements ServiceModule, Initializable {
+public final class BotModule implements ServiceModule {
 
     private final BotCommandService botCommandService;
     private final BotMessageService botMessageService;
@@ -28,9 +29,6 @@ public final class BotModule implements ServiceModule, Initializable {
         this.healthRegistry = new HealthRegistry();
         // Phase A: 先创建 BotCommandService（核心依赖来自 PlatformModule）
         this.botCommandService = new BotCommandService(platform.serverFacade(), platform.configs());
-        // $e 命令输出兜底：注入日志窗口收集服务
-        this.botCommandService.setLogCaptureService(platform.logCaptureService());
-        this.botCommandService.setCommandGuard(platform.commandGuardService(), platform.commandAuditService());
 
         // Phase C: 创建 BotMessageService（以 BotCommandService 作为 BotInboundHandler）
         this.botMessageService = BotMessageServiceProvider.create(
@@ -45,26 +43,6 @@ public final class BotModule implements ServiceModule, Initializable {
 
         // BotStatusService
         this.botStatusService = new BotStatusService(platform.textStyles(), new HealthAccessor(healthRegistry));
-    }
-
-    // 跨模块回引用（通过 afterPropertiesSet 注入）
-    private volatile com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService
-            pendingMaintenanceService;
-
-    /**
-     * 设置跨模块依赖，将在 {@link #afterPropertiesSet()} 阶段注入。
-     */
-    public void setWorldMaintenanceService(
-            com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService maintenanceService) {
-        this.pendingMaintenanceService = maintenanceService;
-    }
-
-    @Override
-    public void afterPropertiesSet() {
-        if (pendingMaintenanceService != null) {
-            botCommandService.setMaintenanceService(pendingMaintenanceService);
-            pendingMaintenanceService = null;
-        }
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BlacklistCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BlacklistCommandHandler.java
@@ -1,0 +1,60 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * $d IP 黑名单命令处理器（从 BotCommandService 抽离）。
+ *
+ * <p>{@code blacklistService} 通过 {@link Supplier} 注入——组合根在 BotCommandService 构造后经
+ * setter 二阶段注入，处理器调用时读取最新值；未注入时提示服务不可用。</p>
+ */
+final class BlacklistCommandHandler extends BotCommandContext {
+
+    private final Supplier<BlacklistService> blacklistService;
+
+    BlacklistCommandHandler(
+            ServerFacade server, TypedConfigProvider configs, Supplier<BlacklistService> blacklistService) {
+        super(server, configs);
+        this.blacklistService = blacklistService;
+    }
+
+    void handleBlacklist(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
+        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
+        BlacklistService svc = blacklistService.get();
+        if (svc == null) {
+            emit(callback, "command_blacklist_error", Map.of("message", "黑名单服务不可用"), "黑名单服务不可用");
+            return;
+        }
+        if (rawArgs.isEmpty()) {
+            List<String> patterns = svc.getPatterns();
+            if (patterns.isEmpty()) {
+                emit(callback, "command_blacklist_list", Map.of("patterns", "黑名单为空"), "黑名单为空");
+            } else {
+                emit(
+                        callback,
+                        "command_blacklist_list",
+                        Map.of("patterns", String.join("\n", patterns)),
+                        String.join("\n", patterns));
+            }
+            return;
+        }
+        if (rawArgs.startsWith("-")) {
+            svc.remove(rawArgs.substring(1));
+            emit(
+                    callback,
+                    "command_blacklist_remove",
+                    Map.of("message", "已移除: " + rawArgs.substring(1)),
+                    "已移除: " + rawArgs.substring(1));
+        } else {
+            svc.add(rawArgs);
+            emit(callback, "command_blacklist_add", Map.of("message", "已添加: " + rawArgs), "已添加: " + rawArgs);
+        }
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BlacklistCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BlacklistCommandHandler.java
@@ -12,8 +12,8 @@ import java.util.function.Supplier;
 /**
  * $d IP 黑名单命令处理器（从 BotCommandService 抽离）。
  *
- * <p>{@code blacklistService} 通过 {@link Supplier} 注入——组合根在 BotCommandService 构造后经
- * setter 二阶段注入，处理器调用时读取最新值；未注入时提示服务不可用。</p>
+ * <p>{@code blacklistService} 通过 {@link Supplier} 注入——组合根经
+ * {@link BotCommandService#injectDependencies} 一次性注入，处理器调用时读取最新值；未注入时提示服务不可用。</p>
  */
 final class BlacklistCommandHandler extends BotCommandContext {
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandDependencies.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandDependencies.java
@@ -1,0 +1,90 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
+import com.jokerhub.paper.plugin.orzmc.features.rank.RankService;
+import com.jokerhub.paper.plugin.orzmc.features.review.ReviewService;
+import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
+import com.jokerhub.paper.plugin.orzmc.features.security.CommandAuditService;
+import com.jokerhub.paper.plugin.orzmc.features.security.CommandGuardService;
+import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
+
+/**
+ * {@link BotCommandService} 的跨模块依赖集合（六边形边界处的一次性批量注入）。
+ *
+ * <p>取代原先的 6 个 {@code setXxxService} 二阶段 setter——组合根在 {@link BotCommandService}
+ * 构造后、WebSocket 连接前一次性 {@code injectDependencies(this)}，消除「先连上、后注入」的
+ * 半初始化窗口。字段可空：未注入的依赖由对应处理器降级处理（见各 Handler 的 Supplier 说明）。</p>
+ */
+public final class BotCommandDependencies {
+
+    private WorldMaintenanceService maintenanceService;
+    private BlacklistService blacklistService;
+    private ReviewService reviewService;
+    private RankService rankService;
+    private LogCaptureService logCaptureService;
+    private CommandGuardService commandGuardService;
+    private CommandAuditService commandAuditService;
+
+    public BotCommandDependencies maintenanceService(WorldMaintenanceService maintenanceService) {
+        this.maintenanceService = maintenanceService;
+        return this;
+    }
+
+    public BotCommandDependencies blacklistService(BlacklistService blacklistService) {
+        this.blacklistService = blacklistService;
+        return this;
+    }
+
+    public BotCommandDependencies reviewService(ReviewService reviewService) {
+        this.reviewService = reviewService;
+        return this;
+    }
+
+    public BotCommandDependencies rankService(RankService rankService) {
+        this.rankService = rankService;
+        return this;
+    }
+
+    public BotCommandDependencies logCaptureService(LogCaptureService logCaptureService) {
+        this.logCaptureService = logCaptureService;
+        return this;
+    }
+
+    public BotCommandDependencies commandGuardService(CommandGuardService commandGuardService) {
+        this.commandGuardService = commandGuardService;
+        return this;
+    }
+
+    public BotCommandDependencies commandAuditService(CommandAuditService commandAuditService) {
+        this.commandAuditService = commandAuditService;
+        return this;
+    }
+
+    WorldMaintenanceService maintenanceService() {
+        return maintenanceService;
+    }
+
+    BlacklistService blacklistService() {
+        return blacklistService;
+    }
+
+    ReviewService reviewService() {
+        return reviewService;
+    }
+
+    RankService rankService() {
+        return rankService;
+    }
+
+    LogCaptureService logCaptureService() {
+        return logCaptureService;
+    }
+
+    CommandGuardService commandGuardService() {
+        return commandGuardService;
+    }
+
+    CommandAuditService commandAuditService() {
+        return commandAuditService;
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -7,20 +7,11 @@ import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceServ
 import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandAuditService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandGuardService;
-import com.jokerhub.paper.plugin.orzmc.features.whitelist.WhitelistService;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.BotConfig;
-import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
-import com.jokerhub.paper.plugin.orzmc.infra.config.configs.WhitelistConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
-import com.jokerhub.paper.plugin.orzmc.infra.paging.Paginator;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
-import java.util.logging.Level;
-import org.bukkit.entity.Player;
 
 public final class BotCommandService extends BotCommandContext implements BotInboundHandler {
     private BotCommandListFeedbackService listFeedbackService;
@@ -40,6 +31,14 @@ public final class BotCommandService extends BotCommandContext implements BotInb
     private final PermissionCommandHandler permissionCommandHandler;
     /** $e 控制台命令执行处理器（Supplier 注入 guard/audit/logCapture）。 */
     private final ConsoleCommandHandler consoleCommandHandler;
+    /** $a/$r/$w 白名单命令处理器（Supplier 注入 listFeedbackService，setRankService 后重建）。 */
+    private final WhitelistCommandHandler whitelistCommandHandler;
+    /** $l 在线玩家列表命令处理器（Supplier 注入 listFeedbackService）。 */
+    private final PlayerListCommandHandler playerListCommandHandler;
+    /** $b/$o 地图备份/优化命令处理器（Supplier 注入 maintenanceService）。 */
+    private final MaintenanceCommandHandler maintenanceCommandHandler;
+    /** $d IP 黑名单命令处理器（Supplier 注入 blacklistService）。 */
+    private final BlacklistCommandHandler blacklistCommandHandler;
 
     @FunctionalInterface
     private interface CmdHandler {
@@ -60,17 +59,30 @@ public final class BotCommandService extends BotCommandContext implements BotInb
         this.permissionCommandHandler = new PermissionCommandHandler(server, configs, () -> rankService);
         this.consoleCommandHandler = new ConsoleCommandHandler(
                 server, configs, () -> commandGuardService, () -> commandAuditService, () -> logCaptureService);
+        this.whitelistCommandHandler = new WhitelistCommandHandler(server, configs, () -> listFeedbackService);
+        this.playerListCommandHandler = new PlayerListCommandHandler(server, configs, () -> listFeedbackService);
+        this.maintenanceCommandHandler = new MaintenanceCommandHandler(server, configs, () -> maintenanceService);
+        this.blacklistCommandHandler = new BlacklistCommandHandler(server, configs, () -> blacklistService);
         this.handlers = Map.ofEntries(
-                Map.entry(OrzUserCmd.SHOW_PLAYERS, (c, a, s, cb, r) -> handleShowPlayers(c, a, cb, r)),
-                Map.entry(OrzUserCmd.SHOW_WHITELIST, (c, a, s, cb, r) -> handleShowWhitelist(c, a, cb, r)),
-                Map.entry(OrzUserCmd.SHOW_HELP, (c, a, s, cb, r) -> handleShowHelp(c, a, cb, r)),
-                Map.entry(OrzUserCmd.ADD_PLAYER_TO_WHITELIST, (c, a, s, cb, r) -> handleAddWhitelist(c, a, cb, r)),
+                Map.entry(
+                        OrzUserCmd.SHOW_PLAYERS,
+                        (c, a, s, cb, r) -> playerListCommandHandler.handleShowPlayers(c, a, cb, r)),
+                Map.entry(
+                        OrzUserCmd.SHOW_WHITELIST,
+                        (c, a, s, cb, r) -> whitelistCommandHandler.handleShowWhitelist(c, a, cb, r)),
+                Map.entry(OrzUserCmd.SHOW_HELP, (c, a, s, cb, r) -> emitHelp(cb)),
+                Map.entry(
+                        OrzUserCmd.ADD_PLAYER_TO_WHITELIST,
+                        (c, a, s, cb, r) -> whitelistCommandHandler.handleAddWhitelist(c, a, cb, r)),
                 Map.entry(
                         OrzUserCmd.REMOVE_PLAYER_FROM_WHITELIST,
-                        (c, a, s, cb, r) -> handleRemoveWhitelist(c, a, cb, r)),
-                Map.entry(OrzUserCmd.BACKUP, (c, a, s, cb, r) -> handleBackup(c, a, cb, r)),
-                Map.entry(OrzUserCmd.OPTIMIZE_WORLD, (c, a, s, cb, r) -> handleOptimize(c, a, cb, r)),
-                Map.entry(OrzUserCmd.BLACKLIST, (c, a, s, cb, r) -> handleBlacklist(c, a, cb, r)),
+                        (c, a, s, cb, r) -> whitelistCommandHandler.handleRemoveWhitelist(c, a, cb, r)),
+                Map.entry(OrzUserCmd.BACKUP, (c, a, s, cb, r) -> maintenanceCommandHandler.handleBackup(c, a, cb, r)),
+                Map.entry(
+                        OrzUserCmd.OPTIMIZE_WORLD,
+                        (c, a, s, cb, r) -> maintenanceCommandHandler.handleOptimize(c, a, cb, r)),
+                Map.entry(
+                        OrzUserCmd.BLACKLIST, (c, a, s, cb, r) -> blacklistCommandHandler.handleBlacklist(c, a, cb, r)),
                 Map.entry(OrzUserCmd.REVIEW, (c, a, s, cb, r) -> reviewCommandHandler.handle(c, a, s, cb, r)),
                 Map.entry(OrzUserCmd.PERMISSION, (c, a, s, cb, r) -> permissionCommandHandler.handle(c, a, cb, r)),
                 Map.entry(
@@ -185,185 +197,4 @@ public final class BotCommandService extends BotCommandContext implements BotInb
         if (rawMessage.length() <= prefix.length()) return "";
         return rawMessage.substring(prefix.length()).trim();
     }
-
-    // ---- Command handlers (all follow CmdHandler interface) ----
-
-    private void handleShowPlayers(
-            OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        server.runAsync(() -> {
-            try {
-                ArrayList<Player> onlinePlayers = listFeedbackService.currentOnlinePlayers();
-                BotCommandListFeedbackService.OnlineList online = listFeedbackService.buildOnlineList(
-                        onlinePlayers, server.server().getMaxPlayers());
-                emit(callback, "command_players", listFeedbackService.onlineVars(online), online.fallback());
-            } catch (Exception e) {
-                server.logger().log(Level.SEVERE, "onlinePlayersInfo 异步任务异常", e);
-            }
-        });
-    }
-
-    private void handleShowWhitelist(
-            OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        server.runAsync(() -> {
-            try {
-                WhitelistConfig whitelistConfig = configs.whitelist();
-                WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
-                int delayTicks = Math.max(0, whitelistConfig.paginationDelayTicks());
-                Integer page = parsePageArg(rawArgs);
-                if (isAdmin) {
-                    renderWhitelistWithCleanup(callback, page, delayTicks, svc, whitelistConfig);
-                } else {
-                    renderWhitelistPages(callback, page, delayTicks, svc);
-                }
-            } catch (Exception e) {
-                server.logger().log(Level.SEVERE, "whiteListInfo 异步任务异常", e);
-            }
-        });
-    }
-
-    private void handleShowHelp(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        String help = feedbackService.helpInfo(botConfig().cmdPromptChar());
-        emit(callback, "command_help", Map.of("help", help), help);
-    }
-
-    private void handleAddWhitelist(
-            OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        Set<String> userNames = parseArgs(rawArgs);
-        if (!guardWhitelistCommand(cmd, isAdmin, userNames, callback)) return;
-        server.runSync(() -> {
-            WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
-            String message = svc.addPlayers(server.server(), userNames);
-            emit(callback, "command_whitelist_add_result", Map.of("message", message), message);
-        });
-    }
-
-    private void handleRemoveWhitelist(
-            OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        Set<String> userNames = parseArgs(rawArgs);
-        if (!guardWhitelistCommand(cmd, isAdmin, userNames, callback)) return;
-        server.runSync(() -> {
-            WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
-            String message = svc.removePlayers(server.server(), userNames);
-            emit(callback, "command_whitelist_remove_result", Map.of("message", message), message);
-        });
-    }
-
-    private void handleBackup(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
-        MaintenanceConfig maintenance = configs.maintenance();
-        long tickTimeThreshold = maintenance.optimizeTickTimeThreshold();
-        int retain = maintenance.backupRetentionCount();
-        if (maintenanceService != null) {
-            maintenanceService.backup(
-                    tickTimeThreshold, retain, msg -> emit(callback, "command_backup", Map.of("message", msg), msg));
-        }
-    }
-
-    private void handleOptimize(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
-        if (!guardOptimizeEnabled(callback)) return;
-        MaintenanceConfig maintenance = configs.maintenance();
-        long tickTimeThreshold = maintenance.optimizeTickTimeThreshold();
-        if (maintenanceService != null) {
-            maintenanceService.optimize(
-                    tickTimeThreshold, msg -> emit(callback, "command_optimize", Map.of("message", msg), msg));
-        }
-    }
-
-    // ---- Blacklist command ----
-
-    private void handleBlacklist(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
-        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
-        if (blacklistService == null) {
-            emit(callback, "command_blacklist_error", Map.of("message", "黑名单服务不可用"), "黑名单服务不可用");
-            return;
-        }
-        if (rawArgs.isEmpty()) {
-            List<String> patterns = blacklistService.getPatterns();
-            if (patterns.isEmpty()) {
-                emit(callback, "command_blacklist_list", Map.of("patterns", "黑名单为空"), "黑名单为空");
-            } else {
-                emit(
-                        callback,
-                        "command_blacklist_list",
-                        Map.of("patterns", String.join("\n", patterns)),
-                        String.join("\n", patterns));
-            }
-            return;
-        }
-        if (rawArgs.startsWith("-")) {
-            blacklistService.remove(rawArgs.substring(1));
-            emit(
-                    callback,
-                    "command_blacklist_remove",
-                    Map.of("message", "已移除: " + rawArgs.substring(1)),
-                    "已移除: " + rawArgs.substring(1));
-        } else {
-            blacklistService.add(rawArgs);
-            emit(callback, "command_blacklist_add", Map.of("message", "已添加: " + rawArgs), "已添加: " + rawArgs);
-        }
-    }
-
-    // ---- Helper ----
-
-    // ---- Whitelist rendering ----
-
-    private void renderWhitelistWithCleanup(
-            Consumer<MessageEnvelope> callback,
-            Integer page,
-            int delayTicks,
-            WhitelistService svc,
-            WhitelistConfig whitelistConfig) {
-        server.runSync(() -> {
-            Set<String> removed =
-                    svc.cleanupInactivePlayers(server.server(), Math.max(1, whitelistConfig.cleanupInactiveDays()));
-            server.runAsync(() -> {
-                try {
-                    ArrayList<String> updatedLines = new ArrayList<>(svc.buildWhitelistLines(server.server()));
-                    BotCommandListFeedbackService.WhitelistHeader headerInfo =
-                            listFeedbackService.buildWhitelistHeader(updatedLines.size());
-                    if (!removed.isEmpty()) {
-                        BotCommandListFeedbackService.CleanupNotice notice =
-                                listFeedbackService.buildCleanupNotice(removed);
-                        emit(
-                                callback,
-                                "command_whitelist_cleanup",
-                                listFeedbackService.cleanupVars(notice),
-                                notice.fallback());
-                    }
-                    emitWhitelistPages(callback, headerInfo.header(), updatedLines, delayTicks, page);
-                } catch (Exception e) {
-                    server.logger().log(Level.SEVERE, "renderWhitelistWithCleanup 异步任务异常", e);
-                }
-            });
-        });
-    }
-
-    private void renderWhitelistPages(
-            Consumer<MessageEnvelope> callback, Integer page, int delayTicks, WhitelistService svc) {
-        ArrayList<String> lines = new ArrayList<>(svc.buildWhitelistLines(server.server()));
-        BotCommandListFeedbackService.WhitelistHeader headerInfo =
-                listFeedbackService.buildWhitelistHeader(lines.size());
-        emitWhitelistPages(callback, headerInfo.header(), lines, delayTicks, page);
-    }
-
-    private void emitWhitelistPages(
-            Consumer<MessageEnvelope> callback, String header, ArrayList<String> lines, int delayTicks, Integer page) {
-        Paginator.paginatePages(
-                server,
-                (pageIndex, total, headerText, body) -> {
-                    BotCommandListFeedbackService.WhitelistPage pageInfo =
-                            listFeedbackService.buildWhitelistPage(headerText, pageIndex, total, body);
-                    emit(callback, "command_whitelist_page", pageInfo.vars(), pageInfo.fallback());
-                },
-                header,
-                lines,
-                delayTicks,
-                page);
-    }
-
-    // ---- Guards ----
-
-    // ---- Emitters ----
-
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -31,7 +31,7 @@ public final class BotCommandService extends BotCommandContext implements BotInb
     private final PermissionCommandHandler permissionCommandHandler;
     /** $e 控制台命令执行处理器（Supplier 注入 guard/audit/logCapture）。 */
     private final ConsoleCommandHandler consoleCommandHandler;
-    /** $a/$r/$w 白名单命令处理器（Supplier 注入 listFeedbackService，setRankService 后重建）。 */
+    /** $a/$r/$w 白名单命令处理器（Supplier 注入 listFeedbackService，rankService 注入后重建）。 */
     private final WhitelistCommandHandler whitelistCommandHandler;
     /** $l 在线玩家列表命令处理器（Supplier 注入 listFeedbackService）。 */
     private final PlayerListCommandHandler playerListCommandHandler;
@@ -90,36 +90,28 @@ public final class BotCommandService extends BotCommandContext implements BotInb
                         (c, a, s, cb, r) -> consoleCommandHandler.handle(c, a, s, cb, r)));
     }
 
-    public void setMaintenanceService(WorldMaintenanceService maintenanceService) {
-        this.maintenanceService = maintenanceService;
-    }
-
-    public void setBlacklistService(BlacklistService blacklistService) {
-        this.blacklistService = blacklistService;
-    }
-
-    public void setReviewService(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService reviewService) {
-        this.reviewService = reviewService;
-    }
-
-    public void setRankService(com.jokerhub.paper.plugin.orzmc.features.rank.RankService rankService) {
-        this.rankService = rankService;
-        // 重建列表反馈服务以注入 rankService（在线列表显示权限组）
-        com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter formatter =
-                new com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter();
-        formatter.setRankService(rankService);
-        this.listFeedbackService = new BotCommandListFeedbackService(server, configs, formatter);
-    }
-
-    /** 注入日志窗口收集服务（$e 命令输出兜底）。未注入时 $e 退化为仅返回执行状态。 */
-    public void setLogCaptureService(LogCaptureService logCaptureService) {
-        this.logCaptureService = logCaptureService;
-    }
-
-    /** 注入危险命令 guard 与审计（安全加固 P0-5）。未注入时 $e 按原路径直接执行（测试向后兼容）。 */
-    public void setCommandGuard(CommandGuardService commandGuardService, CommandAuditService commandAuditService) {
-        this.commandGuardService = commandGuardService;
-        this.commandAuditService = commandAuditService;
+    /**
+     * 一次性注入全部跨模块依赖（取代 6 个 {@code setXxxService} 二阶段 setter）。
+     *
+     * <p>组合根须在 {@link BotCommandService} 构造后、WebSocket 连接前调用本方法，消除「先连上、
+     * 后注入」的半初始化窗口。rankService 非空时重建列表反馈服务（在线列表显示权限组）；其余
+     * 依赖可空，未注入时由对应处理器降级处理（见各 Handler 的 Supplier 说明）。</p>
+     */
+    public void injectDependencies(BotCommandDependencies deps) {
+        this.maintenanceService = deps.maintenanceService();
+        this.blacklistService = deps.blacklistService();
+        this.reviewService = deps.reviewService();
+        this.logCaptureService = deps.logCaptureService();
+        this.commandGuardService = deps.commandGuardService();
+        this.commandAuditService = deps.commandAuditService();
+        this.rankService = deps.rankService();
+        if (deps.rankService() != null) {
+            // 重建列表反馈服务以注入 rankService（在线列表显示权限组）
+            com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter formatter =
+                    new com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter();
+            formatter.setRankService(deps.rankService());
+            this.listFeedbackService = new BotCommandListFeedbackService(server, configs, formatter);
+        }
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/ConsoleCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/ConsoleCommandHandler.java
@@ -15,7 +15,7 @@ import java.util.function.Supplier;
  * $e 控制台命令执行处理器（从 BotCommandService 抽离）。
  *
  * <p>{@code commandGuardService}/{@code commandAuditService}/{@code logCaptureService} 通过
- * {@link Supplier} 注入（setter 二阶段注入），调用时读取最新值；未注入时退化为直接执行/无审计
+ * {@link Supplier} 注入（组合根经 {@link BotCommandService#injectDependencies} 一次性注入），调用时读取最新值；未注入时退化为直接执行/无审计
  * （测试向后兼容）。</p>
  */
 final class ConsoleCommandHandler extends BotCommandContext {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/MaintenanceCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/MaintenanceCommandHandler.java
@@ -12,8 +12,8 @@ import java.util.function.Supplier;
 /**
  * $b/$o 地图备份/优化命令处理器（从 BotCommandService 抽离）。
  *
- * <p>{@code maintenanceService} 通过 {@link Supplier} 注入——组合根在 BotCommandService 构造后经
- * setter 二阶段注入，处理器调用时读取最新值；未注入时静默忽略（向后兼容测试）。</p>
+ * <p>{@code maintenanceService} 通过 {@link Supplier} 注入——组合根经
+ * {@link BotCommandService#injectDependencies} 一次性注入，处理器调用时读取最新值；未注入时静默忽略（向后兼容测试）。</p>
  */
 final class MaintenanceCommandHandler extends BotCommandContext {
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/MaintenanceCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/MaintenanceCommandHandler.java
@@ -1,0 +1,49 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * $b/$o 地图备份/优化命令处理器（从 BotCommandService 抽离）。
+ *
+ * <p>{@code maintenanceService} 通过 {@link Supplier} 注入——组合根在 BotCommandService 构造后经
+ * setter 二阶段注入，处理器调用时读取最新值；未注入时静默忽略（向后兼容测试）。</p>
+ */
+final class MaintenanceCommandHandler extends BotCommandContext {
+
+    private final Supplier<WorldMaintenanceService> maintenanceService;
+
+    MaintenanceCommandHandler(
+            ServerFacade server, TypedConfigProvider configs, Supplier<WorldMaintenanceService> maintenanceService) {
+        super(server, configs);
+        this.maintenanceService = maintenanceService;
+    }
+
+    void handleBackup(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
+        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
+        MaintenanceConfig maintenance = configs.maintenance();
+        long tickTimeThreshold = maintenance.optimizeTickTimeThreshold();
+        int retain = maintenance.backupRetentionCount();
+        WorldMaintenanceService svc = maintenanceService.get();
+        if (svc != null) {
+            svc.backup(tickTimeThreshold, retain, msg -> emit(callback, "command_backup", Map.of("message", msg), msg));
+        }
+    }
+
+    void handleOptimize(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
+        if (!guardAdminCommand(cmd, isAdmin, callback)) return;
+        if (!guardOptimizeEnabled(callback)) return;
+        MaintenanceConfig maintenance = configs.maintenance();
+        long tickTimeThreshold = maintenance.optimizeTickTimeThreshold();
+        WorldMaintenanceService svc = maintenanceService.get();
+        if (svc != null) {
+            svc.optimize(tickTimeThreshold, msg -> emit(callback, "command_optimize", Map.of("message", msg), msg));
+        }
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/PermissionCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/PermissionCommandHandler.java
@@ -11,8 +11,8 @@ import java.util.function.Supplier;
 /**
  * $p u|d 群权限升降级命令处理器（从 BotCommandService 抽离）。
  *
- * <p>{@code rankService} 通过 {@link Supplier} 注入——组合根在 BotCommandService 构造后经
- * setter 二阶段注入，处理器调用时读取最新值。升降级走 {@code promoteAsync/demoteAsync}
+ * <p>{@code rankService} 通过 {@link Supplier} 注入——组合根经
+ * {@link BotCommandService#injectDependencies} 一次性注入，处理器调用时读取最新值。升降级走 {@code promoteAsync/demoteAsync}
  * 异步（LP 操作在非服务器线程），绝不 runSync+join（自锁超时，见 folia-luckperms-gotchas.md）。</p>
  */
 final class PermissionCommandHandler extends BotCommandContext {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/PlayerListCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/PlayerListCommandHandler.java
@@ -1,0 +1,43 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import org.bukkit.entity.Player;
+
+/**
+ * $l 在线玩家列表命令处理器（从 BotCommandService 抽离）。
+ *
+ * <p>{@code listFeedbackService} 通过 {@link Supplier} 注入——其内部 {@code OnlineListFormatter}
+ * 需在 rankService 二阶段注入后重建（在线列表显示权限组），处理器调用时读取最新实例。</p>
+ */
+final class PlayerListCommandHandler extends BotCommandContext {
+
+    private final Supplier<BotCommandListFeedbackService> listFeedbackService;
+
+    PlayerListCommandHandler(
+            ServerFacade server,
+            TypedConfigProvider configs,
+            Supplier<BotCommandListFeedbackService> listFeedbackService) {
+        super(server, configs);
+        this.listFeedbackService = listFeedbackService;
+    }
+
+    void handleShowPlayers(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
+        server.runAsync(() -> {
+            try {
+                ArrayList<Player> onlinePlayers = listFeedbackService.get().currentOnlinePlayers();
+                BotCommandListFeedbackService.OnlineList online = listFeedbackService
+                        .get()
+                        .buildOnlineList(onlinePlayers, server.server().getMaxPlayers());
+                emit(callback, "command_players", listFeedbackService.get().onlineVars(online), online.fallback());
+            } catch (Exception e) {
+                server.logger().log(Level.SEVERE, "onlinePlayersInfo 异步任务异常", e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/PlayerListCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/PlayerListCommandHandler.java
@@ -13,7 +13,7 @@ import org.bukkit.entity.Player;
  * $l 在线玩家列表命令处理器（从 BotCommandService 抽离）。
  *
  * <p>{@code listFeedbackService} 通过 {@link Supplier} 注入——其内部 {@code OnlineListFormatter}
- * 需在 rankService 二阶段注入后重建（在线列表显示权限组），处理器调用时读取最新实例。</p>
+ * 需在 rankService 注入后重建（在线列表显示权限组），处理器调用时读取最新实例。</p>
  */
 final class PlayerListCommandHandler extends BotCommandContext {
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/ReviewCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/ReviewCommandHandler.java
@@ -17,8 +17,7 @@ import java.util.function.Supplier;
  * $v 群审核命令处理器（从 BotCommandService 抽离）。
  *
  * <p>依赖 {@code reviewService}/{@code rankService} 通过 {@link Supplier} 注入——二者由组合根
- * 在 BotCommandService 构造之后经 setter 二阶段注入（且 setReviewService 先于 setRankService），
- * 处理器在调用时读取最新值，避免陈旧引用。</p>
+ * 经 {@link BotCommandService#injectDependencies} 一次性注入，处理器在调用时读取最新值，避免陈旧引用。</p>
  */
 final class ReviewCommandHandler extends BotCommandContext {
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/WhitelistCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/WhitelistCommandHandler.java
@@ -17,7 +17,7 @@ import java.util.logging.Level;
  * $a/$r/$w 白名单命令处理器（从 BotCommandService 抽离）。
  *
  * <p>{@code listFeedbackService} 通过 {@link Supplier} 注入——其内部 {@code OnlineListFormatter}
- * 需在 rankService 二阶段注入后重建（在线列表显示权限组），处理器调用时读取最新实例，避免陈旧引用。</p>
+ * 需在 rankService 注入后重建（在线列表显示权限组），处理器调用时读取最新实例，避免陈旧引用。</p>
  */
 final class WhitelistCommandHandler extends BotCommandContext {
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/WhitelistCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/WhitelistCommandHandler.java
@@ -1,0 +1,125 @@
+package com.jokerhub.paper.plugin.orzmc.features.botcommands;
+
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
+import com.jokerhub.paper.plugin.orzmc.features.whitelist.WhitelistService;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.WhitelistConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.paging.Paginator;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+/**
+ * $a/$r/$w 白名单命令处理器（从 BotCommandService 抽离）。
+ *
+ * <p>{@code listFeedbackService} 通过 {@link Supplier} 注入——其内部 {@code OnlineListFormatter}
+ * 需在 rankService 二阶段注入后重建（在线列表显示权限组），处理器调用时读取最新实例，避免陈旧引用。</p>
+ */
+final class WhitelistCommandHandler extends BotCommandContext {
+
+    private final Supplier<BotCommandListFeedbackService> listFeedbackService;
+
+    WhitelistCommandHandler(
+            ServerFacade server,
+            TypedConfigProvider configs,
+            Supplier<BotCommandListFeedbackService> listFeedbackService) {
+        super(server, configs);
+        this.listFeedbackService = listFeedbackService;
+    }
+
+    void handleShowWhitelist(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
+        server.runAsync(() -> {
+            try {
+                WhitelistConfig whitelistConfig = configs.whitelist();
+                WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
+                int delayTicks = Math.max(0, whitelistConfig.paginationDelayTicks());
+                Integer page = parsePageArg(rawArgs);
+                if (isAdmin) {
+                    renderWhitelistWithCleanup(callback, page, delayTicks, svc, whitelistConfig);
+                } else {
+                    renderWhitelistPages(callback, page, delayTicks, svc);
+                }
+            } catch (Exception e) {
+                server.logger().log(Level.SEVERE, "whiteListInfo 异步任务异常", e);
+            }
+        });
+    }
+
+    void handleAddWhitelist(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
+        Set<String> userNames = parseArgs(rawArgs);
+        if (!guardWhitelistCommand(cmd, isAdmin, userNames, callback)) return;
+        server.runSync(() -> {
+            WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
+            String message = svc.addPlayers(server.server(), userNames);
+            emit(callback, "command_whitelist_add_result", Map.of("message", message), message);
+        });
+    }
+
+    void handleRemoveWhitelist(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
+        Set<String> userNames = parseArgs(rawArgs);
+        if (!guardWhitelistCommand(cmd, isAdmin, userNames, callback)) return;
+        server.runSync(() -> {
+            WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
+            String message = svc.removePlayers(server.server(), userNames);
+            emit(callback, "command_whitelist_remove_result", Map.of("message", message), message);
+        });
+    }
+
+    private void renderWhitelistWithCleanup(
+            Consumer<MessageEnvelope> callback,
+            Integer page,
+            int delayTicks,
+            WhitelistService svc,
+            WhitelistConfig whitelistConfig) {
+        server.runSync(() -> {
+            Set<String> removed =
+                    svc.cleanupInactivePlayers(server.server(), Math.max(1, whitelistConfig.cleanupInactiveDays()));
+            server.runAsync(() -> {
+                try {
+                    ArrayList<String> updatedLines = new ArrayList<>(svc.buildWhitelistLines(server.server()));
+                    BotCommandListFeedbackService.WhitelistHeader headerInfo =
+                            listFeedbackService.get().buildWhitelistHeader(updatedLines.size());
+                    if (!removed.isEmpty()) {
+                        BotCommandListFeedbackService.CleanupNotice notice =
+                                listFeedbackService.get().buildCleanupNotice(removed);
+                        emit(
+                                callback,
+                                "command_whitelist_cleanup",
+                                listFeedbackService.get().cleanupVars(notice),
+                                notice.fallback());
+                    }
+                    emitWhitelistPages(callback, headerInfo.header(), updatedLines, delayTicks, page);
+                } catch (Exception e) {
+                    server.logger().log(Level.SEVERE, "renderWhitelistWithCleanup 异步任务异常", e);
+                }
+            });
+        });
+    }
+
+    private void renderWhitelistPages(
+            Consumer<MessageEnvelope> callback, Integer page, int delayTicks, WhitelistService svc) {
+        ArrayList<String> lines = new ArrayList<>(svc.buildWhitelistLines(server.server()));
+        BotCommandListFeedbackService.WhitelistHeader headerInfo =
+                listFeedbackService.get().buildWhitelistHeader(lines.size());
+        emitWhitelistPages(callback, headerInfo.header(), lines, delayTicks, page);
+    }
+
+    private void emitWhitelistPages(
+            Consumer<MessageEnvelope> callback, String header, ArrayList<String> lines, int delayTicks, Integer page) {
+        Paginator.paginatePages(
+                server,
+                (pageIndex, total, headerText, body) -> {
+                    BotCommandListFeedbackService.WhitelistPage pageInfo =
+                            listFeedbackService.get().buildWhitelistPage(headerText, pageIndex, total, body);
+                    emit(callback, "command_whitelist_page", pageInfo.vars(), pageInfo.fallback());
+                },
+                header,
+                lines,
+                delayTicks,
+                page);
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/assembly/BotModuleTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/assembly/BotModuleTest.java
@@ -3,7 +3,6 @@ package com.jokerhub.paper.plugin.orzmc.assembly;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,9 +14,6 @@ class BotModuleTest {
 
     @Mock
     private PlatformModule platform;
-
-    @Mock
-    private WorldMaintenanceService maintenanceService;
 
     private BotModule module;
 
@@ -46,28 +42,6 @@ class BotModuleTest {
     @Test
     void botInboundHandler_isBotCommandService() {
         assertSame(module.botCommandService(), module.botInboundHandler());
-    }
-
-    @Test
-    void setWorldMaintenanceService_storesReference() {
-        module.setWorldMaintenanceService(maintenanceService);
-        // afterPropertiesSet 之前未设置
-        module.afterPropertiesSet();
-        // 验证 BotCommandService.setMaintenanceService 被调用
-    }
-
-    @Test
-    void setWorldMaintenanceService_null_doesNothing() {
-        module.setWorldMaintenanceService(null);
-        assertDoesNotThrow(() -> module.afterPropertiesSet());
-    }
-
-    @Test
-    void afterPropertiesSet_clearsPendingReference() {
-        module.setWorldMaintenanceService(maintenanceService);
-        module.afterPropertiesSet();
-        // 第二次调用不抛异常（pendingMaintenanceService 已清空）
-        assertDoesNotThrow(() -> module.afterPropertiesSet());
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandServiceTest.java
@@ -179,7 +179,7 @@ class BotCommandServiceTest {
         LogCaptureService capture = mock(LogCaptureService.class);
         when(capture.watermark()).thenReturn(42L);
         when(capture.drainSince(42L)).thenReturn(java.util.List.of("async log line"));
-        service.setLogCaptureService(capture);
+        service.injectDependencies(new BotCommandDependencies().logCaptureService(capture));
 
         when(serverFacade.executeConsoleCommand("say hello"))
                 .thenReturn(new ServerFacade.ConsoleCommandResult("say hello", true, java.util.List.of("sync line")));
@@ -197,7 +197,7 @@ class BotCommandServiceTest {
         LogCaptureService capture = mock(LogCaptureService.class);
         when(capture.watermark()).thenReturn(1L);
         when(capture.drainSince(anyLong())).thenReturn(java.util.List.of());
-        service.setLogCaptureService(capture);
+        service.injectDependencies(new BotCommandDependencies().logCaptureService(capture));
 
         when(serverFacade.executeConsoleCommand("say hi"))
                 .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of()));
@@ -215,7 +215,7 @@ class BotCommandServiceTest {
         LogCaptureService capture = mock(LogCaptureService.class);
         when(capture.watermark()).thenReturn(7L);
         when(capture.drainSince(7L)).thenReturn(java.util.List.of());
-        service.setLogCaptureService(capture);
+        service.injectDependencies(new BotCommandDependencies().logCaptureService(capture));
 
         when(serverFacade.executeConsoleCommand("say hi"))
                 .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of()));
@@ -233,7 +233,7 @@ class BotCommandServiceTest {
         when(capture.watermark()).thenReturn(9L);
         when(capture.drainSince(9L))
                 .thenReturn(java.util.List.of("Rcon issued server command: /say hi", "real async output"));
-        service.setLogCaptureService(capture);
+        service.injectDependencies(new BotCommandDependencies().logCaptureService(capture));
 
         when(serverFacade.executeConsoleCommand("say hi"))
                 .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of()));
@@ -251,7 +251,7 @@ class BotCommandServiceTest {
         when(capture.watermark()).thenReturn(3L);
         when(capture.drainSince(3L)).thenReturn(java.util.List.of("survived line"));
         when(capture.hasGapSince(3L)).thenReturn(true);
-        service.setLogCaptureService(capture);
+        service.injectDependencies(new BotCommandDependencies().logCaptureService(capture));
 
         when(serverFacade.executeConsoleCommand("say hi"))
                 .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of()));
@@ -273,7 +273,8 @@ class BotCommandServiceTest {
     @Test
     void parse_executeConsole_guardBlocked_doesNotExecuteAndEmitsReason() {
         CommandAuditService audit = mock(CommandAuditService.class);
-        service.setCommandGuard(defaultGuard(), audit);
+        service.injectDependencies(
+                new BotCommandDependencies().commandGuardService(defaultGuard()).commandAuditService(audit));
 
         service.parse("$e stop", true, "老板", callback);
 
@@ -287,7 +288,8 @@ class BotCommandServiceTest {
     @Test
     void parse_executeConsole_guardAllowed_executesAndAudits() {
         CommandAuditService audit = mock(CommandAuditService.class);
-        service.setCommandGuard(defaultGuard(), audit);
+        service.injectDependencies(
+                new BotCommandDependencies().commandGuardService(defaultGuard()).commandAuditService(audit));
         when(serverFacade.executeConsoleCommand("say hi"))
                 .thenReturn(new ServerFacade.ConsoleCommandResult("say hi", true, java.util.List.of("执行成功")));
 
@@ -300,7 +302,8 @@ class BotCommandServiceTest {
     @Test
     void parse_executeConsole_guardWarn_stillExecutesWithAudit() {
         CommandAuditService audit = mock(CommandAuditService.class);
-        service.setCommandGuard(defaultGuard(), audit);
+        service.injectDependencies(
+                new BotCommandDependencies().commandGuardService(defaultGuard()).commandAuditService(audit));
         when(serverFacade.executeConsoleCommand("kill @e"))
                 .thenReturn(new ServerFacade.ConsoleCommandResult("kill @e", true, java.util.List.of("执行成功")));
 
@@ -313,10 +316,10 @@ class BotCommandServiceTest {
     @Test
     void parse_executeConsole_guardDisabled_executesWithoutBlock() {
         CommandAuditService audit = mock(CommandAuditService.class);
-        service.setCommandGuard(
-                new CommandGuardService(
-                        () -> new SecurityGuardConfig(false, SecurityGuardConfig.DEFAULT_BLOCKED_COMMANDS, true, true)),
-                audit);
+        service.injectDependencies(new BotCommandDependencies()
+                .commandGuardService(new CommandGuardService(
+                        () -> new SecurityGuardConfig(false, SecurityGuardConfig.DEFAULT_BLOCKED_COMMANDS, true, true)))
+                .commandAuditService(audit));
         when(serverFacade.executeConsoleCommand("stop"))
                 .thenReturn(new ServerFacade.ConsoleCommandResult("stop", true, java.util.List.of("执行成功")));
 
@@ -402,7 +405,7 @@ class BotCommandServiceTest {
     @Test
     void parse_reviewApprove_byPlayerName_callsReviewByApplicantName() {
         var reviewService = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class);
-        service.setReviewService(reviewService);
+        service.injectDependencies(new BotCommandDependencies().reviewService(reviewService));
         when(reviewService.reviewByApplicantName(eq("TestMember"), eq(true), anyString()))
                 .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(
                         com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.Result.ok("已通过", "r1")));
@@ -415,7 +418,7 @@ class BotCommandServiceTest {
     @Test
     void parse_reviewApprove_withSenderName_passesSenderAsReviewer() {
         var reviewService = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class);
-        service.setReviewService(reviewService);
+        service.injectDependencies(new BotCommandDependencies().reviewService(reviewService));
         when(reviewService.reviewByApplicantName(eq("TestMember"), eq(true), anyString()))
                 .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(
                         com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.Result.ok("已通过", "r1")));
@@ -429,7 +432,7 @@ class BotCommandServiceTest {
     @Test
     void parse_reviewReject_byPlayerName_callsReviewByApplicantName() {
         var reviewService = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class);
-        service.setReviewService(reviewService);
+        service.injectDependencies(new BotCommandDependencies().reviewService(reviewService));
         when(reviewService.reviewByApplicantName(eq("TestMember"), eq(false), anyString()))
                 .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(
                         com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.Result.ok("已拒绝", "r1")));
@@ -442,7 +445,7 @@ class BotCommandServiceTest {
     @Test
     void parse_reviewApprove_nonAdmin_doesNotCallReview() {
         var reviewService = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class);
-        service.setReviewService(reviewService);
+        service.injectDependencies(new BotCommandDependencies().reviewService(reviewService));
 
         service.parse("$v y TestMember", false, callback);
         verify(reviewService, never()).reviewByApplicantName(anyString(), anyBoolean(), anyString());
@@ -452,7 +455,7 @@ class BotCommandServiceTest {
     @Test
     void parse_reviewList_callsListPending() {
         var reviewService = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class);
-        service.setReviewService(reviewService);
+        service.injectDependencies(new BotCommandDependencies().reviewService(reviewService));
         when(reviewService.listPending()).thenReturn(java.util.List.of());
 
         service.parse("$v l", true, callback);
@@ -463,7 +466,7 @@ class BotCommandServiceTest {
     @Test
     void parse_reviewUnknownSubcommand_emitsUsage() {
         var reviewService = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class);
-        service.setReviewService(reviewService);
+        service.injectDependencies(new BotCommandDependencies().reviewService(reviewService));
 
         service.parse("$v x", true, callback);
         verify(reviewService, never()).reviewByApplicantName(anyString(), anyBoolean(), anyString());
@@ -479,7 +482,7 @@ class BotCommandServiceTest {
     @Test
     void parse_reviewApprove_byTypeAndPlayer_callsReviewById() {
         var reviewService = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class);
-        service.setReviewService(reviewService);
+        service.injectDependencies(new BotCommandDependencies().reviewService(reviewService));
         var type = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewType.class);
         when(reviewService.typeById("builder-promotion")).thenReturn(java.util.Optional.of(type));
         var request = mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewRequest.class);
@@ -497,7 +500,7 @@ class BotCommandServiceTest {
     @Test
     void parse_permissionDemote_playerName_callsDemote() {
         var rankService = mock(RankService.class);
-        service.setRankService(rankService);
+        service.injectDependencies(new BotCommandDependencies().rankService(rankService));
         when(rankService.isLuckPermsAvailable()).thenReturn(true);
         when(rankService.resolvePlayerId("TestMember")).thenReturn(java.util.UUID.randomUUID());
         when(rankService.demoteAsync(any(java.util.UUID.class)))
@@ -511,7 +514,7 @@ class BotCommandServiceTest {
     @Test
     void parse_permissionUpgrade_playerName_callsPromote() {
         var rankService = mock(RankService.class);
-        service.setRankService(rankService);
+        service.injectDependencies(new BotCommandDependencies().rankService(rankService));
         when(rankService.isLuckPermsAvailable()).thenReturn(true);
         when(rankService.resolvePlayerId("TestMember")).thenReturn(java.util.UUID.randomUUID());
         when(rankService.promoteAsync(any(java.util.UUID.class)))
@@ -525,7 +528,7 @@ class BotCommandServiceTest {
     @Test
     void parse_permissionDemote_atBottom_emitsError() {
         var rankService = mock(RankService.class);
-        service.setRankService(rankService);
+        service.injectDependencies(new BotCommandDependencies().rankService(rankService));
         when(rankService.isLuckPermsAvailable()).thenReturn(true);
         when(rankService.resolvePlayerId("TestPlayer")).thenReturn(java.util.UUID.randomUUID());
         when(rankService.demoteAsync(any(java.util.UUID.class)))
@@ -539,7 +542,7 @@ class BotCommandServiceTest {
     @Test
     void parse_permissionDemote_unknownPlayer_emitsError() {
         var rankService = mock(RankService.class);
-        service.setRankService(rankService);
+        service.injectDependencies(new BotCommandDependencies().rankService(rankService));
         when(rankService.resolvePlayerId("Nobody")).thenReturn(null);
 
         service.parse("$p d Nobody", true, callback);
@@ -550,7 +553,7 @@ class BotCommandServiceTest {
     @Test
     void parse_permissionDemote_nonAdmin_doesNotCallDemote() {
         var rankService = mock(RankService.class);
-        service.setRankService(rankService);
+        service.injectDependencies(new BotCommandDependencies().rankService(rankService));
 
         service.parse("$p d TestMember", false, callback);
         verify(rankService, never()).demoteAsync(any(java.util.UUID.class));
@@ -562,7 +565,7 @@ class BotCommandServiceTest {
     @Test
     void parse_backupHelpQuery_emitsUsageWithoutBackup() {
         var maintenance = mock(com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService.class);
-        service.setMaintenanceService(maintenance);
+        service.injectDependencies(new BotCommandDependencies().maintenanceService(maintenance));
 
         service.parse("$b ?", true, callback);
         var captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);
@@ -577,7 +580,7 @@ class BotCommandServiceTest {
     void parse_backupHelpQuerySuffix_emitsUsageWithoutBackup() {
         // M1：前缀匹配——$b ?x / $b ?? / $b ? 2 均视为帮助请求，绝不执行备份
         var maintenance = mock(com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService.class);
-        service.setMaintenanceService(maintenance);
+        service.injectDependencies(new BotCommandDependencies().maintenanceService(maintenance));
 
         service.parse("$b ? 2", true, callback);
         var captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);
@@ -592,7 +595,7 @@ class BotCommandServiceTest {
     void parse_backupHelpQueryFullWidthSpace_emitsUsageWithoutBackup() {
         // M1：U+3000 全角空格分隔（Java trim 不去全角空格），归一化后仍触发帮助拦截
         var maintenance = mock(com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService.class);
-        service.setMaintenanceService(maintenance);
+        service.injectDependencies(new BotCommandDependencies().maintenanceService(maintenance));
 
         service.parse("$b　?", true, callback);
         var captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);
@@ -606,7 +609,7 @@ class BotCommandServiceTest {
     @Test
     void parse_optimizeHelpQuery_emitsUsageWithoutOptimize() {
         var maintenance = mock(com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService.class);
-        service.setMaintenanceService(maintenance);
+        service.injectDependencies(new BotCommandDependencies().maintenanceService(maintenance));
 
         service.parse("$o ?", true, callback);
         var captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);
@@ -620,7 +623,7 @@ class BotCommandServiceTest {
     @Test
     void parse_permissionBlank_emitsUsageMatchingTip() {
         var rankService = mock(RankService.class);
-        service.setRankService(rankService);
+        service.injectDependencies(new BotCommandDependencies().rankService(rankService));
         when(rankService.isLuckPermsAvailable()).thenReturn(true);
 
         service.parse("$p", true, callback);
@@ -634,7 +637,7 @@ class BotCommandServiceTest {
     @Test
     void parse_permissionInvalidSubcommand_emitsUsageMatchingTip() {
         var rankService = mock(RankService.class);
-        service.setRankService(rankService);
+        service.injectDependencies(new BotCommandDependencies().rankService(rankService));
         when(rankService.isLuckPermsAvailable()).thenReturn(true);
 
         service.parse("$p x", true, callback);
@@ -647,7 +650,8 @@ class BotCommandServiceTest {
 
     @Test
     void parse_reviewBlank_emitsUsageMatchingTip() {
-        service.setReviewService(mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class));
+        service.injectDependencies(new BotCommandDependencies()
+                .reviewService(mock(com.jokerhub.paper.plugin.orzmc.features.review.ReviewService.class)));
 
         service.parse("$v", true, callback);
         var captor = org.mockito.ArgumentCaptor.forClass(MessageEnvelope.class);


### PR DESCRIPTION
## 背景

路线图 §4 架构演进项 **E3：`BotCommandService` God class 拆分**（735 行，11 命令 + 分页 + 守卫全内联）。目标：每个 `$cmd` handler 抽独立策略类、`parse()` 只做分发、6 个二阶段 setter 收敛为一次性批量注入。

## 改动（分阶段小步，每步全测试绿）

| 步骤 | 内容 |
|---|---|
| Step 0 | 抽离 `BotCommandContext` 共享基类（server/configs/feedbackService + emit/guard/参数解析） |
| Step 1a | 抽离 `ReviewCommandHandler`（$v） |
| Step 1b/c | 抽离 `PermissionCommandHandler`（$p）、`ConsoleCommandHandler`（$e） |
| Step 2 | 抽离 `WhitelistCommandHandler`（$a/$r/$w）、`PlayerListCommandHandler`（$l）、`MaintenanceCommandHandler`（$b/$o）、`BlacklistCommandHandler`（$d） |
| Step 3 | 新增 `BotCommandDependencies`（fluent builder），6 个 setter 收敛为 `injectDependencies(...)` |

## 结果

- `BotCommandService` **735 → 192 行**，纯分派（parse + 命令映射 + 依赖注入）。
- 11 个 `$cmd` 全部独立处理器，`parse()` 只做分发。
- 跨模块依赖（维护/黑名单/审核/权限/日志窗口/命令守卫）由组合根在 `OrzServices.assemble` 连接 WebSocket **之前**一次性注入，消除「先连上、后注入」半初始化窗口。
- 删除了 `BotModule` 仅为转发 maintenanceService 而存在的 `Initializable`/`afterPropertiesSet`/`pendingMaintenanceService` 一层。

## 行为保持

- 各处理器通过 `Supplier` 注入读最新依赖，未注入时按原路径降级（测试向后兼容）。
- `$e` 全角空格归一化、`$cmd ?` 帮助拦截、审核/权限的异步 LP 路径均原样保留。

## 验收

- `./gradlew check` 全绿（单测 + MockBukkit 集成 + spotless + jacoco 门禁）。
- 无行为变更，仅结构重构。
