### PR TITLE
fix(leak): AsyncHttp 静态 HttpClient 缓存补 shutdown 关闭（P1-08）

### DIFF
--- a/docs/code-quality-roadmap.md
+++ b/docs/code-quality-roadmap.md
@@ -151,6 +151,14 @@
 
 > 每个任务 = 一个独立 PR。依赖为空即可并行开工。完成标准统一为 §0 约定。
 
+> ⚠️ **进度核对（2026-08-20）**：以下任务已在 PR #204（泄漏/并发/文档/CI 批量修复）与 E3 重构中落地，**无需再做**：
+> P0-01/P0-02（deny-list 绕过）、P1-01（LoginRateLimit sweep）、P1-02（TntEvent cooldown remove）、
+> P1-03（PortalEvent cooldown remove）、P1-04（CooldownRegistry reset）、P1-05（PermissionStore 读锁）、
+> P1-06（RankService 线程守卫）、P1-07（retryCount AtomicInteger）、P1-11（CommandAudit 异步化）、
+> P1-12（$p 日志注入，E3 抽离时已消除）、P1-13（二阶段注入收敛，E3 Step 3）、P2-04（空 catch 日志）。
+> 剩余：**P1-08**（AsyncHttp shutdown，本次已修）、**P1-09**（ServerFacade 单数版一致性，低优先）、
+> **P1-10**（reject 异步化，线程敏感待 Folia 验证）。P2 文档/测试项多数未逐一核对。
+
 ### P0 — 安全防线（立即，最高优先级）
 
 #### P0-01 修复 `/ op`（斜杠后空白）绕过 deny-list

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/PlatformModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/PlatformModule.java
@@ -13,6 +13,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.health.HealthRegistry;
 import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
 import com.jokerhub.paper.plugin.orzmc.infra.logging.OrzLog4JCaptureAppender;
 import com.jokerhub.paper.plugin.orzmc.infra.logging.ThrottledLogger;
+import com.jokerhub.paper.plugin.orzmc.infra.net.AsyncHttp;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.ThrottledNotifier;
 import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import com.jokerhub.paper.plugin.orzmc.infra.styles.OrzTextStyles;
@@ -72,6 +73,7 @@ public final class PlatformModule implements ServiceModule {
     public void tearDown() {
         detachLogCaptureAppender();
         commandAuditService.shutdown();
+        AsyncHttp.shutdown();
         configService.tearDown();
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/net/AsyncHttp.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/net/AsyncHttp.java
@@ -124,4 +124,22 @@ public final class AsyncHttp {
         if (left > Long.MAX_VALUE / right) return Long.MAX_VALUE;
         return left * right;
     }
+
+    /**
+     * 关闭所有缓存的 {@link HttpClient}（插件卸载/重载时回收其线程池，防泄漏）。
+     *
+     * <p>幂等：关闭后 {@code CLIENTS} 置空，下次请求经 {@link #client} 的 {@code computeIfAbsent}
+     * 重建新客户端。</p>
+     */
+    public static void shutdown() {
+        for (HttpClient client : CLIENTS.values()) {
+            client.close();
+        }
+        CLIENTS.clear();
+    }
+
+    /** 当前缓存的 HttpClient 数量（测试用：验证 shutdown 清空缓存）。 */
+    static int clientCount() {
+        return CLIENTS.size();
+    }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/net/AsyncHttpTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/net/AsyncHttpTest.java
@@ -169,6 +169,31 @@ public class AsyncHttpTest {
         assertEquals(2, requestCount.get());
     }
 
+    @Test
+    void shutdown_clearsClientCacheAndAllowsReuse() throws Exception {
+        server.createContext("/cache", exchange -> {
+            byte[] body = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        // 首次请求填充客户端缓存（按 connectTimeout 分桶）
+        AsyncHttp.get(baseUri.resolve("/cache").toString(), Map.of(), Duration.ofSeconds(1), Duration.ofSeconds(1), 0)
+                .join();
+        assertTrue(AsyncHttp.clientCount() > 0, "请求后应缓存 HttpClient");
+
+        // shutdown 关闭所有客户端并清空缓存（回收线程池，防泄漏）
+        AsyncHttp.shutdown();
+        assertEquals(0, AsyncHttp.clientCount(), "shutdown 后缓存应清空");
+
+        // 关闭后再次请求仍可重建客户端（幂等）
+        AsyncHttp.get(baseUri.resolve("/cache").toString(), Map.of(), Duration.ofSeconds(1), Duration.ofSeconds(1), 0)
+                .join();
+        assertTrue(AsyncHttp.clientCount() > 0, "shutdown 后再次请求应重建客户端");
+    }
+
     private void capture(
             HttpExchange exchange,
             AtomicReference<String> authHeader,


### PR DESCRIPTION
## 背景

路线图 §2.2 C3 / §3 P1-08：`AsyncHttp` 静态 `HttpClient` 缓存（按 connectTimeout 分桶）永不 close，线程池在插件卸载/重载后泄漏。

## 改动

- `AsyncHttp` 新增 `shutdown()`：关闭所有缓存 HttpClient 并清空 `CLIENTS`（幂等，关闭后 `computeIfAbsent` 重建）。
- `PlatformModule.tearDown()` 调用 `AsyncHttp.shutdown()`，与 `commandAuditService.shutdown()` 并列回收平台基础设施。
- 新增 `AsyncHttpTest.shutdown_clearsClientCacheAndAllowsReuse`：验证请求填充缓存 → shutdown 清空 → 再次请求重建。

## 验收

- `./gradlew check` 全绿（单测 + 集成 + spotless + jacoco）。
