### PR TITLE
refactor: OrzEasyBot 拆分（E2）——834→229 行编排 + 协作类

### DIFF
--- a/docs/code-quality-roadmap.md
+++ b/docs/code-quality-roadmap.md
@@ -405,7 +405,7 @@
 拆分落地时，**同一文件的并发改动会产生 merge 冲突**，需串行或分轮：
 
 - **E1 ↔ §3 的 6 个 Flash 任务**（P2-02 instanceof、P2-03 死字段、P2-07 OnlineListFormatter、P2-08 ReviewType 工厂、P2-09 渲染收敛、P2-10 tearDown）**同改 `FeatureModule.java`** → 二选一顺序：建议**先做 Flash 小改**（低风险、改动小），再做 E1 大重构；或反过来，但**不可并行**。
-- **E2 ↔ E6** **同改 `OrzEasyBot.java`** → E6 是安全补丁（小而急），**先 E6 后 E2**，或 E2 拆完后在协作类上做 E6，**不可并行**。
+- **E2 ↔ E6（均已闭环 ✅ 2026-08-20）**：E2 已把 `OrzEasyBot` 拆为编排 + `InboundEventParser`/`WebSocketLifecycle`/`HttpSender` 协作类（834→229 行）；E6/S8 已由 2026-08-19 决策关闭（网关 `sender.role` 即权威，fail-closed 降级，无需白名单兜底）。
 - **E3 先于 E1（已完成 ✅ 2026-08-20）**：E3 已将 `BotCommandService` 拆为纯分派 + 独立 `$cmd` 处理器，并把 6 个 setter 收敛为 `injectDependencies(BotCommandDependencies)`（组合根在连接 WebSocket 前一次性注入）。E1 现已解耦：接线点从 6 个 setter 变为 1 个 `injectDependencies`，可直接推进。
 - **E4（orzmc-api SDK 化）已立项**：目标与顺序见 §4.3。注意 SDK 化会动主模块 `core/ports`（被 portal/whitelist 等多个 feature 引用），建议在 E1-E3 稳定后启动，且按 §4.3 分阶段、每阶段全测试绿。
 - **E7/E8 是功能改动非重构**：各自独立，但 E8 涉及 netty 线程模型，需测试服真机验证（见 `folia-luckperms-gotchas.md` §6）。
@@ -414,11 +414,11 @@
 
 | # | 主题 | 范围 | 建议拆法（已按实际代码核实） |
 |---|---|---|---|
-| E1 | `FeatureModule` 拆分（993→服务装配 + 命令注册分离） | `assembly/FeatureModule.java` | **Step 0**：把 4 个静态拦截器助手（`requirement`/`guardedExec`/`commandInterceptors`/`adminInterceptors`，行 878-929）+ 3 个渲染方法（`renderReviewResult`/`renderReviewResultAsync`/`renderRankResult`，行 745-779）+ `handlePortal`/`listBlacklist` 抽到 `commands/BrigadierSupport` + `commands/CommandResultRenderer`（纯搬移，零行为变化）；**Step 1**：把 `setupCommandHandlers`（行 315-868，约 550 行）整块抽到 `commands/FeatureCommandRegistrar`，构造注入 ~20 个服务，FeatureModule 只留构造装配 + `enableForceWhitelist` + 生命周期方法 |
-| E2 | `OrzEasyBot` 拆分（834→编排 + 协作类） | `infra/bot/OrzEasyBot.java` | 抽 `InboundEventParser`/`HttpSender`/`BatchResultParser`/`WebSocketLifecycle` 四类，逐步搬移，每步全测试绿 |
+| E1 | `FeatureModule` 拆分（993→服务装配 + 命令注册分离） | `assembly/FeatureModule.java` | ✅ **已完成**（`FeatureModule` 993→354 行：命令注册抽到 `FeatureCommandRegistrar`，拦截器/渲染助手抽到 `BrigadierSupport`，`setupCommandHandlers` 只剩一行委托） |
+| E2 | `OrzEasyBot` 拆分（834→编排 + 协作类） | `infra/bot/OrzEasyBot.java` | ✅ **已完成**（`OrzEasyBot` 834→229 行编排：抽 `WebSocketLifecycle`（连接/对账/监听器）+ `InboundEventParser`（入站解析/校验/分派）；`HttpSender` 承担出站 HTTP + 批量结果解析，`BotInboundDispatcher` 承担业务分派） |
 | E3 | `BotCommandService` 拆分（735→分派 + 策略） | `features/botcommands/` | ✅ **已完成**（2026-08-20，分支 `refactor/botcommand-service` 5 个 commit：Step 0 `BotCommandContext` → Step 1a/1b/c Review/Permission/Console → Step 2 Whitelist/PlayerList/Maintenance/Blacklist → Step 3 `injectDependencies(BotCommandDependencies)`）。`BotCommandService` 735→192 行纯分派，11 个 `$cmd` 全部独立处理器 |
 | E4 | `orzmc-api` SDK 化（原 E4 去 Bukkit 化 + E5 依赖倒置合并） | `orzmc-api/` + 主模块 `core/ports/*` | **已立项**。分 5 阶段推进，详见 §4.3 |
-| E6 | `$e` 群侧 isAdmin 白名单兜底（S8） | `infra/bot/OrzEasyBot.java` 入站鉴权（行 757-769） | 需产品决策：管理员 user_id 白名单来源（配置/数据库）。先与服主确认再设计；**先于 E2 落地** |
+| E6 | `$e` 群侧 isAdmin 白名单兜底（S8） | `infra/bot/InboundEventParser.java` 入站鉴权 | ✅ **已决策关闭（2026-08-19）**：网关 `sender.role` 即权威，fail-closed 降级为非管理员，无需额外白名单兜底（代码注释已记录） |
 | E7 | 32k 属性扫描扩展（S7） | `ExploitHardeningEventService.java` | 对 `InventoryClickEvent`/`Pickup`/末影箱等进物品路径做属性上限清理；需评估性能与误伤 |
 | E8 | GeoIP 登录异步续接（T2） | `PlayerEventService.java:100-121` | 用 `AsyncPlayerPreLoginEvent` 异步续接或先 allow 再异步 disallow；需实测 netty 线程模型 |
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/bot/InboundEventParser.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/bot/InboundEventParser.java
@@ -1,0 +1,270 @@
+package com.jokerhub.paper.plugin.orzmc.infra.bot;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.jokerhub.paper.plugin.orzmc.core.bot.BotInboundHandler;
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
+import com.jokerhub.paper.plugin.orzmc.core.ports.server.ServerLogger;
+import com.jokerhub.paper.plugin.orzmc.infra.config.ConfigService;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.EasyBotConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.health.HealthRegistry;
+import com.jokerhub.paper.plugin.orzmc.infra.logging.ThrottledLogger;
+import com.jokerhub.paper.plugin.orzmc.infra.ws.WsClient;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+/**
+ * EasyBot 入站事件解析器（从 OrzEasyBot 抽离）。
+ *
+ * <p>解析 WebSocket 入站 JSON：区分系统帧（auth_ok / auth_failed / lagged / ping）与业务事件帧
+ * （{@code message.inbound}），做大小/速率/平台/会话白名单校验，提取 {@code platform}/{@code text}/
+ * {@code sender.role}/{@code chat_id} 后经 {@link BotInboundDispatcher} 分派到业务层。</p>
+ *
+ * <p>与 WebSocket 的连接状态耦合点仅两处：认证失败触发 {@link WebSocketLifecycle#shutdown()}、ping 帧
+ * 经 {@link WebSocketLifecycle#currentClient()} 回 pong。</p>
+ */
+final class InboundEventParser {
+
+    private static final String HEALTH_KEY = "easybot";
+    private static final int MAX_INBOUND_PAYLOAD_CHARS = 64 * 1024;
+    private static final int MAX_INBOUND_TEXT_CHARS = 8 * 1024;
+    private static final int MAX_INBOUND_TARGET_CHARS = 512;
+    private static final int MAX_INBOUND_EVENTS_PER_SECOND = 100;
+
+    private final ServerLogger logger;
+    private final ConfigService configService;
+    private final BotInboundHandler inboundHandler;
+    private final MessageFormatter formatter;
+    private final ThrottledLogger throttledLogger;
+    private final HealthRegistry healthRegistry;
+    private final HttpSender httpSender;
+    private final WebSocketLifecycle wsLifecycle;
+    private final AtomicLong inboundWindowStart = new AtomicLong();
+    private final AtomicInteger inboundWindowCount = new AtomicInteger();
+
+    InboundEventParser(
+            ServerLogger logger,
+            ConfigService configService,
+            BotInboundHandler inboundHandler,
+            MessageFormatter formatter,
+            ThrottledLogger throttledLogger,
+            HealthRegistry healthRegistry,
+            HttpSender httpSender,
+            WebSocketLifecycle wsLifecycle) {
+        this.logger = logger;
+        this.configService = configService;
+        this.inboundHandler = inboundHandler;
+        this.formatter = formatter;
+        this.throttledLogger = throttledLogger;
+        this.healthRegistry = healthRegistry;
+        this.httpSender = httpSender;
+        this.wsLifecycle = wsLifecycle;
+    }
+
+    /**
+     * 处理来自 EasyBot WebSocket 的入站事件。
+     *
+     * <p>所有平台的消息都通过此单一方法处理。EasyBot 已屏蔽协议差异，
+     * 统一为 {platform, text, sender.role, chat_id} 格式。
+     *
+     * <p>系统帧（auth_ok / auth_failed / lagged）在此直接处理，不会传递到业务层。
+     */
+    void process(String jsonString) {
+        if (jsonString == null || jsonString.isEmpty() || jsonString.length() > MAX_INBOUND_PAYLOAD_CHARS) {
+            if (jsonString != null && jsonString.length() > MAX_INBOUND_PAYLOAD_CHARS) {
+                throttledLogger.warning("easybot-inbound-size", "EasyBot 入站消息超过大小限制，已丢弃");
+            }
+            return;
+        }
+        try {
+            JsonElement parsed = JsonParser.parseString(jsonString);
+            if (!parsed.isJsonObject()) {
+                return;
+            }
+            JsonObject root = parsed.getAsJsonObject();
+            String type = stringValue(root, "type");
+            if (type == null) {
+                return;
+            }
+
+            // ---- 系统帧处理 ----
+            if ("auth_ok".equals(type)) {
+                healthRegistry.setWsConnected(HEALTH_KEY, true);
+                healthRegistry.setLastError(HEALTH_KEY, null);
+                throttledLogger.info("easybot-ws-auth", "EasyBot WebSocket 认证成功");
+                return;
+            }
+            if ("auth_failed".equals(type)) {
+                healthRegistry.setWsConnected(HEALTH_KEY, false);
+                String msg = stringValue(root, "message");
+                if (msg == null) msg = "unknown";
+                healthRegistry.setLastError(HEALTH_KEY, "WS auth failed: " + msg);
+                throttledLogger.error("easybot-ws-auth", "EasyBot WebSocket 认证失败: " + msg);
+                wsLifecycle.shutdown();
+                return;
+            }
+            if ("lagged".equals(type)) {
+                int dropped = root.has("dropped") && root.get("dropped").isJsonPrimitive()
+                        ? root.get("dropped").getAsInt()
+                        : 0;
+                throttledLogger.warning("easybot-ws-lag", "EasyBot WS 事件丢失: " + dropped);
+                return;
+            }
+            if ("ping".equals(type)) {
+                WsClient current = wsLifecycle.currentClient();
+                if (current != null) {
+                    current.send("{\"type\":\"pong\"}");
+                }
+                return;
+            }
+
+            // ---- 只处理事件帧 ----
+            if (!"event".equals(type)) {
+                return;
+            }
+            if (!root.has("event")) {
+                return;
+            }
+            String eventType = stringValue(root, "event");
+            if (eventType == null) {
+                return;
+            }
+            if (!"message.inbound".equals(eventType)) {
+                return;
+            }
+            if (!allowInboundEvent()) {
+                throttledLogger.warning("easybot-inbound-rate", "EasyBot 入站消息超过速率限制，已丢弃");
+                return;
+            }
+
+            // ---- 解析消息数据 ----
+            if (!root.has("data") || !root.get("data").isJsonObject()) {
+                return;
+            }
+            JsonObject data = root.getAsJsonObject("data");
+
+            // platform: 标识来源平台，如 "qq", "discord", "telegram"
+            if (!data.has("platform")) {
+                return;
+            }
+            String platformValue = stringValue(data, "platform");
+            if (platformValue == null) {
+                return;
+            }
+            String platform = platformValue.trim().toLowerCase(Locale.ROOT);
+            if (platform.isEmpty() || platform.length() > 64) {
+                return;
+            }
+            EasyBotConfig cfg = loadConfig();
+
+            // 跳过已禁用平台的消息
+            if (!isPlatformEnabled(cfg, platform)) {
+                return;
+            }
+
+            // text: 消息内容
+            String textValue = stringValue(data, "text");
+            String text = textValue == null ? "" : textValue.trim();
+            if (text.isEmpty() || text.length() > MAX_INBOUND_TEXT_CHARS) {
+                if (text.length() > MAX_INBOUND_TEXT_CHARS) {
+                    throttledLogger.warning("easybot-inbound-text-size", "EasyBot 入站文本超过大小限制，已丢弃");
+                }
+                return;
+            }
+
+            // chat_id: 来源会话标识
+            String chatIdValue = stringValue(data, "chat_id");
+            String chatId = chatIdValue == null ? "" : chatIdValue;
+            if (chatId.isEmpty() || chatId.length() > MAX_INBOUND_TARGET_CHARS) {
+                return;
+            }
+            String replyTarget = normalizeTarget(platform, chatId);
+            if (!isInboundTargetAllowed(cfg, platform, replyTarget)) {
+                throttledLogger.warning(
+                        "easybot-inbound-target",
+                        "EasyBot 忽略未授权会话消息: platform=" + platform + ", target=" + replyTarget);
+                return;
+            }
+
+            // sender.role: 发送者角色（EasyBot 已各平台标准化为群主/管理员）；sender.nickname: 群昵称（审核人身份用）
+            // isAdmin 判定 fail-closed：仅网关返回 Owner/Admin 视为管理员，role 缺失/未知一律按非管理员处理
+            // （2026-08-19 决策：网关 role 即权威，无需额外白名单兜底，判断不了即降级为非管理员）
+            boolean isAdmin = false;
+            String senderName = null;
+            if (data.has("sender") && data.get("sender").isJsonObject()) {
+                JsonObject sender = data.getAsJsonObject("sender");
+                String role = stringValue(sender, "role");
+                if (role != null) {
+                    isAdmin = "Owner".equalsIgnoreCase(role) || "Admin".equalsIgnoreCase(role);
+                }
+                senderName = stringValue(sender, "nickname");
+                if (senderName == null || senderName.isBlank()) {
+                    senderName = stringValue(sender, "user_id"); // 无昵称时用平台 ID 兜底
+                }
+            }
+
+            // 关键：sink 捕获来源平台和会话，确保回复定向到正确的位置
+            Consumer<MessageEnvelope> sink = env -> {
+                if (env != null) {
+                    MessageEnvelope.Format replyFormat =
+                            env.format() == null ? MessageEnvelope.Format.DEFAULT : env.format();
+                    for (String part : formatter.format(env.message(), replyFormat)) {
+                        httpSender.sendMessage(cfg, replyTarget, part);
+                    }
+                }
+            };
+
+            BotInboundDispatcher.dispatch(inboundHandler, text, isAdmin, senderName, sink);
+        } catch (Exception e) {
+            healthRegistry.setLastError(HEALTH_KEY, e.toString());
+            logger.logger().warning("EasyBot inbound parse error: " + e);
+        }
+    }
+
+    private EasyBotConfig loadConfig() {
+        return EasyBotConfig.from(configService.getConfig("easybot"));
+    }
+
+    /**
+     * 检查指定平台是否已在配置中启用。
+     * 未找到配置的平台（如未注册的测试平台）视为禁用。
+     */
+    private boolean isPlatformEnabled(EasyBotConfig cfg, String platform) {
+        EasyBotConfig.PlatformEntry entry = cfg.platforms().get(platform);
+        return entry != null && entry.enabled();
+    }
+
+    private boolean isInboundTargetAllowed(EasyBotConfig cfg, String platform, String target) {
+        EasyBotConfig.PlatformEntry entry = cfg.platforms().get(platform);
+        return entry != null
+                && entry.enabled()
+                && (target.equals(entry.adminGroup())
+                        || target.equals(entry.playerGroup())
+                        || target.equals(entry.adminDm()));
+    }
+
+    private static String normalizeTarget(String platform, String chatId) {
+        chatId = chatId.trim();
+        String prefix = platform + ":";
+        return chatId.startsWith(prefix) ? chatId : prefix + chatId;
+    }
+
+    private boolean allowInboundEvent() {
+        long now = System.currentTimeMillis();
+        long windowStart = inboundWindowStart.get();
+        if (windowStart == 0L || now - windowStart >= 1000L) {
+            if (inboundWindowStart.compareAndSet(windowStart, now)) {
+                inboundWindowCount.set(0);
+            }
+        }
+        return inboundWindowCount.incrementAndGet() <= MAX_INBOUND_EVENTS_PER_SECOND;
+    }
+
+    private static String stringValue(JsonObject object, String key) {
+        JsonElement value = object.get(key);
+        return value != null && value.isJsonPrimitive() && !value.isJsonNull() ? value.getAsString() : null;
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/bot/OrzEasyBot.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/bot/OrzEasyBot.java
@@ -1,6 +1,5 @@
 package com.jokerhub.paper.plugin.orzmc.infra.bot;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -13,16 +12,12 @@ import com.jokerhub.paper.plugin.orzmc.infra.health.HealthRegistry;
 import com.jokerhub.paper.plugin.orzmc.infra.logging.ThrottledLogger;
 import com.jokerhub.paper.plugin.orzmc.infra.ws.DefaultWebSocketClientFactory;
 import com.jokerhub.paper.plugin.orzmc.infra.ws.WebSocketClientFactory;
-import com.jokerhub.paper.plugin.orzmc.infra.ws.WebSocketEventListener;
 import com.jokerhub.paper.plugin.orzmc.infra.ws.WsClient;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /**
@@ -43,8 +38,6 @@ import java.util.function.Consumer;
 public class OrzEasyBot implements BotMessageService {
 
     private static final String HEALTH_KEY = "easybot";
-    private static final Gson GSON = new Gson();
-    private static final int MAX_HTTP_IN_FLIGHT = 32;
     private static final int MAX_INBOUND_PAYLOAD_CHARS = 64 * 1024;
     private static final int MAX_INBOUND_TEXT_CHARS = 8 * 1024;
     private static final int MAX_INBOUND_TARGET_CHARS = 512;
@@ -56,14 +49,10 @@ public class OrzEasyBot implements BotMessageService {
     private final MessageFormatter formatter;
     private final ThrottledLogger throttledLogger;
     private final HealthRegistry healthRegistry;
-    private final WebSocketClientFactory wsFactory;
     private final HttpSender httpSender;
-    private final Object lifecycleLock = new Object();
+    private final WebSocketLifecycle wsLifecycle;
     private final AtomicLong inboundWindowStart = new AtomicLong();
     private final AtomicInteger inboundWindowCount = new AtomicInteger();
-
-    private volatile WsClient webSocketClient;
-    private volatile String activeConnectionFingerprint;
 
     // ---- 构造器 -----------------------------------------------------------
 
@@ -80,8 +69,13 @@ public class OrzEasyBot implements BotMessageService {
         this.formatter = formatter;
         this.throttledLogger = throttledLogger;
         this.healthRegistry = healthRegistry;
-        this.wsFactory = new DefaultWebSocketClientFactory();
         this.httpSender = new HttpSender(logger, throttledLogger, healthRegistry);
+        this.wsLifecycle = new WebSocketLifecycle(
+                logger,
+                throttledLogger,
+                healthRegistry,
+                new DefaultWebSocketClientFactory(),
+                this::processInboundEvent);
     }
 
     /** 测试用构造器，允许注入模拟的 {@link WebSocketClientFactory}。 */
@@ -99,8 +93,13 @@ public class OrzEasyBot implements BotMessageService {
         this.formatter = formatter;
         this.throttledLogger = throttledLogger;
         this.healthRegistry = healthRegistry;
-        this.wsFactory = wsFactory == null ? new DefaultWebSocketClientFactory() : wsFactory;
         this.httpSender = new HttpSender(logger, throttledLogger, healthRegistry);
+        this.wsLifecycle = new WebSocketLifecycle(
+                logger,
+                throttledLogger,
+                healthRegistry,
+                wsFactory == null ? new DefaultWebSocketClientFactory() : wsFactory,
+                this::processInboundEvent);
     }
 
     public boolean isEnable() {
@@ -115,36 +114,22 @@ public class OrzEasyBot implements BotMessageService {
 
     @Override
     public void tearDown() {
-        synchronized (lifecycleLock) {
-            shutdownWebSocketClientLocked();
-            healthRegistry.setEnabled(HEALTH_KEY, false);
-            healthRegistry.setWsConnected(HEALTH_KEY, false);
-            healthRegistry.setHttpChecked(HEALTH_KEY, false);
-            healthRegistry.setLastError(HEALTH_KEY, null);
-            healthRegistry.setDelivery(HEALTH_KEY, 0, 0, List.of());
-        }
+        wsLifecycle.shutdown();
+        healthRegistry.setEnabled(HEALTH_KEY, false);
+        healthRegistry.setWsConnected(HEALTH_KEY, false);
+        healthRegistry.setHttpChecked(HEALTH_KEY, false);
+        healthRegistry.setLastError(HEALTH_KEY, null);
+        healthRegistry.setDelivery(HEALTH_KEY, 0, 0, List.of());
     }
 
     @Override
     public void tryReconnectIfDisconnected() {
-        synchronized (lifecycleLock) {
-            EasyBotConfig cfg = loadConfig();
-            if (!cfg.enabled()) {
-                reconcileConfigLocked(cfg);
-                return;
-            }
-            if (webSocketClient == null) {
-                healthRegistry.setLastError(HEALTH_KEY, "reconnecting...");
-                reconcileConfigLocked(cfg);
-            }
-        }
+        wsLifecycle.tryReconnect(loadConfig());
     }
 
     @Override
     public void reloadConfig() {
-        synchronized (lifecycleLock) {
-            reconcileConfigLocked(loadConfig());
-        }
+        wsLifecycle.reconcile(loadConfig());
     }
 
     /**
@@ -223,143 +208,14 @@ public class OrzEasyBot implements BotMessageService {
         return target;
     }
 
-    // ---- WebSocket 生命周期 ------------------------------------------------
+    // ---- WebSocket 生命周期（测试钩子）-------------------------------------
 
     void setupWebSocketClient() {
-        synchronized (lifecycleLock) {
-            reconcileConfigLocked(loadConfig());
-        }
+        wsLifecycle.reconcile(loadConfig());
     }
 
     void shutdownWebSocketClient() {
-        synchronized (lifecycleLock) {
-            shutdownWebSocketClientLocked();
-        }
-    }
-
-    private void reconcileConfigLocked(EasyBotConfig cfg) {
-        healthRegistry.setEnabled(HEALTH_KEY, cfg.enabled());
-        if (!cfg.enabled()) {
-            shutdownWebSocketClientLocked();
-            healthRegistry.setWsConnected(HEALTH_KEY, false);
-            healthRegistry.setHttpChecked(HEALTH_KEY, false);
-            healthRegistry.setLastError(HEALTH_KEY, null);
-            return;
-        }
-        if (cfg.apiServer().isBlank()
-                || cfg.wsServer().isBlank()
-                || cfg.apiKey().isBlank()) {
-            shutdownWebSocketClientLocked();
-            healthRegistry.setWsConnected(HEALTH_KEY, false);
-            healthRegistry.setHttpChecked(HEALTH_KEY, false);
-            healthRegistry.setApiReady(HEALTH_KEY, false);
-            healthRegistry.setLastError(HEALTH_KEY, "EasyBot 连接配置不完整: api_server/ws_server/api_key");
-            return;
-        }
-
-        String fingerprint = cfg.connectionFingerprint();
-        if (webSocketClient != null && fingerprint.equals(activeConnectionFingerprint)) {
-            return;
-        }
-        shutdownWebSocketClientLocked();
-        healthRegistry.setHttpChecked(HEALTH_KEY, false);
-        setupWebSocketClientLocked(cfg, fingerprint);
-    }
-
-    private void setupWebSocketClientLocked(EasyBotConfig cfg, String fingerprint) {
-        try {
-            String wsUrl = cfg.wsServer() + "/api/v1/ws";
-            // EasyBot 使用 WebSocket PING/PONG 检测存活，无需应用层心跳
-            String heartbeatPayload = "";
-            String authApiKey = cfg.apiKey();
-            AtomicReference<WsClient> clientRef = new AtomicReference<>();
-            WebSocketEventListener listener = new WebSocketEventListener() {
-                private WsClient currentClient() {
-                    return clientRef.get();
-                }
-
-                private boolean isCurrent() {
-                    WsClient current = currentClient();
-                    return current != null && webSocketClient == current;
-                }
-
-                @Override
-                public void onOpen() {
-                    if (!isCurrent()) return;
-                    healthRegistry.setWsConnected(HEALTH_KEY, false);
-                    if (!authApiKey.isBlank()) {
-                        currentClient().send(GSON.toJson(Map.of("token", authApiKey)));
-                    }
-                }
-
-                @Override
-                public void onClose(int code, String reason, boolean remote) {
-                    if (isCurrent()) {
-                        healthRegistry.setWsConnected(HEALTH_KEY, false);
-                    }
-                }
-
-                @Override
-                public void onError(Exception ex) {
-                    if (!isCurrent()) return;
-                    healthRegistry.setWsConnected(HEALTH_KEY, false);
-                    healthRegistry.setLastError(HEALTH_KEY, ex.toString());
-                    throttledLogger.error("easybot-ws", "EasyBot WebSocket 异常: " + ex);
-                    if (ex.getMessage() != null && ex.getMessage().contains("WS reconnect exhausted")) {
-                        detachCurrentClient(currentClient());
-                    }
-                }
-            };
-            WsClient client = wsFactory.create(
-                    logger,
-                    wsUrl,
-                    throttledLogger,
-                    Math.max(0, cfg.wsMaxRetries()),
-                    cfg.wsBaseRetryMs() <= 0 ? 5000 : cfg.wsBaseRetryMs(),
-                    cfg.wsMaxDelayMs() <= 0 ? 60000 : cfg.wsMaxDelayMs(),
-                    Math.max(0, cfg.wsJitterPercent()),
-                    cfg.wsStableResetMs() <= 0 ? 20000 : cfg.wsStableResetMs(),
-                    cfg.wsMessageLogEnabled(),
-                    cfg.wsMessageLogThrottleMs() <= 0 ? 60000 : cfg.wsMessageLogThrottleMs(),
-                    Collections.emptyMap(),
-                    heartbeatPayload,
-                    listener,
-                    message -> {
-                        WsClient current = clientRef.get();
-                        if (current != null && webSocketClient == current) {
-                            processInboundEvent(message);
-                        }
-                    });
-            clientRef.set(client);
-            webSocketClient = client;
-            activeConnectionFingerprint = fingerprint;
-            client.connect();
-        } catch (Exception e) {
-            healthRegistry.setLastError(HEALTH_KEY, e.toString());
-            logger.logger().warning("EasyBot WS setup failed: " + e);
-        }
-    }
-
-    private void shutdownWebSocketClientLocked() {
-        WsClient current = webSocketClient;
-        webSocketClient = null;
-        activeConnectionFingerprint = null;
-        if (current != null) {
-            try {
-                current.disconnect();
-            } catch (Exception e) {
-                throttledLogger.warning("easybot-ws-shutdown", "EasyBot WebSocket 关闭异常: " + e);
-            }
-        }
-    }
-
-    private void detachCurrentClient(WsClient client) {
-        synchronized (lifecycleLock) {
-            if (webSocketClient == client) {
-                webSocketClient = null;
-                activeConnectionFingerprint = null;
-            }
-        }
+        wsLifecycle.shutdown();
     }
 
     // ---- 入站消息处理 -------------------------------------------------------
@@ -403,7 +259,7 @@ public class OrzEasyBot implements BotMessageService {
                 if (msg == null) msg = "unknown";
                 healthRegistry.setLastError(HEALTH_KEY, "WS auth failed: " + msg);
                 throttledLogger.error("easybot-ws-auth", "EasyBot WebSocket 认证失败: " + msg);
-                shutdownWebSocketClient();
+                wsLifecycle.shutdown();
                 return;
             }
             if ("lagged".equals(type)) {
@@ -414,7 +270,7 @@ public class OrzEasyBot implements BotMessageService {
                 return;
             }
             if ("ping".equals(type)) {
-                WsClient current = webSocketClient;
+                WsClient current = wsLifecycle.currentClient();
                 if (current != null) {
                     current.send("{\"type\":\"pong\"}");
                 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/bot/OrzEasyBot.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/bot/OrzEasyBot.java
@@ -1,8 +1,5 @@
 package com.jokerhub.paper.plugin.orzmc.infra.bot;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.jokerhub.paper.plugin.orzmc.core.bot.BotInboundHandler;
 import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.core.ports.server.ServerLogger;
@@ -12,13 +9,8 @@ import com.jokerhub.paper.plugin.orzmc.infra.health.HealthRegistry;
 import com.jokerhub.paper.plugin.orzmc.infra.logging.ThrottledLogger;
 import com.jokerhub.paper.plugin.orzmc.infra.ws.DefaultWebSocketClientFactory;
 import com.jokerhub.paper.plugin.orzmc.infra.ws.WebSocketClientFactory;
-import com.jokerhub.paper.plugin.orzmc.infra.ws.WsClient;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 
 /**
  * EasyBot IM Gateway 适配器。
@@ -38,21 +30,13 @@ import java.util.function.Consumer;
 public class OrzEasyBot implements BotMessageService {
 
     private static final String HEALTH_KEY = "easybot";
-    private static final int MAX_INBOUND_PAYLOAD_CHARS = 64 * 1024;
-    private static final int MAX_INBOUND_TEXT_CHARS = 8 * 1024;
-    private static final int MAX_INBOUND_TARGET_CHARS = 512;
-    private static final int MAX_INBOUND_EVENTS_PER_SECOND = 100;
 
-    private final ServerLogger logger;
     private final ConfigService configService;
-    private final BotInboundHandler inboundHandler;
     private final MessageFormatter formatter;
-    private final ThrottledLogger throttledLogger;
     private final HealthRegistry healthRegistry;
     private final HttpSender httpSender;
     private final WebSocketLifecycle wsLifecycle;
-    private final AtomicLong inboundWindowStart = new AtomicLong();
-    private final AtomicInteger inboundWindowCount = new AtomicInteger();
+    private final InboundEventParser inboundParser;
 
     // ---- 构造器 -----------------------------------------------------------
 
@@ -63,11 +47,8 @@ public class OrzEasyBot implements BotMessageService {
             MessageFormatter formatter,
             ThrottledLogger throttledLogger,
             HealthRegistry healthRegistry) {
-        this.logger = logger;
         this.configService = configService;
-        this.inboundHandler = inboundHandler;
         this.formatter = formatter;
-        this.throttledLogger = throttledLogger;
         this.healthRegistry = healthRegistry;
         this.httpSender = new HttpSender(logger, throttledLogger, healthRegistry);
         this.wsLifecycle = new WebSocketLifecycle(
@@ -76,6 +57,15 @@ public class OrzEasyBot implements BotMessageService {
                 healthRegistry,
                 new DefaultWebSocketClientFactory(),
                 this::processInboundEvent);
+        this.inboundParser = new InboundEventParser(
+                logger,
+                configService,
+                inboundHandler,
+                formatter,
+                throttledLogger,
+                healthRegistry,
+                httpSender,
+                wsLifecycle);
     }
 
     /** 测试用构造器，允许注入模拟的 {@link WebSocketClientFactory}。 */
@@ -87,11 +77,8 @@ public class OrzEasyBot implements BotMessageService {
             ThrottledLogger throttledLogger,
             HealthRegistry healthRegistry,
             WebSocketClientFactory wsFactory) {
-        this.logger = logger;
         this.configService = configService;
-        this.inboundHandler = inboundHandler;
         this.formatter = formatter;
-        this.throttledLogger = throttledLogger;
         this.healthRegistry = healthRegistry;
         this.httpSender = new HttpSender(logger, throttledLogger, healthRegistry);
         this.wsLifecycle = new WebSocketLifecycle(
@@ -100,6 +87,15 @@ public class OrzEasyBot implements BotMessageService {
                 healthRegistry,
                 wsFactory == null ? new DefaultWebSocketClientFactory() : wsFactory,
                 this::processInboundEvent);
+        this.inboundParser = new InboundEventParser(
+                logger,
+                configService,
+                inboundHandler,
+                formatter,
+                throttledLogger,
+                healthRegistry,
+                httpSender,
+                wsLifecycle);
     }
 
     public boolean isEnable() {
@@ -220,209 +216,14 @@ public class OrzEasyBot implements BotMessageService {
 
     // ---- 入站消息处理 -------------------------------------------------------
 
-    /**
-     * 处理来自 EasyBot WebSocket 的入站事件。
-     *
-     * <p>所有平台的消息都通过此单一方法处理。EasyBot 已屏蔽协议差异，
-     * 统一为 {platform, text, sender.role, chat_id} 格式。
-     *
-     * <p>系统帧（auth_ok / auth_failed / lagged）在此直接处理，不会传递到业务层。
-     */
+    /** 入站事件入口（WebSocket 消息经此转发到 {@link InboundEventParser}）。 */
     void processInboundEvent(String jsonString) {
-        if (jsonString == null || jsonString.isEmpty() || jsonString.length() > MAX_INBOUND_PAYLOAD_CHARS) {
-            if (jsonString != null && jsonString.length() > MAX_INBOUND_PAYLOAD_CHARS) {
-                throttledLogger.warning("easybot-inbound-size", "EasyBot 入站消息超过大小限制，已丢弃");
-            }
-            return;
-        }
-        try {
-            JsonElement parsed = JsonParser.parseString(jsonString);
-            if (!parsed.isJsonObject()) {
-                return;
-            }
-            JsonObject root = parsed.getAsJsonObject();
-            String type = stringValue(root, "type");
-            if (type == null) {
-                return;
-            }
-
-            // ---- 系统帧处理 ----
-            if ("auth_ok".equals(type)) {
-                healthRegistry.setWsConnected(HEALTH_KEY, true);
-                healthRegistry.setLastError(HEALTH_KEY, null);
-                throttledLogger.info("easybot-ws-auth", "EasyBot WebSocket 认证成功");
-                return;
-            }
-            if ("auth_failed".equals(type)) {
-                healthRegistry.setWsConnected(HEALTH_KEY, false);
-                String msg = stringValue(root, "message");
-                if (msg == null) msg = "unknown";
-                healthRegistry.setLastError(HEALTH_KEY, "WS auth failed: " + msg);
-                throttledLogger.error("easybot-ws-auth", "EasyBot WebSocket 认证失败: " + msg);
-                wsLifecycle.shutdown();
-                return;
-            }
-            if ("lagged".equals(type)) {
-                int dropped = root.has("dropped") && root.get("dropped").isJsonPrimitive()
-                        ? root.get("dropped").getAsInt()
-                        : 0;
-                throttledLogger.warning("easybot-ws-lag", "EasyBot WS 事件丢失: " + dropped);
-                return;
-            }
-            if ("ping".equals(type)) {
-                WsClient current = wsLifecycle.currentClient();
-                if (current != null) {
-                    current.send("{\"type\":\"pong\"}");
-                }
-                return;
-            }
-
-            // ---- 只处理事件帧 ----
-            if (!"event".equals(type)) {
-                return;
-            }
-            if (!root.has("event")) {
-                return;
-            }
-            String eventType = stringValue(root, "event");
-            if (eventType == null) {
-                return;
-            }
-            if (!"message.inbound".equals(eventType)) {
-                return;
-            }
-            if (!allowInboundEvent()) {
-                throttledLogger.warning("easybot-inbound-rate", "EasyBot 入站消息超过速率限制，已丢弃");
-                return;
-            }
-
-            // ---- 解析消息数据 ----
-            if (!root.has("data") || !root.get("data").isJsonObject()) {
-                return;
-            }
-            JsonObject data = root.getAsJsonObject("data");
-
-            // platform: 标识来源平台，如 "qq", "discord", "telegram"
-            if (!data.has("platform")) {
-                return;
-            }
-            String platformValue = stringValue(data, "platform");
-            if (platformValue == null) {
-                return;
-            }
-            String platform = platformValue.trim().toLowerCase(Locale.ROOT);
-            if (platform.isEmpty() || platform.length() > 64) {
-                return;
-            }
-            EasyBotConfig cfg = loadConfig();
-
-            // 跳过已禁用平台的消息
-            if (!isPlatformEnabled(cfg, platform)) {
-                return;
-            }
-
-            // text: 消息内容
-            String textValue = stringValue(data, "text");
-            String text = textValue == null ? "" : textValue.trim();
-            if (text.isEmpty() || text.length() > MAX_INBOUND_TEXT_CHARS) {
-                if (text.length() > MAX_INBOUND_TEXT_CHARS) {
-                    throttledLogger.warning("easybot-inbound-text-size", "EasyBot 入站文本超过大小限制，已丢弃");
-                }
-                return;
-            }
-
-            // chat_id: 来源会话标识
-            String chatIdValue = stringValue(data, "chat_id");
-            String chatId = chatIdValue == null ? "" : chatIdValue;
-            if (chatId.isEmpty() || chatId.length() > MAX_INBOUND_TARGET_CHARS) {
-                return;
-            }
-            String replyTarget = normalizeTarget(platform, chatId);
-            if (!isInboundTargetAllowed(cfg, platform, replyTarget)) {
-                throttledLogger.warning(
-                        "easybot-inbound-target",
-                        "EasyBot 忽略未授权会话消息: platform=" + platform + ", target=" + replyTarget);
-                return;
-            }
-
-            // sender.role: 发送者角色（EasyBot 已各平台标准化为群主/管理员）；sender.nickname: 群昵称（审核人身份用）
-            // isAdmin 判定 fail-closed：仅网关返回 Owner/Admin 视为管理员，role 缺失/未知一律按非管理员处理
-            // （2026-08-19 决策：网关 role 即权威，无需额外白名单兜底，判断不了即降级为非管理员）
-            boolean isAdmin = false;
-            String senderName = null;
-            if (data.has("sender") && data.get("sender").isJsonObject()) {
-                JsonObject sender = data.getAsJsonObject("sender");
-                String role = stringValue(sender, "role");
-                if (role != null) {
-                    isAdmin = "Owner".equalsIgnoreCase(role) || "Admin".equalsIgnoreCase(role);
-                }
-                senderName = stringValue(sender, "nickname");
-                if (senderName == null || senderName.isBlank()) {
-                    senderName = stringValue(sender, "user_id"); // 无昵称时用平台 ID 兜底
-                }
-            }
-
-            // 关键：sink 捕获来源平台和会话，确保回复定向到正确的位置
-            Consumer<MessageEnvelope> sink = env -> {
-                if (env != null) {
-                    MessageEnvelope.Format replyFormat =
-                            env.format() == null ? MessageEnvelope.Format.DEFAULT : env.format();
-                    for (String part : formatter.format(env.message(), replyFormat)) {
-                        httpSender.sendMessage(cfg, replyTarget, part);
-                    }
-                }
-            };
-
-            BotInboundDispatcher.dispatch(inboundHandler, text, isAdmin, senderName, sink);
-        } catch (Exception e) {
-            healthRegistry.setLastError(HEALTH_KEY, e.toString());
-            logger.logger().warning("EasyBot inbound parse error: " + e);
-        }
+        inboundParser.process(jsonString);
     }
 
     // ---- 辅助方法 ----------------------------------------------------------
 
     private EasyBotConfig loadConfig() {
         return EasyBotConfig.from(configService.getConfig("easybot"));
-    }
-
-    /**
-     * 检查指定平台是否已在配置中启用。
-     * 未找到配置的平台（如未注册的测试平台）视为禁用。
-     */
-    private boolean isPlatformEnabled(EasyBotConfig cfg, String platform) {
-        EasyBotConfig.PlatformEntry entry = cfg.platforms().get(platform);
-        return entry != null && entry.enabled();
-    }
-
-    private boolean isInboundTargetAllowed(EasyBotConfig cfg, String platform, String target) {
-        EasyBotConfig.PlatformEntry entry = cfg.platforms().get(platform);
-        return entry != null
-                && entry.enabled()
-                && (target.equals(entry.adminGroup())
-                        || target.equals(entry.playerGroup())
-                        || target.equals(entry.adminDm()));
-    }
-
-    private static String normalizeTarget(String platform, String chatId) {
-        chatId = chatId.trim();
-        String prefix = platform + ":";
-        return chatId.startsWith(prefix) ? chatId : prefix + chatId;
-    }
-
-    private boolean allowInboundEvent() {
-        long now = System.currentTimeMillis();
-        long windowStart = inboundWindowStart.get();
-        if (windowStart == 0L || now - windowStart >= 1000L) {
-            if (inboundWindowStart.compareAndSet(windowStart, now)) {
-                inboundWindowCount.set(0);
-            }
-        }
-        return inboundWindowCount.incrementAndGet() <= MAX_INBOUND_EVENTS_PER_SECOND;
-    }
-
-    private static String stringValue(JsonObject object, String key) {
-        JsonElement value = object.get(key);
-        return value != null && value.isJsonPrimitive() && !value.isJsonNull() ? value.getAsString() : null;
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/bot/WebSocketLifecycle.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/bot/WebSocketLifecycle.java
@@ -1,0 +1,209 @@
+package com.jokerhub.paper.plugin.orzmc.infra.bot;
+
+import com.google.gson.Gson;
+import com.jokerhub.paper.plugin.orzmc.core.ports.server.ServerLogger;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.EasyBotConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.health.HealthRegistry;
+import com.jokerhub.paper.plugin.orzmc.infra.logging.ThrottledLogger;
+import com.jokerhub.paper.plugin.orzmc.infra.ws.WebSocketClientFactory;
+import com.jokerhub.paper.plugin.orzmc.infra.ws.WebSocketEventListener;
+import com.jokerhub.paper.plugin.orzmc.infra.ws.WsClient;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * EasyBot WebSocket 生命周期管理（从 OrzEasyBot 抽离）。
+ *
+ * <p>持有连接状态（当前 {@link WsClient} 与连接指纹）、生命周期锁，负责按配置对账连接
+ * （连接配置变更时重建）、监听器回调（认证/关闭/错误）与健康状态更新。入站消息经
+ * {@code messageSink} 路由回 {@link OrzEasyBot}（或 {@link InboundEventParser}）。</p>
+ */
+final class WebSocketLifecycle {
+
+    private static final String HEALTH_KEY = "easybot";
+    private static final Gson GSON = new Gson();
+
+    private final ServerLogger logger;
+    private final ThrottledLogger throttledLogger;
+    private final HealthRegistry healthRegistry;
+    private final WebSocketClientFactory wsFactory;
+    private final Consumer<String> messageSink;
+
+    private final Object lifecycleLock = new Object();
+    private volatile WsClient webSocketClient;
+    private volatile String activeConnectionFingerprint;
+
+    WebSocketLifecycle(
+            ServerLogger logger,
+            ThrottledLogger throttledLogger,
+            HealthRegistry healthRegistry,
+            WebSocketClientFactory wsFactory,
+            Consumer<String> messageSink) {
+        this.logger = logger;
+        this.throttledLogger = throttledLogger;
+        this.healthRegistry = healthRegistry;
+        this.wsFactory = wsFactory;
+        this.messageSink = messageSink;
+    }
+
+    /** 按最新配置对账连接状态：连接配置变更时重建 WS 客户端，未变更则跳过。 */
+    void reconcile(EasyBotConfig cfg) {
+        synchronized (lifecycleLock) {
+            reconcileLocked(cfg);
+        }
+    }
+
+    /** 尝试重连：仅在未连接（webSocketClient == null）时触发对账，避免频繁重建。 */
+    void tryReconnect(EasyBotConfig cfg) {
+        synchronized (lifecycleLock) {
+            if (!cfg.enabled()) {
+                reconcileLocked(cfg);
+                return;
+            }
+            if (webSocketClient == null) {
+                healthRegistry.setLastError(HEALTH_KEY, "reconnecting...");
+                reconcileLocked(cfg);
+            }
+        }
+    }
+
+    /** 关闭当前 WS 连接并清空连接指纹（不更新健康状态，供 tearDown/auth_failed 调用）。 */
+    void shutdown() {
+        synchronized (lifecycleLock) {
+            shutdownLocked();
+        }
+    }
+
+    /** 若给定 client 仍是当前连接，则清空引用（WS 重连耗尽时由 listener 触发）。 */
+    void detach(WsClient client) {
+        synchronized (lifecycleLock) {
+            if (webSocketClient == client) {
+                webSocketClient = null;
+                activeConnectionFingerprint = null;
+            }
+        }
+    }
+
+    /** 当前 WS 客户端（供入站 ping/pong 回包），无连接时返回 null。 */
+    WsClient currentClient() {
+        return webSocketClient;
+    }
+
+    private void reconcileLocked(EasyBotConfig cfg) {
+        healthRegistry.setEnabled(HEALTH_KEY, cfg.enabled());
+        if (!cfg.enabled()) {
+            shutdownLocked();
+            healthRegistry.setWsConnected(HEALTH_KEY, false);
+            healthRegistry.setHttpChecked(HEALTH_KEY, false);
+            healthRegistry.setLastError(HEALTH_KEY, null);
+            return;
+        }
+        if (cfg.apiServer().isBlank()
+                || cfg.wsServer().isBlank()
+                || cfg.apiKey().isBlank()) {
+            shutdownLocked();
+            healthRegistry.setWsConnected(HEALTH_KEY, false);
+            healthRegistry.setHttpChecked(HEALTH_KEY, false);
+            healthRegistry.setApiReady(HEALTH_KEY, false);
+            healthRegistry.setLastError(HEALTH_KEY, "EasyBot 连接配置不完整: api_server/ws_server/api_key");
+            return;
+        }
+
+        String fingerprint = cfg.connectionFingerprint();
+        if (webSocketClient != null && fingerprint.equals(activeConnectionFingerprint)) {
+            return;
+        }
+        shutdownLocked();
+        healthRegistry.setHttpChecked(HEALTH_KEY, false);
+        setupClientLocked(cfg, fingerprint);
+    }
+
+    private void setupClientLocked(EasyBotConfig cfg, String fingerprint) {
+        try {
+            String wsUrl = cfg.wsServer() + "/api/v1/ws";
+            // EasyBot 使用 WebSocket PING/PONG 检测存活，无需应用层心跳
+            String heartbeatPayload = "";
+            String authApiKey = cfg.apiKey();
+            AtomicReference<WsClient> clientRef = new AtomicReference<>();
+            WebSocketEventListener listener = new WebSocketEventListener() {
+                private WsClient currentClient() {
+                    return clientRef.get();
+                }
+
+                private boolean isCurrent() {
+                    WsClient current = currentClient();
+                    return current != null && webSocketClient == current;
+                }
+
+                @Override
+                public void onOpen() {
+                    if (!isCurrent()) return;
+                    healthRegistry.setWsConnected(HEALTH_KEY, false);
+                    if (!authApiKey.isBlank()) {
+                        currentClient().send(GSON.toJson(Map.of("token", authApiKey)));
+                    }
+                }
+
+                @Override
+                public void onClose(int code, String reason, boolean remote) {
+                    if (isCurrent()) {
+                        healthRegistry.setWsConnected(HEALTH_KEY, false);
+                    }
+                }
+
+                @Override
+                public void onError(Exception ex) {
+                    if (!isCurrent()) return;
+                    healthRegistry.setWsConnected(HEALTH_KEY, false);
+                    healthRegistry.setLastError(HEALTH_KEY, ex.toString());
+                    throttledLogger.error("easybot-ws", "EasyBot WebSocket 异常: " + ex);
+                    if (ex.getMessage() != null && ex.getMessage().contains("WS reconnect exhausted")) {
+                        detach(currentClient());
+                    }
+                }
+            };
+            WsClient client = wsFactory.create(
+                    logger,
+                    wsUrl,
+                    throttledLogger,
+                    Math.max(0, cfg.wsMaxRetries()),
+                    cfg.wsBaseRetryMs() <= 0 ? 5000 : cfg.wsBaseRetryMs(),
+                    cfg.wsMaxDelayMs() <= 0 ? 60000 : cfg.wsMaxDelayMs(),
+                    Math.max(0, cfg.wsJitterPercent()),
+                    cfg.wsStableResetMs() <= 0 ? 20000 : cfg.wsStableResetMs(),
+                    cfg.wsMessageLogEnabled(),
+                    cfg.wsMessageLogThrottleMs() <= 0 ? 60000 : cfg.wsMessageLogThrottleMs(),
+                    Collections.emptyMap(),
+                    heartbeatPayload,
+                    listener,
+                    message -> {
+                        WsClient current = clientRef.get();
+                        if (current != null && webSocketClient == current) {
+                            messageSink.accept(message);
+                        }
+                    });
+            clientRef.set(client);
+            webSocketClient = client;
+            activeConnectionFingerprint = fingerprint;
+            client.connect();
+        } catch (Exception e) {
+            healthRegistry.setLastError(HEALTH_KEY, e.toString());
+            logger.logger().warning("EasyBot WS setup failed: " + e);
+        }
+    }
+
+    private void shutdownLocked() {
+        WsClient current = webSocketClient;
+        webSocketClient = null;
+        activeConnectionFingerprint = null;
+        if (current != null) {
+            try {
+                current.disconnect();
+            } catch (Exception e) {
+                throttledLogger.warning("easybot-ws-shutdown", "EasyBot WebSocket 关闭异常: " + e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 背景

路线图 §4 架构演进项 **E2：`OrzEasyBot` God class 拆分**（834 行，HTTP/WS/解析/限流/鉴权混杂）。上一轮已抽 `HttpSender`（出站 + 批量结果解析）与 `BotInboundDispatcher`（业务分派），本轮收尾剩余内联的 WS 生命周期与入站解析。

## 改动（分阶段，每步全测试绿）

| 步骤 | 内容 |
|---|---|
| Step 1a | 抽离 `WebSocketLifecycle`（209 行）——连接状态（`webSocketClient`/连接指纹）、生命周期锁、配置对账、监听器回调（auth/close/error） |
| Step 1b | 抽离 `InboundEventParser`（270 行）——入站 JSON 解析、系统帧处理（auth_ok/auth_failed/lagged/ping）、大小/速率/平台/会话白名单校验、消息提取与分派 |

## 结果

- `OrzEasyBot` **834 → 229 行**，收敛为纯编排：生命周期委托 + 出站路由 + 构造装配。
- 职责分离：`WebSocketLifecycle`（连接）、`InboundEventParser`（解析）、`HttpSender`（出站 HTTP + 批量结果）、`BotInboundDispatcher`（业务分派）。
- 顺带删除 3 个因抽离而失效的死字段（`logger`/`inboundHandler`/`throttledLogger`，已不再被 OrzEasyBot 读取）。

## 行为保持

- WS 连接对账（配置变更重建）、入站校验顺序、`isAdmin` fail-closed 判定、回复定向 sink 均原样保留。
- 测试钩子 `processInboundEvent`/`setupWebSocketClient` 保留在 OrzEasyBot（委托给协作类），`OrzEasyBotTest` 零改动。

## 验收

- `./gradlew check` 全绿（单测 + MockBukkit 集成 + spotless + jacoco 门禁）。
- 无行为变更，仅结构重构。
