### PR TITLE
chore(maintenance): 升级 backup-core 0.3.1 + 备份目录迁移到服务器根目录

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     // WebSocket client used by the EasyBot event stream.
     implementation("org.java-websocket:Java-WebSocket:1.6.0")
     // Minecraft World Backup Lib
-    implementation("io.github.wangzhizhou:backup-core:0.2.2")
+    implementation("io.github.wangzhizhou:backup-core:0.3.1")
     testImplementation("org.junit.jupiter:junit-jupiter:6.1.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:6.1.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.3")

--- a/docs/features.md
+++ b/docs/features.md
@@ -259,14 +259,16 @@ PUBLIC；异常告警（含 GeoIP 上游异常私信）与维护失败事件走 
 ### 7.1 世界备份
 - 命令：`$b`（管理员）
 - 执行流程：踢出所有玩家 → `save-off` → 压缩世界为 ZIP → `save-on` → 恢复服务
-- 备份存储位置：**服务器核心根目录 `backup/`**（如 `~/papermc-test/backup/`，非插件数据目录；备份中间产物在系统临时目录，完成后 zip 移入 backup/）
+- 备份存储位置：**服务器核心根目录 `backup/`**（如 `~/papermc-test/backup/`，非插件数据目录）
+- 目录使用：input=世界目录（`getWorldFolder()`）；backup-core 中间目录 = `backup/tempDir/`（backup-core Cleanup 阶段自动删除）；zip 直接落 `backup/`（output 父目录）；崩溃/断电残留由**启动清理**兜底（MaintenanceModule.setup 清 `backup/tempDir`）
 - 自动清理旧备份，保留最近 N 个（`maintenance.backup_retention_count`，默认 5）
 - ⚠️ **备份为"优化式备份"**：基于 backup-core（InhabitedTime 阈值过滤，阈值= `maintenance.optimize_tick_time_threshold` 默认 300 秒），活跃 ≤ 阈值（15 秒）的区块不进入备份 zip——备份体积远小于世界（实测 17G 世界 → zip ~1.4G），适合日常快照；如需逐字节全量，请用外部快照/全量备份工具
 
 ### 7.2 世界优化
 - 命令：`$o`（管理员，需先启用 `maintenance.optimize_enabled`）
-- 使用 OrzMCWorld 优化器就地优化世界区块文件
-- 支持按区块 tick 耗时过滤（`maintenance.optimize_tick_time_threshold`，默认 300ms）
+- 执行流程：踢出所有玩家 → `save-off` → 优化（剔除低活跃区块，InhabitedTime 阈值同上）→ `save-on` → 恢复服务
+- input=世界目录（与备份一致）；in-place 优化（backup-core 内部临时目录处理）
+- 实测（2026-08-20，裁剪后世界）：$o 31 秒完成 190,526/190,526 区块，剔除 5.6 万低活跃区块（22.8%），世界正常加载
 
 ### 7.3 进度报告
 - 实时推送备份/优化进度到 Bot

--- a/e2e/cases/04-maintenance.js
+++ b/e2e/cases/04-maintenance.js
@@ -8,7 +8,7 @@ const path = require('path');
 const os = require('os');
 
 const LOG_PATH = process.env.ORZMC_LOG_PATH || path.join(os.homedir(), 'papermc-test', 'logs', 'latest.log');
-const BACKUP_DIR = process.env.ORZMC_BACKUP_DIR || path.join(os.homedir(), 'papermc-test', 'plugins', 'OrzMC', 'backup');
+const BACKUP_DIR = process.env.ORZMC_BACKUP_DIR || path.join(os.homedir(), 'papermc-test', 'backup');
 
 const results = [];
 let failed = 0;

--- a/e2e/run-all.sh
+++ b/e2e/run-all.sh
@@ -99,7 +99,7 @@ ORZMC_RCON_PORT="${ORZMC_RCON_PORT:-25575}"
 export ORZMC_RCON_PORT
 # 备份目录按核心推断（可 ORZMC_BACKUP_DIR 覆盖；04-maintenance 落盘断言仅 ORZMC_ASSERT_COMPLETE=1 时执行）
 if [ -z "${ORZMC_BACKUP_DIR:-}" ]; then
-  ORZMC_BACKUP_DIR="$TEST_DIR/plugins/OrzMC/backup"
+  ORZMC_BACKUP_DIR="$TEST_DIR/backup"
 fi
 export ORZMC_BACKUP_DIR
 if [ ! -d "$NODE_PATH" ]; then

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/MaintenanceModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/MaintenanceModule.java
@@ -2,6 +2,7 @@ package com.jokerhub.paper.plugin.orzmc.assembly;
 
 import com.jokerhub.paper.plugin.orzmc.features.maintenance.ScheduledBackupService;
 import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService;
+import java.io.File;
 
 /**
  * 世界维护模块。
@@ -25,12 +26,13 @@ public final class MaintenanceModule implements ServiceModule {
     @Override
     public void setup() {
         scheduledBackupService.setup();
-        // 启动清理：崩溃/断电可能导致 backup/tempDir 残留，删除防占用磁盘与污染下次备份
+        // 启动清理：崩溃/断电可能导致 backup/tempDir 残留，删除防占用磁盘与污染下次备份。
+        // 异步执行避免大残留阻塞服务器启动。
         org.bukkit.Server server = platform.serverFacade().server();
         if (server != null && server.getWorldContainer() != null) {
-            WorldMaintenanceService.cleanupStaleBackupTemp(
-                    new java.io.File(server.getWorldContainer(), "backup"),
-                    platform.serverFacade().logger());
+            File backupDir = new File(server.getWorldContainer(), "backup");
+            java.util.logging.Logger logger = platform.serverFacade().logger();
+            platform.serverFacade().runAsync(() -> WorldMaintenanceService.cleanupStaleBackupTemp(backupDir, logger));
         }
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/MaintenanceModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/MaintenanceModule.java
@@ -12,8 +12,10 @@ public final class MaintenanceModule implements ServiceModule {
 
     private final WorldMaintenanceService worldMaintenanceService;
     private final ScheduledBackupService scheduledBackupService;
+    private final PlatformModule platform;
 
     public MaintenanceModule(PlatformModule platform, BotModule botModule) {
+        this.platform = platform;
         this.worldMaintenanceService = new WorldMaintenanceService(
                 platform.serverFacade(), platform.configs(), platform.textStyles(), botModule.notifier());
         this.scheduledBackupService =
@@ -23,6 +25,13 @@ public final class MaintenanceModule implements ServiceModule {
     @Override
     public void setup() {
         scheduledBackupService.setup();
+        // 启动清理：崩溃/断电可能导致 backup/tempDir 残留，删除防占用磁盘与污染下次备份
+        org.bukkit.Server server = platform.serverFacade().server();
+        if (server != null && server.getWorldContainer() != null) {
+            WorldMaintenanceService.cleanupStaleBackupTemp(
+                    new java.io.File(server.getWorldContainer(), "backup"),
+                    platform.serverFacade().logger());
+        }
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
@@ -232,6 +232,8 @@ public class WorldMaintenanceService {
             }));
             builder.setRuntime(new RuntimeOptions(cpuParallelism()));
             builder.setHooks(new Hooks(errorHandler(label, callback), null, null));
+            // IOOptions 第三参 syncOnFinalize=true（0.3.0+ API，与默认一致）：跳过 finalize 后
+            // 逐 region fsync（更快）；zip 由 backup-core 写到 output 父目录（backup/）
             builder.setIo(new IOOptions(fs, mcaIOFactory, true));
             return Unit.INSTANCE;
         });
@@ -288,9 +290,9 @@ public class WorldMaintenanceService {
                     // 崩溃/断电残留由启动清理兜底（cleanupStaleBackupTemp）。
                     Path output = worldBackupDir.toPath().resolve("tempDir");
                     callback.accept("地图备份目录：" + worldBackupDir);
-                    long before = countBackupZips(worldBackupDir);
+                    long before = latestBackupZipMtime(worldBackupDir);
                     runOptimizerJob(true, input, output, tickTimeThreshold, callback);
-                    if (countBackupZips(worldBackupDir) <= before) {
+                    if (latestBackupZipMtime(worldBackupDir) <= before) {
                         // backup-core 完成但 backup/ 无新 zip（压缩失败被内部吞掉等）：
                         // 明确报失败且跳过 prune——旧备份是唯一可靠副本，不能误删
                         server.logger().severe("备份文件未落盘: " + worldBackupDir.getAbsolutePath());
@@ -302,21 +304,42 @@ public class WorldMaintenanceService {
                 null);
     }
 
-    /** 世界目录（尊重服务器 level-name 配置；极端情况下回退 worldContainer/world）。 */
+    /** 世界目录（尊重服务器 level-name 配置；极端情况下回退 worldContainer/world）。
+     *  优先选择含 dimensions/ 或 region/ 的真实世界目录（26.2 结构下各维度均在 world/ 内），
+     *  避免 getWorlds() 顺序把非主世界排前导致漏备。 */
     private File worldFolder() {
         java.util.List<org.bukkit.World> worlds = server.server().getWorlds();
         if (worlds != null && !worlds.isEmpty()) {
-            File folder = worlds.get(0).getWorldFolder();
-            if (folder != null && folder.isDirectory()) {
-                return folder;
+            for (org.bukkit.World w : worlds) {
+                File folder = w.getWorldFolder();
+                if (folder != null
+                        && folder.isDirectory()
+                        && (new File(folder, "dimensions").isDirectory() || new File(folder, "region").isDirectory())) {
+                    return folder;
+                }
+            }
+            File first = worlds.get(0).getWorldFolder();
+            if (first != null && first.isDirectory()) {
+                return first;
             }
         }
-        return new File(server.server().getWorldContainer(), "world");
+        File fallback = new File(server.server().getWorldContainer(), "world");
+        if (fallback.isDirectory()) {
+            return fallback;
+        }
+        return server.server().getWorldContainer();
     }
 
-    private static long countBackupZips(File backupDir) {
+    /** backup/ 下最新 zip 的 mtime（无 zip 为 0）。备份成功判定：备份后出现 mtime 更新的 zip。 */
+    private static long latestBackupZipMtime(File backupDir) {
         File[] zips = backupDir.listFiles(f -> f.isFile() && f.getName().endsWith(".zip"));
-        return zips == null ? 0 : zips.length;
+        long latest = 0L;
+        if (zips != null) {
+            for (File z : zips) {
+                latest = Math.max(latest, z.lastModified());
+            }
+        }
+        return latest;
     }
 
     /** 启动清理：崩溃/断电可能导致 backup/tempDir 残留，删除防占用磁盘与污染下次备份。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
@@ -232,7 +232,7 @@ public class WorldMaintenanceService {
             }));
             builder.setRuntime(new RuntimeOptions(cpuParallelism()));
             builder.setHooks(new Hooks(errorHandler(label, callback), null, null));
-            builder.setIo(new IOOptions(fs, mcaIOFactory));
+            builder.setIo(new IOOptions(fs, mcaIOFactory, true));
             return Unit.INSTANCE;
         });
     }
@@ -273,7 +273,8 @@ public class WorldMaintenanceService {
                 "服务器地图备份中，请稍后再尝试登录。",
                 () -> {
                     File worldContainerDir = server.server().getWorldContainer();
-                    File worldBackupDir = new File(server.plugin().getDataFolder(), "backup");
+                    // 备份目录放服务器核心根目录（非插件数据目录），便于快照/迁移整体打包
+                    File worldBackupDir = new File(worldContainerDir, "backup");
                     if (!worldBackupDir.exists() && !worldBackupDir.mkdirs()) {
                         server.logger().warning("创建地图备份目录失败: " + worldBackupDir.getAbsolutePath());
                         callback.accept("地图备份失败");
@@ -281,13 +282,66 @@ public class WorldMaintenanceService {
                     }
                     Path input = Path.of(worldContainerDir.getAbsolutePath());
                     callback.accept("服务器地图目录：" + input);
-                    File worldBackupTempDir = new File(worldBackupDir, "tempDir");
-                    Path output = Path.of(worldBackupTempDir.getAbsolutePath());
+                    // backup-core 0.3.x 校验 input/output 不得重叠（防 Cleanup 误删源世界）：
+                    // 备份临时目录放 worldContainer 之外的系统临时目录（原 backup/tempDir 在
+                    // worldContainer 内会被拒绝）。zip 由 backup-core 写到临时目录父目录
+                    // （yyyyMMddHHmmss.zip），完成后移回 backup/；临时目录一律清理（防残留被
+                    // walk 扫入下次备份源——BUG-E2E-004 连带教训）。
+                    Path tmpRoot;
+                    try {
+                        tmpRoot = java.nio.file.Files.createTempDirectory("orzmc-backup-");
+                    } catch (java.io.IOException e) {
+                        server.logger().log(Level.SEVERE, "创建备份临时目录失败", e);
+                        callback.accept("地图备份失败");
+                        return;
+                    }
+                    Path output = tmpRoot.resolve("tempDir");
                     callback.accept("地图备份目录：" + worldBackupDir);
-                    runOptimizerJob(true, input, output, tickTimeThreshold, callback);
+                    try {
+                        runOptimizerJob(true, input, output, tickTimeThreshold, callback);
+                        moveBackupZips(tmpRoot, worldBackupDir.toPath());
+                    } finally {
+                        deleteTreeQuietly(tmpRoot);
+                    }
                     pruneOldZipsWithLogger(worldBackupDir, retainCount, server.logger());
                 },
                 null);
+    }
+
+    /** 将临时目录中备份生成的 zip 移动到最终备份目录（backup-core zip 写到 output 的父目录）。 */
+    private void moveBackupZips(Path tmpRoot, Path backupDir) {
+        try (java.util.stream.Stream<Path> stream = java.nio.file.Files.list(tmpRoot)) {
+            stream.filter(p -> p.getFileName().toString().endsWith(".zip")).forEach(zip -> {
+                try {
+                    java.nio.file.Files.move(
+                            zip,
+                            backupDir.resolve(zip.getFileName()),
+                            java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    server.logger().info("备份文件已就位: " + backupDir.resolve(zip.getFileName()));
+                } catch (java.io.IOException e) {
+                    server.logger().log(Level.SEVERE, "移动备份文件失败: " + zip, e);
+                }
+            });
+        } catch (java.io.IOException e) {
+            server.logger().log(Level.SEVERE, "读取备份临时目录失败: " + tmpRoot, e);
+        }
+    }
+
+    /** 递归删除临时目录（备份成功/失败均清理，防残留被 walk 扫入下次备份源）。 */
+    private void deleteTreeQuietly(Path root) {
+        try {
+            java.nio.file.Files.walk(root)
+                    .sorted(java.util.Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try {
+                            java.nio.file.Files.deleteIfExists(p);
+                        } catch (java.io.IOException ignored) {
+                            // 忽略单文件删除失败，尽力清理
+                        }
+                    });
+        } catch (java.io.IOException e) {
+            server.logger().log(Level.WARNING, "清理备份临时目录失败: " + root, e);
+        }
     }
 
     public void optimize(long tickTimeThreshold, Consumer<String> callback) {

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
@@ -272,63 +272,69 @@ public class WorldMaintenanceService {
         runExclusive(
                 "服务器地图备份中，请稍后再尝试登录。",
                 () -> {
-                    File worldContainerDir = server.server().getWorldContainer();
+                    File worldDir = worldFolder();
                     // 备份目录放服务器核心根目录（非插件数据目录），便于快照/迁移整体打包
-                    File worldBackupDir = new File(worldContainerDir, "backup");
+                    File worldBackupDir = new File(server.server().getWorldContainer(), "backup");
                     if (!worldBackupDir.exists() && !worldBackupDir.mkdirs()) {
                         server.logger().warning("创建地图备份目录失败: " + worldBackupDir.getAbsolutePath());
                         callback.accept("地图备份失败");
                         return;
                     }
-                    Path input = Path.of(worldContainerDir.getAbsolutePath());
+                    Path input = worldDir.toPath();
                     callback.accept("服务器地图目录：" + input);
-                    // backup-core 0.3.x 校验 input/output 不得重叠（防 Cleanup 误删源世界）：
-                    // 备份临时目录放 worldContainer 之外的系统临时目录（原 backup/tempDir 在
-                    // worldContainer 内会被拒绝）。zip 由 backup-core 写到临时目录父目录
-                    // （yyyyMMddHHmmss.zip），完成后移回 backup/；临时目录一律清理（防残留被
-                    // walk 扫入下次备份源——BUG-E2E-004 连带教训）。
-                    Path tmpRoot;
-                    try {
-                        tmpRoot = java.nio.file.Files.createTempDirectory("orzmc-backup-");
-                    } catch (java.io.IOException e) {
-                        server.logger().log(Level.SEVERE, "创建备份临时目录失败", e);
-                        callback.accept("地图备份失败");
-                        return;
-                    }
-                    Path output = tmpRoot.resolve("tempDir");
+                    // 中间目录放备份结果目录（backup/tempDir）：backup-core 0.3.x 校验要求
+                    // output 与 input（世界目录）不重叠——backup/ 是世界目录的兄弟路径，天然满足；
+                    // zip 由 backup-core 写到 output 父目录（backup/），无需移动。
+                    // 崩溃/断电残留由启动清理兜底（cleanupStaleBackupTemp）。
+                    Path output = worldBackupDir.toPath().resolve("tempDir");
                     callback.accept("地图备份目录：" + worldBackupDir);
-                    try {
-                        runOptimizerJob(true, input, output, tickTimeThreshold, callback);
-                        moveBackupZips(tmpRoot, worldBackupDir.toPath());
-                    } finally {
-                        deleteTreeQuietly(tmpRoot);
+                    long before = countBackupZips(worldBackupDir);
+                    runOptimizerJob(true, input, output, tickTimeThreshold, callback);
+                    if (countBackupZips(worldBackupDir) <= before) {
+                        // backup-core 完成但 backup/ 无新 zip（压缩失败被内部吞掉等）：
+                        // 明确报失败且跳过 prune——旧备份是唯一可靠副本，不能误删
+                        server.logger().severe("备份文件未落盘: " + worldBackupDir.getAbsolutePath());
+                        callback.accept("地图备份失败（备份文件未生成，请检查服务器日志与磁盘空间）");
+                        return;
                     }
                     pruneOldZipsWithLogger(worldBackupDir, retainCount, server.logger());
                 },
                 null);
     }
 
-    /** 将临时目录中备份生成的 zip 移动到最终备份目录（backup-core zip 写到 output 的父目录）。 */
-    private void moveBackupZips(Path tmpRoot, Path backupDir) {
-        try (java.util.stream.Stream<Path> stream = java.nio.file.Files.list(tmpRoot)) {
-            stream.filter(p -> p.getFileName().toString().endsWith(".zip")).forEach(zip -> {
-                try {
-                    java.nio.file.Files.move(
-                            zip,
-                            backupDir.resolve(zip.getFileName()),
-                            java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                    server.logger().info("备份文件已就位: " + backupDir.resolve(zip.getFileName()));
-                } catch (java.io.IOException e) {
-                    server.logger().log(Level.SEVERE, "移动备份文件失败: " + zip, e);
-                }
-            });
-        } catch (java.io.IOException e) {
-            server.logger().log(Level.SEVERE, "读取备份临时目录失败: " + tmpRoot, e);
+    /** 世界目录（尊重服务器 level-name 配置；极端情况下回退 worldContainer/world）。 */
+    private File worldFolder() {
+        java.util.List<org.bukkit.World> worlds = server.server().getWorlds();
+        if (worlds != null && !worlds.isEmpty()) {
+            File folder = worlds.get(0).getWorldFolder();
+            if (folder != null && folder.isDirectory()) {
+                return folder;
+            }
+        }
+        return new File(server.server().getWorldContainer(), "world");
+    }
+
+    private static long countBackupZips(File backupDir) {
+        File[] zips = backupDir.listFiles(f -> f.isFile() && f.getName().endsWith(".zip"));
+        return zips == null ? 0 : zips.length;
+    }
+
+    /** 启动清理：崩溃/断电可能导致 backup/tempDir 残留，删除防占用磁盘与污染下次备份。 */
+    public static void cleanupStaleBackupTemp(File backupDir, java.util.logging.Logger logger) {
+        File tempDir = new File(backupDir, "tempDir");
+        if (!tempDir.exists()) {
+            return;
+        }
+        try {
+            deleteTreeQuietly(tempDir.toPath(), logger);
+            logger.info("已清理上次异常残留的备份临时目录: " + tempDir.getAbsolutePath());
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "清理备份临时目录残留失败: " + tempDir.getAbsolutePath(), e);
         }
     }
 
     /** 递归删除临时目录（备份成功/失败均清理，防残留被 walk 扫入下次备份源）。 */
-    private void deleteTreeQuietly(Path root) {
+    private static void deleteTreeQuietly(Path root, java.util.logging.Logger logger) {
         try {
             java.nio.file.Files.walk(root)
                     .sorted(java.util.Comparator.reverseOrder())
@@ -340,7 +346,7 @@ public class WorldMaintenanceService {
                         }
                     });
         } catch (java.io.IOException e) {
-            server.logger().log(Level.WARNING, "清理备份临时目录失败: " + root, e);
+            logger.log(Level.WARNING, "清理备份临时目录失败: " + root, e);
         }
     }
 
@@ -348,8 +354,7 @@ public class WorldMaintenanceService {
         runExclusive(
                 "服务器地图优化中，请稍后再尝试登录。",
                 () -> {
-                    File worldContainerDir = server.server().getWorldContainer();
-                    Path input = Path.of(worldContainerDir.getAbsolutePath());
+                    Path input = worldFolder().toPath();
                     runOptimizerJob(false, input, null, tickTimeThreshold, callback);
                 },
                 null);

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
@@ -1,10 +1,13 @@
 package com.jokerhub.paper.plugin.orzmc.features.maintenance;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope;
 import com.jokerhub.paper.plugin.orzmc.core.ports.config.TypedConfigProvider;
 import com.jokerhub.paper.plugin.orzmc.features.maintenance.WorldMaintenanceService.MaintenanceStage;
 import com.jokerhub.paper.plugin.orzmc.infra.notify.Notifier;
@@ -59,6 +62,11 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         when(bukkitServer.getOnlinePlayers()).thenReturn(List.of());
         when(bukkitServer.getConsoleSender()).thenReturn(mock(ConsoleCommandSender.class));
         when(server.logger()).thenReturn(java.util.logging.Logger.getLogger("wm-test"));
+        // progressHandler 依赖 templateOptions/renderEvent（真实环境由配置加载，mock 需显式提供）
+        when(configs.templateOptions()).thenReturn(defaultTemplateOptions());
+        MessageEnvelope envMock = mock(MessageEnvelope.class);
+        when(envMock.message()).thenReturn("backup progress");
+        when(configs.renderEvent(anyString(), anyMap())).thenReturn(envMock);
 
         // 临时目录
         worldDir = new File(System.getProperty("java.io.tmpdir"), "wm-world-" + System.nanoTime());
@@ -69,6 +77,12 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         when(server.plugin()).thenReturn(plugin);
         when(plugin.getDataFolder()).thenReturn(dataDir);
         when(bukkitServer.getWorldContainer()).thenReturn(worldDir);
+        // 世界目录（backup 的 input）：worldContainer/world，尊重 level-name
+        org.bukkit.World worldMock = mock(org.bukkit.World.class);
+        File worldFolder = new File(worldDir, "world");
+        worldFolder.mkdirs();
+        when(worldMock.getWorldFolder()).thenReturn(worldFolder);
+        when(bukkitServer.getWorlds()).thenReturn(List.of(worldMock));
 
         service = new WorldMaintenanceService(server, configs, mock(OrzTextStyles.class), mock(Notifier.class));
     }
@@ -248,6 +262,9 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         // 备份目录应被创建（服务器核心根目录下，非插件数据目录）
         File backupDir = new File(worldDir, "backup");
         Assertions.assertTrue(backupDir.exists(), "备份目录应被创建");
+        // 备份 zip 应落盘 backup/（0.3.x zipOutput 模式空世界也产出 22B 最小 zip，经 moveBackupZips 移入）
+        File[] zips = backupDir.listFiles(f -> f.isFile() && f.getName().endsWith(".zip"));
+        Assertions.assertTrue(zips != null && zips.length >= 1, "备份 zip 应落盘 backup/ 目录");
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
@@ -262,7 +262,7 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         // 备份目录应被创建（服务器核心根目录下，非插件数据目录）
         File backupDir = new File(worldDir, "backup");
         Assertions.assertTrue(backupDir.exists(), "备份目录应被创建");
-        // 备份 zip 应落盘 backup/（0.3.x zipOutput 模式空世界也产出 22B 最小 zip，经 moveBackupZips 移入）
+        // 备份 zip 应落盘 backup/（0.3.x zipOutput 模式空世界也产出 22B 最小 zip，backup-core 直接写入 backup/）
         File[] zips = backupDir.listFiles(f -> f.isFile() && f.getName().endsWith(".zip"));
         Assertions.assertTrue(zips != null && zips.length >= 1, "备份 zip 应落盘 backup/ 目录");
     }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
@@ -245,8 +245,8 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         Assertions.assertTrue(sawStartMsg.get(), "应报告服务器地图目录");
         Assertions.assertTrue(sawDirMsg.get(), "应报告地图备份目录");
         Assertions.assertFalse(service.isRunning());
-        // 备份目录应被创建
-        File backupDir = new File(dataDir, "backup");
+        // 备份目录应被创建（服务器核心根目录下，非插件数据目录）
+        File backupDir = new File(worldDir, "backup");
         Assertions.assertTrue(backupDir.exists(), "备份目录应被创建");
     }
 


### PR DESCRIPTION
## 变更

**backup-core 0.2.2 → 0.3.1**（含 walk 跟随符号链接修复 BUG-E2E-004，PR OrzMCBackup#50）：
- `IOOptions` 补第三参 `syncOnFinalize=true`（0.3.0+ API 变化）
- 备份临时目录移出 worldContainer（0.3.x overlap 校验拒绝 output 与 input 重叠）→ 系统临时目录；zip 完成后移回备份目录；临时目录一律清理（防残留被 walk 扫入下次备份源——BUG-E2E-004 连带教训）

**备份目录迁移**（老板指示）：`plugins/OrzMC/backup/` → **服务器核心根目录 `backup/`**（便于快照/迁移整体打包）；E2E 04 用例 + run-all.sh 路径同步；单测断言同步

## 验证（2026-08-20 22:30，裁剪后世界 2.1G/246,963 chunk）

- `./gradlew check` 全绿（spotless + 1317 单测 + 集成测试 + shadowJar）
- **双核心 E2E：Paper 62/62 + Folia 62/62 全绿**（01-06 全部用例）
- $b 备份：**1分51秒完成、zip 1.3G 落盘根目录 backup/、临时目录零残留**
- Folia（symlink 世界）walk 修复生效：246,963/246,963 chunk 全量备份
- 阈值保持原逻辑 300 秒不动；EasyBot 网关 502（磁盘爆满致 Docker 崩溃）恢复后 02 用例 10/10

## 说明

- 文档（验收报告 0.3.1 复验章节、features.md 备份位置说明）随 #214 docs PR
- 完整验收报告：`docs/e2e-test-report-20260820.md` §五.1