### PR TITLE
docs: CHANGELOG 1.0.19 + 陈旧文档清理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.0.19] - 2026-08-20
+
+### 🐛 修复
+- **BUG-E2E-004：symlink 世界备份空跑假完成（backup-core，OrzMCBackup #50/#51）** — Folia 等以符号链接挂载世界目录的场景下，`RealFileSystem.walk` 不跟随符号链接，`$b` 备份静默产出 22B 空 zip（无任何报错）——backup-core 修复（walk 跟随符号链接），双核心复验 246,963/246,963 区块全量备份 ✅
+- **备份失败静默化（0.3.x 适配）** — 备份完成但 zip 未落盘时明确报「地图备份失败」并跳过旧备份清理（防 prune 误删唯一可靠副本）；zip 落盘判定用 mtime（同名覆盖不误判）
+
+### ✨ 新功能
+- **备份目录迁移到服务器核心根目录** — `plugins/OrzMC/backup/` → `<worldContainer>/backup/`（快照/迁移整体打包）
+- **备份中间目录统一在 `backup/` 内处理** — backup-core 临时目录 = `backup/tempDir/`（Cleanup 阶段自动删除），zip 直接落 `backup/`；不再依赖系统临时目录
+- **启动清理** — 崩溃/断电残留的 `backup/tempDir` 启动时异步清理（MaintenanceModule.setup）
+- **备份/优化 input 改为世界目录** — `getWorldFolder()`（尊重 level-name，优先含 dimensions/region 的真实世界目录）——backup-core 0.3.x overlap 校验天然满足，避免误选非主世界漏备
+
+### 📦 依赖
+- backup-core 0.2.2 → **0.3.1**（symlink walk 修复 + 0.3.x API：IOOptions 三参 syncOnFinalize）
+
+### ⚠️ 升级注意
+- 备份目录位置变化：存量 zip 位于 `plugins/OrzMC/backup/` 的服务器，升级后请手动迁移到 `<worldContainer>/backup/`（或从新备份开始）
+- 备份为「优化式备份」（InhabitedTime 阈值 `maintenance.optimize_tick_time_threshold` 默认 300 秒过滤低活跃区块），如需逐字节全量请用外部快照/全量备份工具
+
+---
+
 ## [1.0.18] - 2026-08-19
 
 ### 🐛 修复

--- a/docs/e2e-test-report-20260820.md
+++ b/docs/e2e-test-report-20260820.md
@@ -14,8 +14,8 @@
 | 核心 | paper-26.2-112 | folia-26.2-4 |
 | 端口 / RCON | 25565 / 25575（两服统一） | 同左 |
 | 登录插件 | LoginSecurity | SimpleLogin |
-| 世界 | 共享物理地图（17G / 317 万 chunk），`folia-test/world` 为 symlink → `papermc-test/world` | 同左 |
-| 插件版本 | **OrzMC-1.0.19-dev.jar**（sha256 6eff9d51…，backup-core 0.2.2 原依赖） | 同左（功能用例）；walk 修复版 0.3.1-SNAPSHOT 用于备份修复验证 |
+| 世界 | 共享物理地图（已裁剪：17G/317 万 → 2.1G/24.7 万 chunk），`folia-test/world` 为 symlink → `papermc-test/world` | 同左 |
+| 插件版本 | **OrzMC-1.0.19-dev.jar**（sha256 94536e31…，backup-core 0.3.1） | 同左 |
 | CI 门禁 | `./gradlew check`（spotless + 1317 单测 + MockBukkit 集成测试 + shadowJar）全绿 | 同左 |
 
 > ⚠️ **两服共用世界、严禁同跑**（session.lock 互斥）：Paper 验收完成后停服 → 启 Folia → 验收 → 停 Folia → 恢复 Paper。全程无并发冲突。
@@ -81,13 +81,14 @@
 - **背景**：老板确定升级 0.3.1（PR #50 已合并发布）；测试服世界已裁剪（17G → 2.1G，磁盘 28Gi）
 - **插件适配**（最小集，阈值保持原逻辑 300 不动）：
   1. `IOOptions` 补第三参 `syncOnFinalize=true`（0.3.0+ API）
-  2. 备份临时目录移出 worldContainer（0.3.x overlap 校验：output 不得与 input 重叠）→ 系统临时目录
-  3. zip 完成后移回备份目录；临时目录一律清理（防残留被 walk 扫入备份源）
+  2. **input 改为世界目录**（`getWorldFolder()`，优先含 dimensions/region 的真实世界目录）——output=`backup/tempDir` 与世界目录成兄弟路径，天然通过 0.3.x overlap 校验（不再依赖系统临时目录）
+  3. **备份中间目录统一在 `backup/` 内处理**：tempDir 由 backup-core Cleanup 自动删除；zip 直接落 `backup/`（output 父目录）；启动清理兜底崩溃/断电残留（MaintenanceModule.setup 异步清理）
   4. **备份目录迁移：插件数据目录 `plugins/OrzMC/backup/` → 服务器核心根目录 `backup/`**（老板指示，便于快照/迁移整体打包）；E2E 04 用例 + run-all.sh 路径同步
 - **复验结果**（裁剪后世界 2.1G / 246,963 chunk）：
   - Paper：62/62 ✅（01:8 02:10 03:10 04:4 05:11 06:19）
   - Folia：62/62 ✅（02 的 /bot wsOk 正常）
-  - $b 备份：**1分51秒完成、zip 1.3G 落盘根目录 backup/、临时目录零残留**；Folia（symlink 世界）walk 修复生效（246,963/246,963 chunk 全量）
+  - $b 备份：**1分51秒完成、zip 1.3G 落盘根目录 backup/、tempDir 零残留**；Folia（symlink 世界）walk 修复生效（246,963/246,963 chunk 全量）
+  - **$o 优化验收：31 秒完成 190,526/190,526 区块，剔除 5.6 万低活跃区块（22.8%），世界正常加载**
   - EasyBot 网关恢复（之前磁盘爆满致 Docker 崩溃 → 502；重启 Docker 后 22:19 插件 ws 自动重连）——02 首跑失败（Paper 9/10）为环境问题，非回归
 
 ## 六、环境恢复状态

--- a/e2e/buglog.md
+++ b/e2e/buglog.md
@@ -64,7 +64,7 @@
 - **根因**：backup-core `RealFileSystem.walk` 用 `Files.walk(path)` **不跟随符号链接** → symlink 世界内部 `dimensions/<dim>/region/*.mca` 全部不可见 → 0 chunk 备份；`progressTotal = 0 + 0 + 2(zip 固定项)` → 假"2/2 完成"
 - **修复**：`Files.walk(path, FileVisitOption.FOLLOW_LINKS)`（backup-core PR #50 main 线 / #51 0.2.x 线）——插件零改动
 - **验证**：backup-core 新增 `RealFileSystemSymlinkTest`（链接目标内 region 可见性）+ 全量测试全绿；Folia 真实环境修复版 $b **3170460/3170460 chunk 全量完成（6分16秒，zip 1.42GB）**
-- **连带**：Folia 上 walk 跟随链接后，worldContainer 内历史残留的备份中间目录（旧布局 `plugins/OrzMC/backup/tempDir`）会被扫入备份源 → 需保持 worldContainer 内无备份残留（新布局输出在外部）
+- **连带**：Folia 上 walk 跟随链接后，worldContainer 内历史残留的备份中间目录（旧布局 `plugins/OrzMC/backup/tempDir`）会被扫入备份源 → 需保持世界目录内无备份残留（新布局：中间目录 `backup/tempDir` 在世界目录外——`backup/` 是世界目录的兄弟路径；崩溃/断电残留由插件启动清理兜底）
 
 ## E2E 套件双核心适配（PR #199，2026-08-19）
 


### PR DESCRIPTION
## 内容

- CHANGELOG.md 新增 [1.0.19]（2026-08-20）：BUG-E2E-004 symlink 备份修复、backup-core 0.3.1 升级、备份目录迁移/中间目录方案、启动清理、升级注意
- docs/e2e-test-report-20260820.md：适配方案更新为最终版（input=世界目录 + backup/tempDir + 启动清理）、版本表 0.3.1、世界已裁剪 2.1G、补充 $o 优化验收
- e2e/buglog.md：BUG-E2E-004 连带说明更新（新布局中间目录在 backup/ 内 + 启动清理）