### PR TITLE
refactor: 低价值打磨项批量扫尾（P2-06/07/18/19）

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzServices.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/OrzServices.java
@@ -68,6 +68,7 @@ public final class OrzServices {
                         .blacklistService(feature.blacklistService())
                         .reviewService(feature.reviewService())
                         .rankService(feature.rankService())
+                        .listFormatter(feature.listFormatter())
                         .logCaptureService(platform.logCaptureService())
                         .commandGuardService(platform.commandGuardService())
                         .commandAuditService(platform.commandAuditService()));

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -313,6 +313,11 @@ public final class FeatureModule implements ServiceModule {
         return rankService;
     }
 
+    /** 在线列表格式化器（单一事实源，$l/$w 命令与上下线广播共享）。 */
+    public com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter listFormatter() {
+        return listFormatter;
+    }
+
     // --- Lifecycle ---
 
     /** 禁用/重载时同步冲刷上下线聚合批次，避免最后一个窗口的事件被调度器取消而静默丢弃。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandDependencies.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandDependencies.java
@@ -7,6 +7,7 @@ import com.jokerhub.paper.plugin.orzmc.features.security.BlacklistService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandAuditService;
 import com.jokerhub.paper.plugin.orzmc.features.security.CommandGuardService;
 import com.jokerhub.paper.plugin.orzmc.infra.logging.LogCaptureService;
+import com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter;
 
 /**
  * {@link BotCommandService} 的跨模块依赖集合（六边形边界处的一次性批量注入）。
@@ -24,6 +25,7 @@ public final class BotCommandDependencies {
     private LogCaptureService logCaptureService;
     private CommandGuardService commandGuardService;
     private CommandAuditService commandAuditService;
+    private OnlineListFormatter listFormatter;
 
     public BotCommandDependencies maintenanceService(WorldMaintenanceService maintenanceService) {
         this.maintenanceService = maintenanceService;
@@ -60,6 +62,11 @@ public final class BotCommandDependencies {
         return this;
     }
 
+    public BotCommandDependencies listFormatter(OnlineListFormatter listFormatter) {
+        this.listFormatter = listFormatter;
+        return this;
+    }
+
     WorldMaintenanceService maintenanceService() {
         return maintenanceService;
     }
@@ -86,5 +93,9 @@ public final class BotCommandDependencies {
 
     CommandAuditService commandAuditService() {
         return commandAuditService;
+    }
+
+    OnlineListFormatter listFormatter() {
+        return listFormatter;
     }
 }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/BotCommandService.java
@@ -105,11 +105,14 @@ public final class BotCommandService extends BotCommandContext implements BotInb
         this.commandGuardService = deps.commandGuardService();
         this.commandAuditService = deps.commandAuditService();
         this.rankService = deps.rankService();
-        if (deps.rankService() != null) {
-            // 重建列表反馈服务以注入 rankService（在线列表显示权限组）
-            com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter formatter =
-                    new com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter();
+        // 优先使用组合根注入的共享 formatter（与上下线广播同一实例，保证格式一致）；
+        // 未注入时按旧路径用 rankService 重建（测试向后兼容）。
+        com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter formatter = deps.listFormatter();
+        if (formatter == null && deps.rankService() != null) {
+            formatter = new com.jokerhub.paper.plugin.orzmc.infra.player.OnlineListFormatter();
             formatter.setRankService(deps.rankService());
+        }
+        if (formatter != null) {
             this.listFeedbackService = new BotCommandListFeedbackService(server, configs, formatter);
         }
     }

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/WhitelistCommandHandler.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/botcommands/WhitelistCommandHandler.java
@@ -22,6 +22,8 @@ import java.util.logging.Level;
 final class WhitelistCommandHandler extends BotCommandContext {
 
     private final Supplier<BotCommandListFeedbackService> listFeedbackService;
+    /** 单例白名单服务（替代每处 defaultImpl 新建，避免无状态对象重复实例化）。 */
+    private final WhitelistService whitelistService;
 
     WhitelistCommandHandler(
             ServerFacade server,
@@ -29,13 +31,14 @@ final class WhitelistCommandHandler extends BotCommandContext {
             Supplier<BotCommandListFeedbackService> listFeedbackService) {
         super(server, configs);
         this.listFeedbackService = listFeedbackService;
+        this.whitelistService = WhitelistService.defaultImpl(server.plugin());
     }
 
     void handleShowWhitelist(OrzUserCmd cmd, boolean isAdmin, Consumer<MessageEnvelope> callback, String rawArgs) {
         server.runAsync(() -> {
             try {
                 WhitelistConfig whitelistConfig = configs.whitelist();
-                WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
+                WhitelistService svc = whitelistService;
                 int delayTicks = Math.max(0, whitelistConfig.paginationDelayTicks());
                 Integer page = parsePageArg(rawArgs);
                 if (isAdmin) {
@@ -53,7 +56,7 @@ final class WhitelistCommandHandler extends BotCommandContext {
         Set<String> userNames = parseArgs(rawArgs);
         if (!guardWhitelistCommand(cmd, isAdmin, userNames, callback)) return;
         server.runSync(() -> {
-            WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
+            WhitelistService svc = whitelistService;
             String message = svc.addPlayers(server.server(), userNames);
             emit(callback, "command_whitelist_add_result", Map.of("message", message), message);
         });
@@ -63,7 +66,7 @@ final class WhitelistCommandHandler extends BotCommandContext {
         Set<String> userNames = parseArgs(rawArgs);
         if (!guardWhitelistCommand(cmd, isAdmin, userNames, callback)) return;
         server.runSync(() -> {
-            WhitelistService svc = WhitelistService.defaultImpl(server.plugin());
+            WhitelistService svc = whitelistService;
             String message = svc.removePlayers(server.server(), userNames);
             emit(callback, "command_whitelist_remove_result", Map.of("message", message), message);
         });

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/command/binding/CooldownRegistry.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/command/binding/CooldownRegistry.java
@@ -1,15 +1,18 @@
 package com.jokerhub.paper.plugin.orzmc.features.command.binding;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 
 public final class CooldownRegistry {
     private static final ConcurrentHashMap<String, Long> lastInvoke = new ConcurrentHashMap<>();
+    /** 测试用：注入假时钟避免真实 sleep；生产默认系统时钟。 */
+    static LongSupplier clock = System::currentTimeMillis;
 
     private CooldownRegistry() {}
 
     public static boolean isCoolingDown(String key, int seconds) {
         if (seconds <= 0) return false;
-        long now = System.currentTimeMillis();
+        long now = clock.getAsLong();
         Long prev = lastInvoke.get(key);
         if (prev == null || now - prev >= seconds * 1000L) {
             lastInvoke.put(key, now);

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/portal/PortalEventService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/portal/PortalEventService.java
@@ -6,6 +6,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -35,6 +36,7 @@ public final class PortalEventService {
     private final PortalPort portalService;
     private final Predicate<Player> authCheck;
     private final boolean folia;
+    private final LongSupplier clock;
     private final Map<UUID, Long> lastTransfer = new ConcurrentHashMap<>();
 
     public PortalEventService(ServerFacade server, PortalPort portalService) {
@@ -48,17 +50,28 @@ public final class PortalEventService {
 
     /** 测试用：可注入 folia 模式 + 认证决策（测试环境无 LoginSecurity，默认实现恒 true 无法覆盖未认证分支）。 */
     PortalEventService(ServerFacade server, PortalPort portalService, boolean folia, Predicate<Player> authCheck) {
+        this(server, portalService, folia, authCheck, System::currentTimeMillis);
+    }
+
+    /** 测试用：注入可控时钟验证冷却滑动，避免真实 sleep。 */
+    PortalEventService(
+            ServerFacade server,
+            PortalPort portalService,
+            boolean folia,
+            Predicate<Player> authCheck,
+            LongSupplier clock) {
         this.server = server;
         this.portalService = portalService;
         this.authCheck = authCheck;
         this.folia = folia;
+        this.clock = clock;
     }
 
     /** Paper 路径：PlayerPortalEvent（玩家即将传送门传送）。 */
     public void handle(PlayerPortalEvent event) {
         Player player = event.getPlayer();
         // 冷却内不接管本次事件：避免「取消了原版传送但 transfer 被冷却拦截」的状态分歧
-        if (isOnCooldown(player, System.currentTimeMillis())) {
+        if (isOnCooldown(player, clock.getAsLong())) {
             return;
         }
         // 检查玩家是否已认证
@@ -102,7 +115,7 @@ public final class PortalEventService {
             return;
         }
         // 冷却内快速跳过（transfer() 内为双路径共享的权威判断）
-        if (isOnCooldown(player, System.currentTimeMillis())) {
+        if (isOnCooldown(player, clock.getAsLong())) {
             return;
         }
         // 精确命中传送门内部格（水平无邻域容差）：move 路径对每个方块移动求值，
@@ -132,7 +145,7 @@ public final class PortalEventService {
 
     private void transfer(Player player, String target) {
         // 双路径共享冷却（权威判断）：防 PlayerPortalEvent + PlayerMoveEvent 重复触发
-        long now = System.currentTimeMillis();
+        long now = clock.getAsLong();
         if (isOnCooldown(player, now)) {
             return;
         }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/command/binding/CooldownRegistryTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/command/binding/CooldownRegistryTest.java
@@ -7,12 +7,20 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class CooldownRegistryTest {
     @Test
-    public void testCooldownFlow() throws Exception {
+    public void testCooldownFlow() {
         String key = "tpbow|tester";
-        Assertions.assertFalse(CooldownRegistry.isCoolingDown(key, 1));
-        Assertions.assertTrue(CooldownRegistry.isCoolingDown(key, 1));
-        Thread.sleep(1000L);
-        Assertions.assertFalse(CooldownRegistry.isCoolingDown(key, 1));
+        java.util.concurrent.atomic.AtomicLong now = new java.util.concurrent.atomic.AtomicLong(0);
+        java.util.function.LongSupplier original = CooldownRegistry.clock;
+        CooldownRegistry.clock = now::get;
+        CooldownRegistry.reset();
+        try {
+            Assertions.assertFalse(CooldownRegistry.isCoolingDown(key, 1));
+            Assertions.assertTrue(CooldownRegistry.isCoolingDown(key, 1));
+            now.set(1000); // 假时钟推进 1s，冷却过期
+            Assertions.assertFalse(CooldownRegistry.isCoolingDown(key, 1));
+        } finally {
+            CooldownRegistry.clock = original;
+        }
     }
 
     @ParameterizedTest

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/portal/PortalEventServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/portal/PortalEventServiceTest.java
@@ -235,14 +235,15 @@ class PortalEventServiceTest extends ServiceTestBase {
     }
 
     @Test
-    void moveEvent_afterCooldown_transfersAgain() throws Exception {
+    void moveEvent_afterCooldown_transfersAgain() {
         when(portalService.findTargetExact(any(Location.class))).thenReturn("127.0.0.1:25566");
-        PortalEventService service = new PortalEventService(server, portalService, true);
+        java.util.concurrent.atomic.AtomicLong clock = new java.util.concurrent.atomic.AtomicLong(0);
+        PortalEventService service = new PortalEventService(server, portalService, true, p -> true, clock::get);
         service.handleMove(new PlayerMoveEvent(player, loc(100, 64, 100), loc(101, 64, 100)));
         verify(server, times(1)).executeConsoleCommand(anyString());
 
-        // 冷却（5s）过期后再次走进传送门 → 允许再次 transfer
-        Thread.sleep(5100);
+        // 冷却（5s）过期后再次走进传送门 → 允许再次 transfer（假时钟推进，无需真实 sleep）
+        clock.set(6000);
         service.handleMove(new PlayerMoveEvent(player, loc(101, 64, 100), loc(102, 64, 100)));
         verify(server, times(2)).executeConsoleCommand(anyString());
     }


### PR DESCRIPTION
## 背景

「不需测试服」低价值打磨项批量扫尾（用户指定），共 4 项：

| 项 | 内容 |
|---|---|
| P2-06 | `WhitelistCommandHandler` 三处 `WhitelistService.defaultImpl` 新建收敛为单例字段（无状态对象，去重复实例化） |
| P2-07 | `OnlineListFormatter` 三实例收敛为单一实例：组合根经 `BotCommandDependencies.listFormatter` 注入 `FeatureModule` 的 formatter，$l/$w 命令与上下线广播共享同一实例 |
| P2-18 | `PortalEventService` 注入 `LongSupplier` 假时钟，测试消除 `Thread.sleep(5100)`（5s 慢测试） |
| P2-19 | `CooldownRegistry` 注入 `LongSupplier` 假时钟，测试消除 `Thread.sleep(1000)` |

## 验收

- `./gradlew check` 全绿（单测 + MockBukkit 集成 + spotless + jacoco）。
- P2-07 保留向后兼容：未注入 formatter 时按旧路径用 rankService 重建（测试兼容）。
