### PR TITLE
fix(maintenance): 备份/优化 input 改回 worldContainer+level-name 世界根目录

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
@@ -317,11 +317,10 @@ public class WorldMaintenanceService {
         if (levelRoot.isDirectory()) {
             return levelRoot;
         }
-        File fallback = new File(container, "world");
-        if (fallback.isDirectory()) {
-            return fallback;
-        }
-        return container;
+        // level-name 目录缺失：回退默认 world/；仍不存在时交给 backup-core 明确报错——
+        // 不能回退 container 本身：backup/ 嵌套其内会触发 0.3.x 重叠校验拒绝，
+        // 或把 plugins/logs/历史 zip 全部扫入备份。
+        return new File(container, "world");
     }
 
     /** 读取 server.properties 的 level-name（尊重自定义世界目录名），缺失/解析失败回退默认 "world"。 */
@@ -332,14 +331,19 @@ public class WorldMaintenanceService {
                 java.util.Properties p = new java.util.Properties();
                 p.load(in);
                 String name = p.getProperty("level-name");
-                if (name != null && !name.isBlank()) {
+                if (name != null && !name.isBlank() && isValidLevelName(name)) {
                     return name.trim();
                 }
-            } catch (java.io.IOException ignored) {
-                // 解析失败回退默认值，备份不因此中断
+            } catch (Exception e) {
+                // 解析失败（含非法 Unicode 转义序列导致的 IllegalArgumentException）回退默认值，备份不因此中断
             }
         }
         return "world";
+    }
+
+    /** level-name 只允许目录名（Minecraft 本身不允许路径分隔符），拒绝越出容器/撞入备份目录。 */
+    private static boolean isValidLevelName(String name) {
+        return !name.contains("/") && !name.contains("\\") && !name.contains("..") && !name.equals(".");
     }
 
     /** backup/ 下最新 zip 的 mtime（无 zip 为 0）。备份成功判定：备份后出现 mtime 更新的 zip。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceService.java
@@ -304,30 +304,42 @@ public class WorldMaintenanceService {
                 null);
     }
 
-    /** 世界目录（尊重服务器 level-name 配置；极端情况下回退 worldContainer/world）。
-     *  优先选择含 dimensions/ 或 region/ 的真实世界目录（26.2 结构下各维度均在 world/ 内），
-     *  避免 getWorlds() 顺序把非主世界排前导致漏备。 */
+    /** 世界根目录（备份/优化 input）：以 worldContainer 为基准解析 level-name 世界目录
+     *  （server.properties 配置，默认 world/）。
+     *  ⚠️ 26.1+ 布局下 World#getWorldFolder()/getWorldPath() 返回的是维度数据目录
+     *  （world/dimensions/minecraft/overworld）而非世界根——直接用作 input 会漏备
+     *  level.dat/players/世界级 data/下界/末地（#215 回归）；改回 1.0.17 的
+     *  getWorldContainer 系 API 定位世界根。backup/ 与它是兄弟路径，
+     *  天然满足 backup-core 0.3.x 的 input/output 不重叠校验。 */
     private File worldFolder() {
-        java.util.List<org.bukkit.World> worlds = server.server().getWorlds();
-        if (worlds != null && !worlds.isEmpty()) {
-            for (org.bukkit.World w : worlds) {
-                File folder = w.getWorldFolder();
-                if (folder != null
-                        && folder.isDirectory()
-                        && (new File(folder, "dimensions").isDirectory() || new File(folder, "region").isDirectory())) {
-                    return folder;
-                }
-            }
-            File first = worlds.get(0).getWorldFolder();
-            if (first != null && first.isDirectory()) {
-                return first;
-            }
+        File container = server.server().getWorldContainer();
+        File levelRoot = new File(container, levelNameFromProperties(container));
+        if (levelRoot.isDirectory()) {
+            return levelRoot;
         }
-        File fallback = new File(server.server().getWorldContainer(), "world");
+        File fallback = new File(container, "world");
         if (fallback.isDirectory()) {
             return fallback;
         }
-        return server.server().getWorldContainer();
+        return container;
+    }
+
+    /** 读取 server.properties 的 level-name（尊重自定义世界目录名），缺失/解析失败回退默认 "world"。 */
+    private static String levelNameFromProperties(File container) {
+        File props = new File(container, "server.properties");
+        if (props.isFile()) {
+            try (java.io.InputStream in = new java.io.FileInputStream(props)) {
+                java.util.Properties p = new java.util.Properties();
+                p.load(in);
+                String name = p.getProperty("level-name");
+                if (name != null && !name.isBlank()) {
+                    return name.trim();
+                }
+            } catch (java.io.IOException ignored) {
+                // 解析失败回退默认值，备份不因此中断
+            }
+        }
+        return "world";
     }
 
     /** backup/ 下最新 zip 的 mtime（无 zip 为 0）。备份成功判定：备份后出现 mtime 更新的 zip。 */

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
@@ -251,13 +251,19 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
     public void backup_createsDirAndReportsProgress() {
         AtomicBoolean sawStartMsg = new AtomicBoolean(false);
         AtomicBoolean sawDirMsg = new AtomicBoolean(false);
+        AtomicBoolean inputIsWorldRoot = new AtomicBoolean(false);
         service.backup(300L, 5, msg -> {
-            if (msg.contains("服务器地图目录")) sawStartMsg.set(true);
+            if (msg.contains("服务器地图目录")) {
+                sawStartMsg.set(true);
+                // 世界根 = worldContainer/level-name（默认 world/），而非 26.1+ 的维度数据目录
+                inputIsWorldRoot.set(msg.contains(new File(worldDir, "world").getAbsolutePath()));
+            }
             if (msg.contains("地图备份目录")) sawDirMsg.set(true);
         });
 
         Assertions.assertTrue(sawStartMsg.get(), "应报告服务器地图目录");
         Assertions.assertTrue(sawDirMsg.get(), "应报告地图备份目录");
+        Assertions.assertTrue(inputIsWorldRoot.get(), "input 应为 worldContainer/level-name 世界根目录");
         Assertions.assertFalse(service.isRunning());
         // 备份目录应被创建（服务器核心根目录下，非插件数据目录）
         File backupDir = new File(worldDir, "backup");
@@ -265,6 +271,42 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         // 备份 zip 应落盘 backup/（0.3.x zipOutput 模式空世界也产出 22B 最小 zip，backup-core 直接写入 backup/）
         File[] zips = backupDir.listFiles(f -> f.isFile() && f.getName().endsWith(".zip"));
         Assertions.assertTrue(zips != null && zips.length >= 1, "备份 zip 应落盘 backup/ 目录");
+    }
+
+    @Test
+    public void backup_usesCustomLevelNameFromProperties() throws Exception {
+        // server.properties 自定义 level-name → 世界根取 worldContainer/custom_world
+        File customWorld = new File(worldDir, "custom_world");
+        customWorld.mkdirs();
+        File props = new File(worldDir, "server.properties");
+        try (FileOutputStream fos = new FileOutputStream(props)) {
+            fos.write("level-name=custom_world\n".getBytes());
+        }
+        AtomicBoolean inputIsCustom = new AtomicBoolean(false);
+        service.backup(300L, 5, msg -> {
+            if (msg.contains("服务器地图目录")) {
+                inputIsCustom.set(msg.contains(customWorld.getAbsolutePath()));
+            }
+        });
+        Assertions.assertTrue(inputIsCustom.get(), "自定义 level-name 时 input 应为 worldContainer/custom_world");
+    }
+
+    @Test
+    public void backup_fallsBackToDefaultWorldWhenLevelRootMissing() {
+        // level-name 目录不存在（如 server.properties 指向未生成的目录）→ 回退 worldContainer/world
+        File props = new File(worldDir, "server.properties");
+        try (FileOutputStream fos = new FileOutputStream(props)) {
+            fos.write("level-name=ghost_world\n".getBytes());
+        } catch (java.io.IOException e) {
+            throw new RuntimeException(e);
+        }
+        AtomicBoolean inputIsFallback = new AtomicBoolean(false);
+        service.backup(300L, 5, msg -> {
+            if (msg.contains("服务器地图目录")) {
+                inputIsFallback.set(msg.contains(new File(worldDir, "world").getAbsolutePath()));
+            }
+        });
+        Assertions.assertTrue(inputIsFallback.get(), "level-name 目录缺失应回退 worldContainer/world");
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/maintenance/WorldMaintenanceServiceTest.java
@@ -81,7 +81,13 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
         org.bukkit.World worldMock = mock(org.bukkit.World.class);
         File worldFolder = new File(worldDir, "world");
         worldFolder.mkdirs();
-        when(worldMock.getWorldFolder()).thenReturn(worldFolder);
+        // 26.1+ 布局下 getWorldFolder()/getWorldPath() 返回维度数据目录（非世界根）——
+        // #215 回归正是被它误导；mock 保持该形状以守住回归防护（旧实现会因此把
+        // input 选成维度目录，本修复后仍返回世界根）
+        File dimensionFolder = new File(worldFolder, "dimensions/minecraft/overworld");
+        dimensionFolder.mkdirs();
+        when(worldMock.getWorldFolder()).thenReturn(dimensionFolder);
+        when(worldMock.getWorldPath()).thenReturn(dimensionFolder.toPath());
         when(bukkitServer.getWorlds()).thenReturn(List.of(worldMock));
 
         service = new WorldMaintenanceService(server, configs, mock(OrzTextStyles.class), mock(Notifier.class));
@@ -256,7 +262,8 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
             if (msg.contains("服务器地图目录")) {
                 sawStartMsg.set(true);
                 // 世界根 = worldContainer/level-name（默认 world/），而非 26.1+ 的维度数据目录
-                inputIsWorldRoot.set(msg.contains(new File(worldDir, "world").getAbsolutePath()));
+                inputIsWorldRoot.set(
+                        msg.contains(new File(worldDir, "world").getAbsolutePath()) && !msg.contains("dimensions"));
             }
             if (msg.contains("地图备份目录")) sawDirMsg.set(true);
         });
@@ -292,13 +299,11 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
     }
 
     @Test
-    public void backup_fallsBackToDefaultWorldWhenLevelRootMissing() {
+    public void backup_fallsBackToDefaultWorldWhenLevelRootMissing() throws Exception {
         // level-name 目录不存在（如 server.properties 指向未生成的目录）→ 回退 worldContainer/world
         File props = new File(worldDir, "server.properties");
         try (FileOutputStream fos = new FileOutputStream(props)) {
             fos.write("level-name=ghost_world\n".getBytes());
-        } catch (java.io.IOException e) {
-            throw new RuntimeException(e);
         }
         AtomicBoolean inputIsFallback = new AtomicBoolean(false);
         service.backup(300L, 5, msg -> {
@@ -307,6 +312,79 @@ public class WorldMaintenanceServiceTest extends ServiceTestBase {
             }
         });
         Assertions.assertTrue(inputIsFallback.get(), "level-name 目录缺失应回退 worldContainer/world");
+    }
+
+    @Test
+    public void backup_fallsBackOnCorruptProperties() throws Exception {
+        // 非法 Unicode 转义序列 → Properties.load 抛 IllegalArgumentException → 回退默认 world
+        File props = new File(worldDir, "server.properties");
+        String backslash = "\\";
+        try (FileOutputStream fos = new FileOutputStream(props)) {
+            fos.write(("level-name=" + backslash + "uZZZZ\n").getBytes());
+        }
+        AtomicBoolean inputIsWorld = new AtomicBoolean(false);
+        service.backup(300L, 5, msg -> {
+            if (msg.contains("服务器地图目录")) {
+                inputIsWorld.set(msg.contains(new File(worldDir, "world").getAbsolutePath()));
+            }
+        });
+        Assertions.assertTrue(inputIsWorld.get(), "损坏 server.properties 应回退默认 world");
+    }
+
+    @Test
+    public void backup_blankLevelNameFallsBackToDefault() throws Exception {
+        // level-name 空白值 → 回退默认 world
+        File props = new File(worldDir, "server.properties");
+        try (FileOutputStream fos = new FileOutputStream(props)) {
+            fos.write("level-name=   \n".getBytes());
+        }
+        AtomicBoolean inputIsWorld = new AtomicBoolean(false);
+        service.backup(300L, 5, msg -> {
+            if (msg.contains("服务器地图目录")) {
+                inputIsWorld.set(msg.contains(new File(worldDir, "world").getAbsolutePath()));
+            }
+        });
+        Assertions.assertTrue(inputIsWorld.get(), "空白 level-name 应回退默认 world");
+    }
+
+    @Test
+    public void backup_rejectsPathTraversalLevelName() throws Exception {
+        // level-name 含路径分隔符 → 视为非法回退默认 world（防越出容器/撞入备份目录）
+        File props = new File(worldDir, "server.properties");
+        try (FileOutputStream fos = new FileOutputStream(props)) {
+            fos.write("level-name=../evil\n".getBytes());
+        }
+        AtomicBoolean inputIsWorld = new AtomicBoolean(false);
+        service.backup(300L, 5, msg -> {
+            if (msg.contains("服务器地图目录")) {
+                inputIsWorld.set(msg.contains(new File(worldDir, "world").getAbsolutePath()));
+            }
+        });
+        Assertions.assertTrue(inputIsWorld.get(), "含路径分隔符的 level-name 应拒绝并回退默认 world");
+    }
+
+    @Test
+    public void backup_reportsFailureWhenNoWorldRootExists() throws Exception {
+        // level-name 与默认 world/ 目录都不存在：不应回退到 worldContainer（会撞 0.3.x
+        // 重叠校验/把整个服务器目录扫入备份），而是交给 backup-core 明确报备份失败
+        try (var stream = Files.walk(new File(worldDir, "world").toPath())) {
+            stream.sorted(java.util.Comparator.reverseOrder())
+                    .forEach(p -> p.toFile().delete());
+        }
+        File props = new File(worldDir, "server.properties");
+        try (FileOutputStream fos = new FileOutputStream(props)) {
+            fos.write("level-name=ghost_world\n".getBytes());
+        }
+        AtomicBoolean sawFail = new AtomicBoolean(false);
+        AtomicBoolean inputIsContainer = new AtomicBoolean(false);
+        service.backup(300L, 5, msg -> {
+            if (msg.contains("服务器地图目录")) {
+                inputIsContainer.set(!msg.trim().endsWith("/world"));
+            }
+            if (msg.contains("备份失败")) sawFail.set(true);
+        });
+        Assertions.assertTrue(sawFail.get(), "无世界根时应明确报备份失败");
+        Assertions.assertFalse(inputIsContainer.get(), "不应把 worldContainer 本身当作 input");
     }
 
     @Test


### PR DESCRIPTION
## 背景

26.1+ 布局下 `World#getWorldFolder()`（默认方法 → `getWorldPath()` → `getDimensionPath()`）返回**维度数据目录**（`world/dimensions/minecraft/overworld`）而非世界根。字节码级验证（Paper 26.2-112 / Folia 26.2-4 一致）：

- `World.getWorldFolder()` = `getWorldPath().toFile()`（paper-api 26.2 默认方法）
- `CraftWorld.getWorldPath()` = `storageSource.getDimensionPath(dimension)`
- `DimensionType.getStorageFolder()` = `identifier.resolveAgainst(path.resolve("dimensions"))`（26.1+ 已删 overworld 特例）

#215 引入的 `worldFolder()` 用「含 dimensions/ 或 region/」判定选目录，维度目录含 region/ 误判通过 → input 变成 `world/dimensions/minecraft/overworld`，备份**只含主世界维度数据**，漏备 level.dat / players/ / 世界级 data/ / 下界 / 末地。

## 修复

`worldFolder()` 改以 `worldContainer` 为基准解析 `level-name` 世界目录（server.properties 配置，默认 world/），回退 `worldContainer/world` → `worldContainer`。backup/ 与世界根是兄弟路径，满足 backup-core 0.3.x 的 input/output 不重叠校验（1.0.17 直接传 worldContainer 会触发 OverlapGuard，故不能原样复刻）。

## 验证

- 单测：新增 level-name 自定义 / 目录缺失回退 / input 路径断言（默认 world 根）
- `./gradlew check` 全绿（spotless + test + integrationTest + shadowJar + 覆盖率）
- **Paper 26.2-112 真机**：`服务器地图目录：./world` ✓ zip 含 level.dat + players/(data/stats/advancements) + 三维度 region，无 world/ 前缀
- **Folia 26.2-4 真机**：`服务器地图目录：./world` ✓ zip 内容与 Paper 一致（10533 文件，三维度齐全）