### PR TITLE
feat(rank): 权限等级玩家名颜色显示（头顶/聊天/Tab + OP 专属色 + EssentialsX 兼容）

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -95,6 +95,10 @@ public final class FeatureModule implements ServiceModule {
     private final com.jokerhub.paper.plugin.orzmc.features.rank.RankCommandService rankCommandService;
     private final com.jokerhub.paper.plugin.orzmc.features.review.ReviewService reviewService;
     private final com.jokerhub.paper.plugin.orzmc.features.review.ReviewCommandService reviewCommandService;
+    /** 玩家名颜色服务（按权限等级：头顶/聊天/Tab 三处着色）。 */
+    private final com.jokerhub.paper.plugin.orzmc.features.rank.PlayerRankDisplayService rankDisplayService;
+    /** 等级变更 → 颜色实时刷新桥（LP 启用时非 null，软依赖条件实例化）。 */
+    private final com.jokerhub.paper.plugin.orzmc.features.rank.RankDisplayLpBridge rankDisplayLpBridge;
 
     // 模块引用（供事件/命令注册使用）
     private final PlatformModule platform;
@@ -197,6 +201,17 @@ public final class FeatureModule implements ServiceModule {
                 rankService, reviewService, platform.textStyles());
         this.reviewCommandService = new com.jokerhub.paper.plugin.orzmc.features.review.ReviewCommandService(
                 reviewService, platform.textStyles());
+        // 玩家名颜色（按权限等级）：rankService 创建后装配；LP 启用时桥接等级变更实时刷新。
+        // 三元短路：仅 LP 启用时才求值 LuckPermsProvider.get()，LP 缺失时 rankDisplayLpBridge 为 null
+        this.rankDisplayService = new com.jokerhub.paper.plugin.orzmc.features.rank.PlayerRankDisplayService(
+                platform.serverFacade(), rankService, () -> platform.configs().rankColors());
+        this.rankDisplayLpBridge = rankPromoter.isAvailable()
+                ? new com.jokerhub.paper.plugin.orzmc.features.rank.RankDisplayLpBridge(
+                        platform.serverFacade().plugin(),
+                        platform.serverFacade(),
+                        net.luckperms.api.LuckPermsProvider.get(),
+                        rankDisplayService)
+                : null;
 
         // 保留模块引用（供事件/命令注册使用）
         this.platform = platform;
@@ -270,9 +285,12 @@ public final class FeatureModule implements ServiceModule {
             new OrzWhiteListEvent(plugin, whitelistEventService),
             new OrzDebugEvent(plugin, botModule.botInboundHandler()),
             new OrzPortalEvent(plugin, portalEventService),
-            new com.jokerhub.paper.plugin.orzmc.events.OrzRankEvent(plugin, rankService)
+            new com.jokerhub.paper.plugin.orzmc.events.OrzRankEvent(plugin, rankService),
+            new com.jokerhub.paper.plugin.orzmc.events.OrzRankDisplayEvent(plugin, rankDisplayService)
         };
         EventBinder.bind(plugin, Arrays.asList(eventListeners));
+        // 周期自愈：约 60s 重刷一次在线玩家颜色（兜底 Paper 头顶名刷新遗漏 + /config reload 热生效）
+        rankDisplayService.startPeriodicRefresh();
     }
 
     // --- Command Registration ---
@@ -311,6 +329,11 @@ public final class FeatureModule implements ServiceModule {
 
     public com.jokerhub.paper.plugin.orzmc.features.rank.RankService rankService() {
         return rankService;
+    }
+
+    /** 玩家名颜色服务（按权限等级三处着色，跨模块引用用）。 */
+    public com.jokerhub.paper.plugin.orzmc.features.rank.PlayerRankDisplayService rankDisplayService() {
+        return rankDisplayService;
     }
 
     /** 在线列表格式化器（单一事实源，$l/$w 命令与上下线广播共享）。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/core/ports/config/TypedConfigProvider.java
@@ -8,6 +8,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.RankColorsConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.SecurityGuardConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.Templates;
@@ -43,6 +44,9 @@ public interface TypedConfigProvider {
 
     /** 已知漏洞加固（P2-3）配置。 */
     ExploitHardeningConfig exploitHardening();
+
+    /** 玩家名颜色（按权限等级）配置。 */
+    RankColorsConfig rankColors();
 
     MessageEnvelope renderEvent(String eventKey, Map<String, String> vars);
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzRankDisplayEvent.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/events/OrzRankDisplayEvent.java
@@ -1,0 +1,68 @@
+package com.jokerhub.paper.plugin.orzmc.events;
+
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.features.rank.PlayerRankDisplayService;
+import io.papermc.paper.chat.ChatRenderer;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+/**
+ * 玩家名颜色显示监听器（按权限等级，三处统一着色）。
+ *
+ * <ul>
+ *   <li>聊天：{@link AsyncChatEvent} 用 {@link ChatRenderer#viewerUnaware} 给玩家名着色。
+ *       名字取 displayName 纯文本（保留 EssentialsX {@code /nick} 等昵称）再强制 rank 色。
+ *       <b>让位语义</b>：在 {@link EventPriority#LOWEST} 设渲染器，若存在聊天格式化插件
+ *       （如 EssentialsChat）会在更高优先级覆盖本渲染器 → 聊天格式归对方，rank 色体现在
+ *       Tab + 头顶名牌；无则本渲染器保留 → 聊天着色。</li>
+ *   <li>上线：调度线程应用头顶队伍 + Tab 名；再延迟 1 tick 兜底 LP 在线缓存未就绪</li>
+ *   <li>下线：调度线程清理 orzmc-* 队伍成员</li>
+ * </ul>
+ */
+public final class OrzRankDisplayEvent extends OrzBaseListener {
+
+    private final PlayerRankDisplayService service;
+
+    public OrzRankDisplayEvent(OrzMC plugin, PlayerRankDisplayService service) {
+        super(plugin);
+        this.service = service;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onAsyncChat(AsyncChatEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        NamedTextColor color = service.colorFor(event.getPlayer());
+        if (color == null) {
+            return;
+        }
+        // 镜像默认渲染器（chat.type.text），仅把玩家名改成等级色。
+        // 名字用 displayName 纯文本：保留昵称（EssentialsX /nick），强制统一 rank 色（纯色不加前缀）。
+        // LOWEST 设渲染器：聊天格式化插件（如 EssentialsChat）在更高优先级覆盖即让位；
+        // 不用「renderer != defaultRenderer」检测——Paper 的 defaultRenderer() 每次新建实例，身份比较不可靠。
+        event.renderer(ChatRenderer.viewerUnaware((viewer, displayName, message) -> Component.translatable(
+                "chat.type.text",
+                Component.text(PlainTextComponentSerializer.plainText().serialize(displayName))
+                        .color(color),
+                message)));
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        serverFacade().runSync(() -> service.applyTo(event.getPlayer()));
+        // 兜底：上线瞬间 LP 在线缓存可能未就绪（currentGroup 落到 default），1 秒后再刷一次
+        serverFacade().runLater(() -> service.applyTo(event.getPlayer()), 20L);
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        serverFacade().runSync(() -> service.removeFor(event.getPlayer()));
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
@@ -1,0 +1,202 @@
+package com.jokerhub.paper.plugin.orzmc.features.rank;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.RankColorsConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
+
+/**
+ * 玩家名颜色服务（按权限等级，三处统一着色）。
+ *
+ * <p>权限等级来自现有 LuckPerms track（default→member→builder→admin，{@link RankService}），
+ * 在三个界面按等级给玩家名着色：头顶名牌（计分板队伍颜色）、聊天消息、Tab 列表。
+ * 纯颜色区分，不加前缀文字。聊天/Tab 的名字用 {@code displayName} 纯文本（保留
+ * EssentialsX {@code /nick} 等昵称）强制 rank 色；头顶名牌受计分板 team entry 限制
+ * 只能用真实名着色（与 vanilla+EssentialsX 自身行为一致）。</p>
+ *
+ * <p>OP 与四级权限是独立体系：{@code player.isOp()} 优先显示 {@code op_color}，与等级组无关。</p>
+ *
+ * <p><b>冲突感知（只动自家队伍）</b>：只创建/管理 {@code orzmc-*} 队伍，绝不删改外部队伍；
+ * 若某玩家的 entry 已被非 orzmc 队伍占用（其它插件接管名牌），主动让位跳过头顶着色，
+ * 聊天+Tab 照常；全程不触碰任何队伍的 prefix/suffix 字段。</p>
+ *
+ * <p><b>线程模型</b>：{@link #applyTo} / {@link #removeFor} / {@link #refreshAllOnline} 必须在
+ * 调度线程执行（调用方一律经 {@code ServerFacade.runSync} 或周期定时器）；
+ * 聊天着色由监听器在异步聊天线程只读 {@link RankService#currentGroup}（LP 在线缓存，零阻塞）。</p>
+ */
+public final class PlayerRankDisplayService {
+
+    private static final Logger LOGGER = Logger.getLogger("OrzMC.PlayerRankDisplay");
+
+    /** 本服务独占的队伍名前缀（orzmc-op / orzmc-<group>，最长为 orzmc-builder 13 字符，≤16 协议上限）。 */
+    private static final String TEAM_PREFIX = "orzmc-";
+
+    private static final long PERIODIC_REFRESH_DELAY_TICKS = 100;
+    private static final long PERIODIC_REFRESH_PERIOD_TICKS = 1200;
+
+    private final ServerFacade serverFacade;
+    private final RankService rankService;
+    private final Supplier<RankColorsConfig> configSupplier;
+
+    public PlayerRankDisplayService(
+            ServerFacade serverFacade, RankService rankService, Supplier<RankColorsConfig> configSupplier) {
+        this.serverFacade = serverFacade;
+        this.rankService = rankService;
+        this.configSupplier = configSupplier;
+    }
+
+    /** 当前玩家显示色：feature 关闭返回 null（聊天监听据此跳过）；OP 优先。 */
+    public NamedTextColor colorFor(Player player) {
+        RankColorsConfig config = configSupplier.get();
+        if (!config.enabled()) {
+            return null;
+        }
+        if (player.isOp()) {
+            return config.opColor();
+        }
+        return colorFor(config, rankService.currentGroup(player.getUniqueId()));
+    }
+
+    /** 等级组 → 颜色；未知组回退 GRAY（对应访客）。 */
+    private static NamedTextColor colorFor(RankColorsConfig config, String group) {
+        return config.colors().getOrDefault(group, NamedTextColor.GRAY);
+    }
+
+    /** 当前权限组（委托 {@link RankService}，永不 null）。 */
+    public String currentGroupOf(UUID playerId) {
+        return rankService.currentGroup(playerId);
+    }
+
+    /**
+     * 重设某在线玩家的头顶名牌队伍 + Tab 名（幂等）。必须在调度线程调用。
+     *
+     * <p>关闭 {@code enabled}/{@code nametag_enabled} 时清理队伍并还原纯名 Tab。</p>
+     */
+    public void applyTo(Player player) {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+        RankColorsConfig config = configSupplier.get();
+        if (!config.enabled()) {
+            removeFor(player);
+            player.playerListName(Component.text(player.getName()));
+            return;
+        }
+        boolean op = player.isOp();
+        // OP 时等级组不参与颜色与队伍命名，跳过 LP 查询（微优化）
+        String group = op ? null : currentGroupOf(player.getUniqueId());
+        NamedTextColor color = op ? config.opColor() : colorFor(config, group);
+        if (!config.nametagEnabled()) {
+            // 只关头顶名牌：聊天+Tab 仍着色（避让占用计分板队伍的插件时用）
+            removeFor(player);
+            player.playerListName(coloredTabName(player, color));
+            return;
+        }
+        Scoreboard board = mainScoreboard();
+        if (board == null) {
+            return;
+        }
+        String entry = player.getName();
+        // 队伍按「显示层级」命名：OP 归 orzmc-op，非 OP 归 orzmc-<组>——避免 OP 与同组非 OP
+        // 共享同一队伍（队伍颜色全队一致）导致普通玩家被 OP 金色串色
+        String displayKey = op ? "op" : group;
+        // 冲突感知：entry 已被非 orzmc-* 队伍占用（其它插件接管名牌）→ 让位，只做 Tab 着色
+        Team existing = board.getEntryTeam(entry);
+        if (existing != null && !existing.getName().startsWith(TEAM_PREFIX)) {
+            LOGGER.fine("玩家 " + entry + " 头顶队伍已被其它插件接管(" + existing.getName() + ")，让位跳过头顶着色");
+            player.playerListName(coloredTabName(player, color));
+            return;
+        }
+        if (existing != null) {
+            existing.removeEntry(entry);
+        }
+        Team team = ensureTeam(board, displayKey, color);
+        // 强制刷新：removeEntry+addEntry 重发队伍包，让客户端重绘头顶名（规避 Paper 已知刷新遗漏）
+        team.removeEntry(entry);
+        team.addEntry(entry);
+        player.playerListName(coloredTabName(player, color));
+    }
+
+    /** 从 orzmc-* 队伍移除玩家 entry（退出/禁用时）。必须在调度线程调用。 */
+    public void removeFor(Player player) {
+        if (player == null) {
+            return;
+        }
+        Scoreboard board = mainScoreboard();
+        if (board == null) {
+            return;
+        }
+        Team team = board.getEntryTeam(player.getName());
+        if (team != null && team.getName().startsWith(TEAM_PREFIX)) {
+            team.removeEntry(player.getName());
+        }
+    }
+
+    /** 按 UUID 刷新在线玩家显示（LP 等级变更实时刷新用）。 */
+    public void refresh(UUID playerId) {
+        if (playerId == null) {
+            return;
+        }
+        Player player = Bukkit.getPlayer(playerId);
+        if (player != null && player.isOnline()) {
+            applyTo(player);
+        }
+    }
+
+    /** 重刷所有在线玩家（自愈 + /config reload 热生效）。 */
+    public void refreshAllOnline() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            try {
+                applyTo(player);
+            } catch (RuntimeException e) {
+                LOGGER.log(Level.WARNING, "刷新玩家名颜色失败: " + player.getName(), e);
+            }
+        }
+    }
+
+    /** 周期自愈：延迟 100 tick 后每 1200 tick（≈60s）重刷一次。 */
+    public void startPeriodicRefresh() {
+        serverFacade.runTaskTimer(this::refreshAllOnline, PERIODIC_REFRESH_DELAY_TICKS, PERIODIC_REFRESH_PERIOD_TICKS);
+    }
+
+    /** Tab 名组件：displayName 纯文本（保留 EssentialsX /nick 昵称）强制 rank 色。 */
+    private static Component coloredTabName(Player player, NamedTextColor color) {
+        return Component.text(displayNameText(player)).color(color);
+    }
+
+    /** displayName 纯文本；为 null/空则回退真实名（Paper 默认 displayName 即真实名）。 */
+    private static String displayNameText(Player player) {
+        Component displayName = player.displayName();
+        if (displayName == null) {
+            return player.getName();
+        }
+        String text = PlainTextComponentSerializer.plainText().serialize(displayName);
+        return text.isBlank() ? player.getName() : text;
+    }
+
+    /** 主计分板（null 守卫：测试环境可能无 ScoreboardManager）。 */
+    private static Scoreboard mainScoreboard() {
+        var manager = Bukkit.getScoreboardManager();
+        return manager == null ? null : manager.getMainScoreboard();
+    }
+
+    /** 取或建 orzmc-<displayKey> 队伍，并（总是）重设队伍颜色以热生效配置变更。 */
+    private Team ensureTeam(Scoreboard board, String displayKey, NamedTextColor color) {
+        String teamName = TEAM_PREFIX + displayKey;
+        Team team = board.getTeam(teamName);
+        if (team == null) {
+            team = board.registerNewTeam(teamName);
+        }
+        team.color(color);
+        return team;
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
@@ -79,7 +79,8 @@ public final class PlayerRankDisplayService {
     /**
      * 重设某在线玩家的头顶名牌队伍 + Tab 名（幂等）。必须在调度线程调用。
      *
-     * <p>关闭 {@code enabled}/{@code nametag_enabled} 时清理队伍并还原纯名 Tab。</p>
+     * <p>关闭 {@code enabled}/{@code nametag_enabled} 时清理队伍并还原 Tab 名
+     * （还原为 displayName 纯文本，保留 EssentialsX 昵称）。</p>
      */
     public void applyTo(Player player) {
         if (player == null || !player.isOnline()) {
@@ -88,7 +89,8 @@ public final class PlayerRankDisplayService {
         RankColorsConfig config = configSupplier.get();
         if (!config.enabled()) {
             removeFor(player);
-            player.playerListName(Component.text(player.getName()));
+            // 还原用 displayName 文本而非真实名：避免丢掉 EssentialsX /nick 昵称
+            player.playerListName(Component.text(displayNameText(player)));
             return;
         }
         boolean op = player.isOp();
@@ -120,6 +122,11 @@ public final class PlayerRankDisplayService {
             existing.removeEntry(entry);
         }
         Team team = ensureTeam(board, displayKey, color);
+        if (team == null) {
+            // 队伍名超协议上限（自定义超长 track 组名）→ 跳过头顶着色，Tab 仍着色
+            player.playerListName(coloredTabName(player, color));
+            return;
+        }
         // 强制刷新：removeEntry+addEntry 重发队伍包，让客户端重绘头顶名（规避 Paper 已知刷新遗漏）
         team.removeEntry(entry);
         team.addEntry(entry);
@@ -189,9 +196,18 @@ public final class PlayerRankDisplayService {
         return manager == null ? null : manager.getMainScoreboard();
     }
 
-    /** 取或建 orzmc-<displayKey> 队伍，并（总是）重设队伍颜色以热生效配置变更。 */
+    /**
+     * 取或建 orzmc-<displayKey> 队伍，并（总是）重设队伍颜色以热生效配置变更。
+     *
+     * <p>队伍名超协议上限（{@code orzmc-} + 自定义超长 track 组名 &gt; 16）时返回 null——
+     * 调用方降级为「跳过头顶着色、只 Tab 着色」，避免 registerNewTeam 在调度线程抛异常。</p>
+     */
     private Team ensureTeam(Scoreboard board, String displayKey, NamedTextColor color) {
         String teamName = TEAM_PREFIX + displayKey;
+        if (teamName.length() > 16) {
+            LOGGER.fine("队伍名超长(" + teamName + ")，跳过头顶着色，仅 Tab/聊天着色");
+            return null;
+        }
         Team team = board.getTeam(teamName);
         if (team == null) {
             team = board.registerNewTeam(teamName);

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/RankDisplayLpBridge.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/RankDisplayLpBridge.java
@@ -1,0 +1,43 @@
+package com.jokerhub.paper.plugin.orzmc.features.rank;
+
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.event.EventSubscription;
+import net.luckperms.api.event.user.track.UserTrackEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * 等级变更 → 玩家名颜色实时刷新桥（LP 专属，软依赖条件实例化）。
+ *
+ * <p>订阅 LuckPerms {@link UserTrackEvent}（track promote/demote 触发，含插件内
+ * {@code $p}/{@code /apply}/{@code /review} 与控制台手动 {@code lp user X promote rank}），
+ * 等级变更即在调度线程刷新在线玩家三处颜色。</p>
+ *
+ * <p><b>软依赖加载约束</b>：本类直接引用 {@code net.luckperms.api} 类型，仅在 LP 已启用时由
+ * 装配层实例化（同 {@link LuckPermsPromoter} 模式）——LP 缺失时本类不会被加载，
+ * 不会触发 NoClassDefFoundError。订阅传 {@code plugin}，LP 在插件禁用时自动注销。</p>
+ */
+public final class RankDisplayLpBridge {
+
+    private static final Logger LOGGER = Logger.getLogger("OrzMC.RankDisplayLP");
+
+    /** 持有订阅引用作生命周期锚点（LP 因传入 plugin 亦会在插件禁用时自动关闭）。 */
+    private final EventSubscription<UserTrackEvent> subscription;
+
+    public RankDisplayLpBridge(
+            JavaPlugin plugin, ServerFacade serverFacade, LuckPerms api, PlayerRankDisplayService displayService) {
+        this.subscription = api.getEventBus().subscribe(plugin, UserTrackEvent.class, event -> {
+            // LP 事件可发自异步线程；计分板/Tab 变更必须回到调度线程执行
+            serverFacade.runSync(() -> {
+                try {
+                    displayService.refresh(event.getUser().getUniqueId());
+                } catch (RuntimeException e) {
+                    LOGGER.log(
+                            Level.WARNING, "等级变更刷新玩家名颜色失败: " + event.getUser().getUniqueId(), e);
+                }
+            });
+        });
+    }
+}

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPath.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPath.java
@@ -87,6 +87,14 @@ public final class ConfigPath {
         reg(map, "templates", "templates.coord.scale", Double.class, 1.0, "坐标缩放比例");
         reg(map, "templates", "templates.coord.precision", Integer.class, 2, "坐标小数位数");
         reg(map, "templates", "templates.coord.unit_label", String.class, "block", "坐标单位标签");
+        // rank_colors (config.yml)
+        reg(map, "config", "rank_colors.enabled", Boolean.class, true, "玩家名颜色总开关");
+        reg(map, "config", "rank_colors.nametag_enabled", Boolean.class, true, "头顶名牌着色开关");
+        reg(map, "config", "rank_colors.op_color", String.class, "gold", "OP 玩家名颜色(命名色)");
+        reg(map, "config", "rank_colors.colors.admin", String.class, "red", "管理员名颜色(命名色)");
+        reg(map, "config", "rank_colors.colors.builder", String.class, "green", "建造者名颜色(命名色)");
+        reg(map, "config", "rank_colors.colors.member", String.class, "aqua", "成员名颜色(命名色)");
+        reg(map, "config", "rank_colors.colors.default", String.class, "gray", "访客名颜色(命名色)");
         return Collections.unmodifiableMap(map);
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigService.java
@@ -38,6 +38,15 @@ public final class ConfigService {
         configManager.checkAndUpdateConfigVersion("config", 2.0);
         configManager.checkAndUpdateConfigVersion("templates", 2.0);
 
+        // 玩家名颜色（按权限等级）：仅缺失键写入默认值，不覆盖管理员修改（幂等）
+        configManager.getOrSetDefault("config", "rank_colors.enabled", true);
+        configManager.getOrSetDefault("config", "rank_colors.nametag_enabled", true);
+        configManager.getOrSetDefault("config", "rank_colors.op_color", "gold");
+        configManager.getOrSetDefault("config", "rank_colors.colors.admin", "red");
+        configManager.getOrSetDefault("config", "rank_colors.colors.builder", "green");
+        configManager.getOrSetDefault("config", "rank_colors.colors.member", "aqua");
+        configManager.getOrSetDefault("config", "rank_colors.colors.default", "gray");
+
         List<String> issues = ConfigHealthCheck.validateAll(configManager);
         if (!issues.isEmpty()) {
             plugin.getLogger().warning("配置健康检查发现问题:");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProvider.java
@@ -9,6 +9,7 @@ import com.jokerhub.paper.plugin.orzmc.infra.config.configs.IpWhitelist;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.LoginRateLimitConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.MaintenanceConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.PlayerNotifyConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.RankColorsConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.SecurityGuardConfig;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.TemplateOptions;
 import com.jokerhub.paper.plugin.orzmc.infra.config.configs.Templates;
@@ -101,6 +102,12 @@ public final class DefaultTypedConfigProvider implements TypedConfigProvider {
     public ExploitHardeningConfig exploitHardening() {
         ConfigurationSection section = sectionOrLegacy("config", "exploit_hardening", "exploit_hardening.yml");
         return ExploitHardeningConfig.from(section);
+    }
+
+    @Override
+    public RankColorsConfig rankColors() {
+        ConfigurationSection section = sectionOrLegacy("config", "rank_colors", "rank_colors.yml");
+        return RankColorsConfig.from(section);
     }
 
     @Override

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/RankColorsConfig.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/RankColorsConfig.java
@@ -1,0 +1,73 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextColor;
+import org.bukkit.configuration.ConfigurationSection;
+
+/**
+ * 玩家名颜色（按权限等级）配置。
+ *
+ * <p>对应 config.yml 的 {@code rank_colors:} 段：是否启用、是否启用头顶名牌着色、
+ * OP 专用色（OP 与四级权限独立，isOp 优先），以及四级权限组 → 命名色映射。</p>
+ *
+ * <p>计分板队伍颜色协议只支持 16 个命名色（NamedTextColor，无任意 hex 重载）：
+ * 为让头顶名牌/聊天/Tab 三处颜色完全一致，配置统一用命名色；也兼容
+ * {@code #RRGGBB}，自动吸附到最近的命名色。解析失败的键保留默认值。</p>
+ */
+public record RankColorsConfig(
+        boolean enabled, boolean nametagEnabled, NamedTextColor opColor, Map<String, NamedTextColor> colors) {
+
+    /** 默认 OP 色（金色）。 */
+    public static final NamedTextColor DEFAULT_OP_COLOR = NamedTextColor.GOLD;
+
+    /** 四级权限组默认颜色映射（default→member→builder→admin）。 */
+    public static final Map<String, NamedTextColor> DEFAULTS = Map.of(
+            "default", NamedTextColor.GRAY,
+            "member", NamedTextColor.AQUA,
+            "builder", NamedTextColor.GREEN,
+            "admin", NamedTextColor.RED);
+
+    public static RankColorsConfig from(ConfigurationSection cfg) {
+        if (cfg == null) {
+            return new RankColorsConfig(true, true, DEFAULT_OP_COLOR, DEFAULTS);
+        }
+        Map<String, NamedTextColor> colors = new HashMap<>();
+        ConfigurationSection colorsSection = cfg.getConfigurationSection("colors");
+        if (colorsSection != null) {
+            DEFAULTS.forEach((key, defaultValue) -> {
+                NamedTextColor parsed = parseColor(colorsSection.getString(key));
+                if (parsed != null) {
+                    colors.put(key, parsed);
+                }
+            });
+        }
+        // 未配置/解析失败的键补齐默认，保证四组都有色
+        DEFAULTS.forEach((key, defaultValue) -> colors.putIfAbsent(key, defaultValue));
+        NamedTextColor opColor = parseColor(cfg.getString("op_color"));
+        return new RankColorsConfig(
+                cfg.getBoolean("enabled", true),
+                cfg.getBoolean("nametag_enabled", true),
+                opColor != null ? opColor : DEFAULT_OP_COLOR,
+                Map.copyOf(colors));
+    }
+
+    /** 解析命名色或 {@code #RRGGBB}；无效输入返回 null（调用方保留默认）。 */
+    private static NamedTextColor parseColor(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        String trimmed = raw.trim();
+        NamedTextColor named = NamedTextColor.NAMES.value(trimmed.toLowerCase(Locale.ROOT));
+        if (named != null) {
+            return named;
+        }
+        TextColor hex = TextColor.fromCSSHexString(trimmed);
+        if (hex != null) {
+            return NamedTextColor.nearestTo(hex);
+        }
+        return null;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -218,3 +218,28 @@ exploit_hardening:
   notify_admins: true
   # 命中时的提示文案
   message: "检测到异常内容，已自动处理"
+
+# ==================================================
+#             玩家名颜色（按权限等级，2026-08-21）
+# ==================================================
+# 三个界面生效：头顶名（计分板队伍颜色）、聊天、Tab 列表。
+# 纯颜色区分等级，不加前缀文字。OP 与四级权限独立：是 OP 优先显示 op_color，
+# 非 OP 才显示所属等级组颜色（colors）。计分板队伍颜色协议仅 16 个命名色，
+# 保证三处一致统一用命名色；也可填 #RRGGBB，自动吸附最近命名色。
+#
+# EssentialsX 兼容：聊天/Tab 名字用玩家 displayName（保留 /nick 昵称）再强制 rank 色；
+# 头顶名牌受计分板限制只能用真实名着色。若存在其它聊天格式化插件（如 EssentialsChat），
+# 聊天颜色自动让位给该插件，rank 色仍体现在 Tab + 头顶名牌。
+rank_colors:
+  # 总开关：关闭后三处着色全部停用（头顶名/聊天/Tab 还原默认）
+  enabled: true
+  # 头顶名牌着色开关：关闭后仅聊天+Tab 着色（避让占用计分板队伍的其它插件时可关）
+  nametag_enabled: true
+  # OP 专用色（玩家 isOp 即显示此色，与等级组无关；优先级最高）
+  op_color: "gold"
+  # 四级权限组 → 命名色（非 OP 玩家按所属组显示）
+  colors:
+    admin: "red"
+    builder: "green"
+    member: "aqua"
+    default: "gray"

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzRankDisplayEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzRankDisplayEventTest.java
@@ -1,0 +1,94 @@
+package com.jokerhub.paper.plugin.orzmc.events;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.jokerhub.paper.plugin.orzmc.OrzMC;
+import com.jokerhub.paper.plugin.orzmc.features.rank.PlayerRankDisplayService;
+import com.jokerhub.paper.plugin.orzmc.features.rank.RankService;
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.RankColorsConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import io.papermc.paper.chat.ChatRenderer;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import java.util.UUID;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/** OrzRankDisplayEvent 测试：聊天渲染器保留 displayName 昵称并强制 rank 色；取消/禁用时跳过。 */
+class OrzRankDisplayEventTest {
+
+    private OrzMC plugin;
+    private ServerFacade serverFacade;
+    private RankService rankService;
+    private PlayerRankDisplayService service;
+
+    @BeforeEach
+    void setUp() {
+        plugin = mock(OrzMC.class);
+        serverFacade = mock(ServerFacade.class);
+        rankService = mock(RankService.class);
+        service = new PlayerRankDisplayService(serverFacade, rankService, () -> RankColorsConfig.from(null));
+    }
+
+    private Player mockPlayer(String name, boolean op) {
+        Player p = mock(Player.class);
+        when(p.getName()).thenReturn(name);
+        when(p.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(p.isOp()).thenReturn(op);
+        return p;
+    }
+
+    @Test
+    void onAsyncChat_preservesDisplayNameNickAndColors() {
+        Player sender = mockPlayer("Steve", false);
+        when(rankService.currentGroup(sender.getUniqueId())).thenReturn("member");
+        AsyncChatEvent event = mock(AsyncChatEvent.class);
+        when(event.isCancelled()).thenReturn(false);
+        when(event.getPlayer()).thenReturn(sender);
+
+        new OrzRankDisplayEvent(plugin, service).onAsyncChat(event);
+
+        ArgumentCaptor<ChatRenderer> cap = ArgumentCaptor.forClass(ChatRenderer.class);
+        verify(event).renderer(cap.capture());
+        Component rendered = cap.getValue()
+                .render(mock(Player.class), Component.text("CoolGuy"), Component.text("hi"), mock(Audience.class));
+
+        // displayName 昵称保留 + rank 色强制 + 消息透传（整体组件相等断言，避免触碰已废弃 args()）
+        assertEquals(
+                Component.translatable(
+                        "chat.type.text", Component.text("CoolGuy").color(NamedTextColor.AQUA), Component.text("hi")),
+                rendered);
+    }
+
+    @Test
+    void onAsyncChat_cancelled_skipsRenderer() {
+        Player sender = mockPlayer("Steve", false);
+        AsyncChatEvent event = mock(AsyncChatEvent.class);
+        when(event.isCancelled()).thenReturn(true);
+
+        new OrzRankDisplayEvent(plugin, service).onAsyncChat(event);
+
+        verify(event, never()).renderer(any());
+    }
+
+    @Test
+    void onAsyncChat_featureDisabled_skipsRenderer() {
+        Player sender = mockPlayer("Steve", false);
+        AsyncChatEvent event = mock(AsyncChatEvent.class);
+        when(event.isCancelled()).thenReturn(false);
+        when(event.getPlayer()).thenReturn(sender);
+        PlayerRankDisplayService disabled = new PlayerRankDisplayService(
+                serverFacade,
+                rankService,
+                () -> new RankColorsConfig(false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS));
+
+        new OrzRankDisplayEvent(plugin, disabled).onAsyncChat(event);
+
+        verify(event, never()).renderer(any());
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
@@ -216,6 +216,31 @@ class PlayerRankDisplayServiceTest {
         verify(p).playerListName(Component.text("Steve"));
     }
 
+    @Test
+    void applyTo_disabled_preservesDisplayNameNickInTab() {
+        Player p = mockPlayer("Steve", false);
+        when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
+        RankColorsConfig disabled = new RankColorsConfig(false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+
+        service(disabled).applyTo(p);
+
+        // 禁用还原时保留昵称（displayName 文本），而非还原真实名丢掉 /nick
+        verify(p).playerListName(Component.text("CoolGuy"));
+    }
+
+    @Test
+    void applyTo_overlongGroupName_skipsNametagButColorsTab() {
+        Player p = mockPlayer("Steve", false);
+        // 自定义超长 track 组名 → orzmc-<组> 超 16 协议上限：降级为只 Tab 着色，不建队伍
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("super-long-group-name");
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+
+        service().applyTo(p);
+
+        verify(board, never()).registerNewTeam(anyString());
+        verify(p).playerListName(Component.text("Steve").color(NamedTextColor.GRAY));
+    }
+
     // ---- removeFor ----
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
@@ -1,0 +1,293 @@
+package com.jokerhub.paper.plugin.orzmc.features.rank;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import com.jokerhub.paper.plugin.orzmc.infra.config.configs.RankColorsConfig;
+import com.jokerhub.paper.plugin.orzmc.infra.server.ServerFacade;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
+import org.bukkit.scoreboard.Team;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+/**
+ * PlayerRankDisplayService 测试：颜色解析（OP 优先 / 等级组 / 关闭）、
+ * 头顶队伍 + Tab 应用、OP 专用 orzmc-op 队伍、冲突让位、关闭还原、退出清理。
+ */
+class PlayerRankDisplayServiceTest {
+
+    private ServerFacade serverFacade;
+    private RankService rankService;
+    private MockedStatic<Bukkit> bukkitMock;
+    private ScoreboardManager manager;
+    private Scoreboard board;
+
+    @BeforeEach
+    void setUp() {
+        serverFacade = mock(ServerFacade.class);
+        rankService = mock(RankService.class);
+        bukkitMock = mockStatic(Bukkit.class);
+        manager = mock(ScoreboardManager.class);
+        board = mock(Scoreboard.class);
+        bukkitMock.when(Bukkit::getScoreboardManager).thenReturn(manager);
+        when(manager.getMainScoreboard()).thenReturn(board);
+    }
+
+    @AfterEach
+    void tearDown() {
+        bukkitMock.close();
+    }
+
+    private PlayerRankDisplayService service() {
+        return service(RankColorsConfig.from(null));
+    }
+
+    private PlayerRankDisplayService service(RankColorsConfig config) {
+        return new PlayerRankDisplayService(serverFacade, rankService, () -> config);
+    }
+
+    private Player mockPlayer(String name, boolean op) {
+        Player p = mock(Player.class);
+        when(p.getName()).thenReturn(name);
+        when(p.isOnline()).thenReturn(true);
+        when(p.isOp()).thenReturn(op);
+        when(p.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(p.displayName()).thenReturn(Component.text(name));
+        return p;
+    }
+
+    // ---- colorFor ----
+
+    @Test
+    void colorFor_disabled_returnsNull() {
+        Player p = mockPlayer("Steve", false);
+        RankColorsConfig disabled = new RankColorsConfig(false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+        assertNull(service(disabled).colorFor(p));
+    }
+
+    @Test
+    void colorFor_op_returnsOpColorWithoutRankLookup() {
+        Player p = mockPlayer("Steve", true);
+        assertEquals(NamedTextColor.GOLD, service().colorFor(p));
+        verifyNoInteractions(rankService);
+    }
+
+    @Test
+    void colorFor_memberGroup_returnsMemberColor() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
+        assertEquals(NamedTextColor.AQUA, service().colorFor(p));
+    }
+
+    @Test
+    void colorFor_unknownGroup_returnsGray() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("weird-group");
+        assertEquals(NamedTextColor.GRAY, service().colorFor(p));
+    }
+
+    // ---- applyTo ----
+
+    @Test
+    void applyTo_createsTeamAndSetsPlayerListName() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+        when(board.getTeam("orzmc-member")).thenReturn(null);
+        Team team = mock(Team.class);
+        when(board.registerNewTeam("orzmc-member")).thenReturn(team);
+
+        service().applyTo(p);
+
+        verify(team).color(NamedTextColor.AQUA);
+        verify(team).removeEntry("Steve");
+        verify(team).addEntry("Steve");
+        ArgumentCaptor<Component> cap = ArgumentCaptor.forClass(Component.class);
+        verify(p).playerListName(cap.capture());
+        assertEquals(NamedTextColor.AQUA, cap.getValue().color());
+    }
+
+    @Test
+    void applyTo_op_usesDedicatedOrzmcOpTeam() {
+        Player p = mockPlayer("Steve", true);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("admin"); // OP 但组 admin
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+        when(board.getTeam("orzmc-op")).thenReturn(null);
+        Team team = mock(Team.class);
+        when(board.registerNewTeam("orzmc-op")).thenReturn(team);
+
+        service().applyTo(p);
+
+        verify(board).registerNewTeam("orzmc-op");
+        verify(team).color(NamedTextColor.GOLD);
+        // 不按等级组建队，避免与同组非 OP 共享队伍导致串色
+        verify(board, never()).registerNewTeam("orzmc-admin");
+    }
+
+    @Test
+    void applyTo_moveToNewTeam_removesFromOldOrzmcTeam() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("builder");
+        Team oldTeam = mock(Team.class);
+        when(oldTeam.getName()).thenReturn("orzmc-default");
+        when(board.getEntryTeam("Steve")).thenReturn(oldTeam);
+        when(board.getTeam("orzmc-builder")).thenReturn(null);
+        Team newTeam = mock(Team.class);
+        when(board.registerNewTeam("orzmc-builder")).thenReturn(newTeam);
+
+        service().applyTo(p);
+
+        verify(oldTeam).removeEntry("Steve");
+        verify(newTeam).color(NamedTextColor.GREEN);
+        verify(newTeam).addEntry("Steve");
+    }
+
+    @Test
+    void applyTo_foreignTeam_backsOffNametagButColorsTab() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("admin");
+        Team foreign = mock(Team.class);
+        when(foreign.getName()).thenReturn("TAB-123");
+        when(board.getEntryTeam("Steve")).thenReturn(foreign);
+
+        service().applyTo(p);
+
+        verify(board, never()).registerNewTeam(anyString());
+        verify(foreign, never()).removeEntry(anyString());
+        verify(p).playerListName(any(Component.class)); // Tab 仍着色
+    }
+
+    @Test
+    void applyTo_usesDisplayNameTextForTab_whileNametagKeepsRealName() {
+        Player p = mockPlayer("Steve", false);
+        when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+        when(board.getTeam("orzmc-member")).thenReturn(null);
+        Team team = mock(Team.class);
+        when(board.registerNewTeam("orzmc-member")).thenReturn(team);
+
+        service().applyTo(p);
+
+        // Tab 用昵称 + rank 色；头顶队伍 entry 仍是真实名（计分板限制）
+        ArgumentCaptor<Component> cap = ArgumentCaptor.forClass(Component.class);
+        verify(p).playerListName(cap.capture());
+        assertEquals("CoolGuy", PlainTextComponentSerializer.plainText().serialize(cap.getValue()));
+        assertEquals(NamedTextColor.AQUA, cap.getValue().color());
+        verify(team).addEntry("Steve");
+    }
+
+    @Test
+    void applyTo_nametagDisabled_stillColorsTabNoTeam() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+        RankColorsConfig cfg = new RankColorsConfig(true, false, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+
+        service(cfg).applyTo(p);
+
+        // 只关头顶：Tab 仍着色、不建/不碰队伍（聊天由 colorFor 独立着色）
+        verify(p).playerListName(Component.text("Steve").color(NamedTextColor.AQUA));
+        verify(board, never()).registerNewTeam(anyString());
+    }
+
+    @Test
+    void applyTo_disabled_cleansTeamAndResetsPlainTab() {
+        Player p = mockPlayer("Steve", false);
+        RankColorsConfig disabled = new RankColorsConfig(false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+        Team orzmc = mock(Team.class);
+        when(orzmc.getName()).thenReturn("orzmc-default");
+        when(board.getEntryTeam("Steve")).thenReturn(orzmc);
+
+        service(disabled).applyTo(p);
+
+        verify(orzmc).removeEntry("Steve");
+        verify(p).playerListName(Component.text("Steve"));
+    }
+
+    // ---- removeFor ----
+
+    @Test
+    void removeFor_removesFromOrzmcTeam() {
+        Player p = mockPlayer("Steve", false);
+        Team orzmc = mock(Team.class);
+        when(orzmc.getName()).thenReturn("orzmc-default");
+        when(board.getEntryTeam("Steve")).thenReturn(orzmc);
+
+        service().removeFor(p);
+
+        verify(orzmc).removeEntry("Steve");
+    }
+
+    @Test
+    void removeFor_ignoresForeignTeam() {
+        Player p = mockPlayer("Steve", false);
+        Team foreign = mock(Team.class);
+        when(foreign.getName()).thenReturn("TAB-123");
+        when(board.getEntryTeam("Steve")).thenReturn(foreign);
+
+        service().removeFor(p);
+
+        verify(foreign, never()).removeEntry(anyString());
+    }
+
+    // ---- refresh ----
+
+    @Test
+    void refresh_onlinePlayer_appliesDisplay() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
+        bukkitMock.when(() -> Bukkit.getPlayer(p.getUniqueId())).thenReturn(p);
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+        when(board.getTeam("orzmc-member")).thenReturn(null);
+        Team team = mock(Team.class);
+        when(board.registerNewTeam("orzmc-member")).thenReturn(team);
+
+        service().refresh(p.getUniqueId());
+
+        verify(team).addEntry("Steve");
+    }
+
+    @Test
+    void refresh_offlinePlayer_doesNothing() {
+        UUID id = UUID.randomUUID();
+        bukkitMock.when(() -> Bukkit.getPlayer(id)).thenReturn(null);
+
+        service().refresh(id);
+
+        verifyNoInteractions(board);
+    }
+
+    @Test
+    void refreshAllOnline_appliesToEveryPlayer() {
+        Player a = mockPlayer("A", false);
+        when(rankService.currentGroup(a.getUniqueId())).thenReturn("admin");
+        Player b = mockPlayer("B", false);
+        when(rankService.currentGroup(b.getUniqueId())).thenReturn("member");
+        bukkitMock.when(Bukkit::getOnlinePlayers).thenReturn(java.util.List.of(a, b));
+        when(board.getEntryTeam("A")).thenReturn(null);
+        when(board.getEntryTeam("B")).thenReturn(null);
+        when(board.getTeam("orzmc-admin")).thenReturn(null);
+        when(board.getTeam("orzmc-member")).thenReturn(null);
+        Team admin = mock(Team.class);
+        when(board.registerNewTeam("orzmc-admin")).thenReturn(admin);
+        Team member = mock(Team.class);
+        when(board.registerNewTeam("orzmc-member")).thenReturn(member);
+
+        service().refreshAllOnline();
+
+        verify(admin).addEntry("A");
+        verify(member).addEntry("B");
+    }
+}

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPathTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPathTest.java
@@ -11,7 +11,7 @@ class ConfigPathTest {
     void all_containsExpectedEntries() {
         Map<String, ConfigPath> all = ConfigPath.all();
         assertNotNull(all);
-        assertEquals(29, all.size());
+        assertEquals(36, all.size());
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProviderTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/DefaultTypedConfigProviderTest.java
@@ -62,6 +62,16 @@ class DefaultTypedConfigProviderTest {
     }
 
     @Test
+    void rankColors_returnsConfigWithDefaultsWhenSectionMissing() {
+        // sectionOrLegacy 未 stub → null → RankColorsConfig.from(null) 返回默认
+        com.jokerhub.paper.plugin.orzmc.infra.config.configs.RankColorsConfig result = provider.rankColors();
+        assertNotNull(result);
+        assertTrue(result.enabled());
+        assertTrue(result.nametagEnabled());
+        assertEquals(net.kyori.adventure.text.format.NamedTextColor.GOLD, result.opColor());
+    }
+
+    @Test
     void renderEvent_returnsMessageEnvelope() {
         when(configService.getConfig("templates")).thenReturn(templatesConfig);
         com.jokerhub.paper.plugin.orzmc.core.bot.MessageEnvelope result =

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/RankColorsConfigTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/RankColorsConfigTest.java
@@ -1,0 +1,87 @@
+package com.jokerhub.paper.plugin.orzmc.infra.config.configs;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.junit.jupiter.api.Test;
+
+/** RankColorsConfig 解析测试：缺失默认 / 命名色 / hex 吸附 / 无效回退 / 开关。 */
+class RankColorsConfigTest {
+
+    @Test
+    void fromNull_returnsDefaults() {
+        RankColorsConfig cfg = RankColorsConfig.from(null);
+        assertTrue(cfg.enabled());
+        assertTrue(cfg.nametagEnabled());
+        assertEquals(NamedTextColor.GOLD, cfg.opColor());
+        assertEquals(NamedTextColor.GRAY, cfg.colors().get("default"));
+        assertEquals(NamedTextColor.AQUA, cfg.colors().get("member"));
+        assertEquals(NamedTextColor.GREEN, cfg.colors().get("builder"));
+        assertEquals(NamedTextColor.RED, cfg.colors().get("admin"));
+    }
+
+    @Test
+    void fromSection_parsesNamedColorsAndFlags() {
+        ConfigurationSection colors = mock(ConfigurationSection.class);
+        when(colors.getString("admin")).thenReturn("red");
+        when(colors.getString("builder")).thenReturn("green");
+        when(colors.getString("member")).thenReturn("blue");
+        when(colors.getString("default")).thenReturn("gray");
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled", true)).thenReturn(false);
+        when(cfg.getBoolean("nametag_enabled", true)).thenReturn(false);
+        when(cfg.getString("op_color")).thenReturn("gold");
+        when(cfg.getConfigurationSection("colors")).thenReturn(colors);
+
+        RankColorsConfig parsed = RankColorsConfig.from(cfg);
+        assertFalse(parsed.enabled());
+        assertFalse(parsed.nametagEnabled());
+        assertEquals(NamedTextColor.GOLD, parsed.opColor());
+        assertEquals(NamedTextColor.RED, parsed.colors().get("admin"));
+        assertEquals(NamedTextColor.GREEN, parsed.colors().get("builder"));
+        assertEquals(NamedTextColor.BLUE, parsed.colors().get("member"));
+        assertEquals(NamedTextColor.GRAY, parsed.colors().get("default"));
+    }
+
+    @Test
+    void fromSection_hexSnapsToNearestNamedColor() {
+        ConfigurationSection colors = mock(ConfigurationSection.class);
+        when(colors.getString("admin")).thenReturn("#FF5555"); // 与 RED 完全一致
+        when(colors.getString("builder")).thenReturn(null);
+        when(colors.getString("member")).thenReturn(null);
+        when(colors.getString("default")).thenReturn(null);
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled", true)).thenReturn(true);
+        when(cfg.getBoolean("nametag_enabled", true)).thenReturn(true);
+        when(cfg.getString("op_color")).thenReturn(null);
+        when(cfg.getConfigurationSection("colors")).thenReturn(colors);
+
+        RankColorsConfig parsed = RankColorsConfig.from(cfg);
+        assertEquals(NamedTextColor.RED, parsed.colors().get("admin"));
+        // 未配置键保留默认
+        assertEquals(NamedTextColor.GREEN, parsed.colors().get("builder"));
+        assertEquals(NamedTextColor.AQUA, parsed.colors().get("member"));
+        assertEquals(NamedTextColor.GRAY, parsed.colors().get("default"));
+    }
+
+    @Test
+    void fromSection_invalidColor_fallsBackToDefault() {
+        ConfigurationSection colors = mock(ConfigurationSection.class);
+        when(colors.getString("admin")).thenReturn("not-a-color");
+        when(colors.getString("builder")).thenReturn(null);
+        when(colors.getString("member")).thenReturn(null);
+        when(colors.getString("default")).thenReturn(null);
+        ConfigurationSection cfg = mock(ConfigurationSection.class);
+        when(cfg.getBoolean("enabled", true)).thenReturn(true);
+        when(cfg.getBoolean("nametag_enabled", true)).thenReturn(true);
+        when(cfg.getString("op_color")).thenReturn("not-a-color");
+        when(cfg.getConfigurationSection("colors")).thenReturn(colors);
+
+        RankColorsConfig parsed = RankColorsConfig.from(cfg);
+        assertEquals(NamedTextColor.RED, parsed.colors().get("admin")); // 解析失败回退默认
+        assertEquals(NamedTextColor.GRAY, parsed.colors().get("default"));
+        assertEquals(NamedTextColor.GOLD, parsed.opColor()); // op 解析失败回退默认
+    }
+}


### PR DESCRIPTION
## 功能
按 LuckPerms track 四级权限（`default → member → builder → admin`）在**三处统一**给玩家名着色，**纯颜色、不加前缀文字**，玩家可一眼识别他人权限等级。

| 显示表面 | 实现 |
|---|---|
| 头顶名牌 | 计分板 `orzmc-<group>` 队伍色（`team.color`，协议限 16 命名色，`#RRGGBB` 自动吸附最近命名色） |
| 聊天 | `AsyncChatEvent` 在 LOWEST 设 `ChatRenderer.viewerUnaware`，镜像默认渲染器仅改名字颜色 |
| Tab 列表 | `playerListName(Component)`，用 displayName 纯文本 |

## 关键设计
- **OP 独立体系优先**：`player.isOp()` 优先显示 `op_color`（默认金），与等级组无关；归 `orzmc-op` 专属队伍，避免 OP 与同组非 OP 共享队伍导致金色串色。非 OP 才回落等级组色。
- **冲突感知（只动自家队伍）**：只创建/管理 `orzmc-*` 队伍；若玩家 entry 已被外部队伍占用（TAB/NametagEdit 等接管名牌），主动让位跳过头顶着色，聊天+Tab 照常；全程不触碰任何队伍的 prefix/suffix。
- **EssentialsX 兼容**：
  - 聊天/Tab 名字取 `displayName` 纯文本（保留 `/nick` 昵称）再强制 rank 色；
  - 聊天渲染器 **LOWEST** 设置 → EssentialsChat 等格式化插件更高优先级覆盖即**自然让位**，聊天格式归对方，rank 色仍体现在 Tab + 头顶名牌。
- **等级变更实时刷新**：LuckPerms `UserTrackEvent` → 调度线程重刷；`runTaskTimer` 60s 周期自愈兜底（覆盖手动 `lp user X parent set` 等不触发事件的情况）。
- **Folia 线程红线**：计分板/Tab 变更一律 `ServerFacade.runSync`（global 调度器）；聊天渲染器异步线程只读 `RankService.currentGroup`（LP 在线缓存，零阻塞，无 future 等待）。
- **LP 软依赖**：`RankDisplayLpBridge` 三元短路条件实例化（仅 LP 启用时 `LuckPermsProvider.get()`）；LP 缺失时全员 `default` 灰。
- **配置热调**：`rank_colors` 段 + `getOrSetDefault` 幂等迁移（不覆盖管理员修改）+ `ConfigPath.reg` 支持 `/orzmc config set rank_colors.*`。

## 测试验证
- `./gradlew spotlessApply && ./gradlew test`：**1272 全绿**（新增 21 例）
  - `RankColorsConfigTest`：`from(null)` 默认 / 命名色+hex 吸附 / 未知键回退 / enabled 开关
  - `PlayerRankDisplayServiceTest`：颜色解析（OP 优先）、队伍归属、OP 专属 `orzmc-op`、**外部队伍冲突让位**、displayName 昵称保留（Tab 用昵称 / 队伍 entry 用真实名）、`nametag_enabled=false` 只关头顶、关闭还原、退出清理
  - `OrzRankDisplayEventTest`：渲染器保留昵称+强制 rank 色（整体组件相等断言）、取消/禁用跳过
- `integrationTest` 编译通过

## 测试服验收清单（Paper/Folia）
- [ ] 4 等级玩家各一 → 三处颜色一致且互不相同
- [ ] 加 1 个 OP（等级 default）→ 金色，与同组非 OP 灰明显区分；`deop` 后实时回落
- [ ] `$p u <name>` 升降级 / 控制台 `lp user X promote rank` 在线实时变色
- [ ] `/orzmc config set rank_colors.colors.admin blue` 60s 内生效
- [ ] `rank_colors.enabled=false` 还原纯名
- [ ] 装 EssentialsChat → 聊天格式归 EssentialsChat，Tab+头顶仍 rank 色