### PR TITLE
feat(rank): rank_colors.tab_enabled 独立开关 Tab 着色 + /orzmc config 改动热生效

### DIFF
--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/assembly/FeatureModule.java
@@ -289,8 +289,12 @@ public final class FeatureModule implements ServiceModule {
             new com.jokerhub.paper.plugin.orzmc.events.OrzRankDisplayEvent(plugin, rankDisplayService)
         };
         EventBinder.bind(plugin, Arrays.asList(eventListeners));
-        // 周期自愈：约 60s 重刷一次在线玩家颜色（兜底 Paper 头顶名刷新遗漏 + /config reload 热生效）
+        // 周期自愈：约 60s 重刷一次在线玩家颜色（兜底 Paper 头顶名刷新遗漏 + 配置改动兜底生效）
         rankDisplayService.startPeriodicRefresh();
+        // rank_colors.* 运行时改动（/orzmc config set/reset/reload）→ 立即重刷在线玩家，消除最长 ~60s 生效延迟；
+        // 命令线程 → 调度线程（Folia 区域线程安全，PlayerRankDisplayService 的 applyTo 必须在调度线程执行）
+        orzConfigCommand.setRankColorsReload(
+                () -> platform.serverFacade().runSync(rankDisplayService::refreshAllOnline));
     }
 
     // --- Command Registration ---

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/commands/OrzConfigCommand.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/commands/OrzConfigCommand.java
@@ -28,6 +28,7 @@ public class OrzConfigCommand implements CommandExecutor {
     private final OrzTextStyles textStyles;
     private final Map<String, ConfigPath> registry;
     private final Runnable easyBotConfigReload;
+    private Runnable rankColorsReload = () -> {};
 
     public OrzConfigCommand(ConfigService configService, OrzTextStyles textStyles) {
         this(configService, textStyles, () -> {});
@@ -38,6 +39,14 @@ public class OrzConfigCommand implements CommandExecutor {
         this.textStyles = textStyles;
         this.registry = ConfigPath.all();
         this.easyBotConfigReload = easyBotConfigReload == null ? () -> {} : easyBotConfigReload;
+    }
+
+    /**
+     * 注册 rank_colors.* 配置改动后的回调（组合根注入：{@code /orzmc config} 改完即重刷在线玩家，
+     * 消除最长 ~60s 周期自愈才生效的延迟）。回调需自行保证在调度线程执行。
+     */
+    public void setRankColorsReload(Runnable rankColorsReload) {
+        this.rankColorsReload = rankColorsReload == null ? () -> {} : rankColorsReload;
     }
 
     @Override
@@ -145,7 +154,7 @@ public class OrzConfigCommand implements CommandExecutor {
             cfg.set(cp.path(), parsed);
             configService.saveConfig(cp.configName());
             configService.reloadConfig(cp.configName());
-            notifyEasyBotReload(cp.configName());
+            notifyConfigReload(cp);
             sender.sendMessage(textStyles.success("已设置: " + key + " = " + formatValue(parsed)));
         } catch (NumberFormatException e) {
             sender.sendMessage(textStyles.error("类型错误: " + key + " 需为 " + typeDisplay(cp.type()) + "，输入值无法解析"));
@@ -173,14 +182,14 @@ public class OrzConfigCommand implements CommandExecutor {
         cfg.set(cp.path(), cp.defaultValue());
         configService.saveConfig(cp.configName());
         configService.reloadConfig(cp.configName());
-        notifyEasyBotReload(cp.configName());
+        notifyConfigReload(cp);
         sender.sendMessage(textStyles.success("已恢复默认: " + key + " = " + formatValue(cp.defaultValue())));
     }
 
     private void handleReload(CommandSender sender, String[] args) {
         if (args.length >= 2) {
             if (configService.reloadConfig(args[1])) {
-                notifyEasyBotReload(args[1]);
+                notifyConfigNameReload(args[1]);
                 sender.sendMessage(textStyles.success("配置文件 " + args[1] + " 已重新加载"));
             } else {
                 sender.sendMessage(textStyles.error("配置文件 " + args[1] + " 不存在"));
@@ -188,13 +197,26 @@ public class OrzConfigCommand implements CommandExecutor {
         } else {
             configService.reloadAll();
             easyBotConfigReload.run();
+            rankColorsReload.run();
             sender.sendMessage(textStyles.success("所有配置文件已重新加载"));
         }
     }
 
-    private void notifyEasyBotReload(String configName) {
+    /** 按配置路径派发改动后回调：easybot → 连接协调；rank_colors.* → 重刷在线玩家着色。 */
+    private void notifyConfigReload(ConfigPath cp) {
+        if ("easybot".equalsIgnoreCase(cp.configName())) {
+            easyBotConfigReload.run();
+        } else if (cp.path().startsWith("rank_colors.")) {
+            rankColorsReload.run();
+        }
+    }
+
+    /** 按配置文件名派发改动后回调：easybot → 连接协调；config.yml（含 rank_colors）→ 重刷在线玩家着色。 */
+    private void notifyConfigNameReload(String configName) {
         if ("easybot".equalsIgnoreCase(configName)) {
             easyBotConfigReload.run();
+        } else if ("config".equalsIgnoreCase(configName)) {
+            rankColorsReload.run();
         }
     }
 

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
@@ -24,9 +24,9 @@ import org.bukkit.scoreboard.Team;
  * 只能用真实名着色（与 vanilla+EssentialsX 自身行为一致）。</p>
  *
  * <p>{@code nametag_enabled} / {@code tab_enabled} 可独立开关头顶名牌与 Tab 着色
- * （默认均开）；{@code tab_enabled} 关闭时 Tab 名 {@code playerListName} 置空，交由 client
- * 计分板队伍/vanilla 渲染（恢复原 team 前缀），聊天着色不受影响。总开关关闭时还原
- * displayName 文本（保留昵称）。</p>
+ * （默认均开）；总开关 {@code enabled} 或 {@code tab_enabled} 关闭时 Tab 名
+ * {@code playerListName} 置空，交由 client 计分板队伍/vanilla 渲染（恢复原 team 前缀、
+ * 真实名），聊天着色不受影响。</p>
  *
  * <p>OP 与四级权限是独立体系：{@code player.isOp()} 优先显示 {@code op_color}，与等级组无关。</p>
  *
@@ -84,11 +84,10 @@ public final class PlayerRankDisplayService {
     /**
      * 重设某在线玩家的头顶名牌队伍 + Tab 名（幂等）。必须在调度线程调用。
      *
-     * <p>关闭 {@code enabled} 时清理队伍并还原 Tab 名（displayName 文本，保留昵称）；
-     * {@code tab_enabled} 关闭时仅还原 Tab 名（保留头顶/聊天着色）——{@code playerListName}
-     * 置空交由 client 计分板队伍/vanilla 渲染（恢复原 team 前缀+名字）；若
-     * {@code nametag_enabled} 开着玩家仍在 orzmc 队伍，Tab 回退会沿用该队伍色——team 机制
-     * 固有交互。</p>
+     * <p>关闭 {@code enabled} 或 {@code tab_enabled} 时 Tab 名均 {@code playerListName} 置空，
+     * 交由 client 计分板队伍/vanilla 渲染（恢复原 team 前缀+真实名）；{@code tab_enabled}
+     * 关闭时保留头顶/聊天着色。若 {@code nametag_enabled} 开着玩家仍在 orzmc 队伍，Tab 回退
+     * 会沿用该队伍色——team 机制固有交互。</p>
      */
     public void applyTo(Player player) {
         if (player == null || !player.isOnline()) {
@@ -97,8 +96,8 @@ public final class PlayerRankDisplayService {
         RankColorsConfig config = configSupplier.get();
         if (!config.enabled()) {
             removeFor(player);
-            // 总开关关闭：还原 displayName 文本（保留 EssentialsX /nick 昵称），与 1.0.22 既有行为一致
-            player.playerListName(Component.text(displayNameText(player)));
+            // 总开关关闭同样置空：恢复服务器原显示策略（client 走计分板队伍/vanilla 渲染，含原 team 前缀）
+            player.playerListName(null);
             return;
         }
         boolean op = player.isOp();

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
@@ -24,7 +24,8 @@ import org.bukkit.scoreboard.Team;
  * 只能用真实名着色（与 vanilla+EssentialsX 自身行为一致）。</p>
  *
  * <p>{@code nametag_enabled} / {@code tab_enabled} 可独立开关头顶名牌与 Tab 着色
- * （默认均开）；关闭时该界面还原 displayName 纯文本，聊天着色不受影响。</p>
+ * （默认均开）；关闭时该界面还原服务器原 displayName 组件（保留昵称及格式），
+ * 聊天着色不受影响。</p>
  *
  * <p>OP 与四级权限是独立体系：{@code player.isOp()} 优先显示 {@code op_color}，与等级组无关。</p>
  *
@@ -83,7 +84,8 @@ public final class PlayerRankDisplayService {
      * 重设某在线玩家的头顶名牌队伍 + Tab 名（幂等）。必须在调度线程调用。
      *
      * <p>关闭 {@code enabled} 时清理队伍并还原 Tab 名；{@code tab_enabled} 关闭时仅
-     * 还原 Tab 名（保留头顶/聊天着色）。还原均用 displayName 纯文本（保留 EssentialsX 昵称）。</p>
+     * 还原 Tab 名（保留头顶/聊天着色）。还原均用服务器原 displayName 组件
+     * （保留 EssentialsX 昵称及其格式），即恢复 OrzMC 介入前的显示策略。</p>
      */
     public void applyTo(Player player) {
         if (player == null || !player.isOnline()) {
@@ -92,16 +94,16 @@ public final class PlayerRankDisplayService {
         RankColorsConfig config = configSupplier.get();
         if (!config.enabled()) {
             removeFor(player);
-            // 还原用 displayName 文本而非真实名：避免丢掉 EssentialsX /nick 昵称
-            player.playerListName(plainTabName(player));
+            // 还原服务器原显示策略：displayName 原组件（保留 EssentialsX /nick 昵称及格式）
+            player.playerListName(restoredTabName(player));
             return;
         }
         boolean op = player.isOp();
         // OP 时等级组不参与颜色与队伍命名，跳过 LP 查询（微优化）
         String group = op ? null : currentGroupOf(player.getUniqueId());
         NamedTextColor color = op ? config.opColor() : colorFor(config, group);
-        // Tab 名组件：tab_enabled 关闭时还原 displayName 纯文本（保留昵称），仅头顶/聊天着色
-        Component tabName = config.tabEnabled() ? coloredTabName(player, color) : plainTabName(player);
+        // Tab 名组件：tab_enabled 关闭时还原服务器原 displayName 组件（保留昵称及格式），仅头顶/聊天着色
+        Component tabName = config.tabEnabled() ? coloredTabName(player, color) : restoredTabName(player);
         if (!config.nametagEnabled()) {
             // 只关头顶名牌：不建/不碰队伍；Tab 按 tab_enabled 着色或还原（避让占用计分板队伍的插件时用）
             removeFor(player);
@@ -185,9 +187,18 @@ public final class PlayerRankDisplayService {
         return Component.text(displayNameText(player)).color(color);
     }
 
-    /** Tab 名组件：displayName 纯文本（保留昵称），不强制颜色（tab_enabled 关闭时还原用）。 */
-    private static Component plainTabName(Player player) {
-        return Component.text(displayNameText(player));
+    /**
+     * Tab 名还原组件：服务器原 displayName 原组件（保留 EssentialsX /nick 昵称及其格式），
+     * 不强制任何颜色——即恢复 OrzMC 介入前的显示策略（tab_enabled / 总开关关闭时用）。
+     * displayName 为 null/空文本时回退真实名组件。
+     */
+    private static Component restoredTabName(Player player) {
+        Component displayName = player.displayName();
+        if (displayName == null) {
+            return Component.text(player.getName());
+        }
+        String text = PlainTextComponentSerializer.plainText().serialize(displayName);
+        return text.isBlank() ? Component.text(player.getName()) : displayName;
     }
 
     /** displayName 纯文本；为 null/空则回退真实名（Paper 默认 displayName 即真实名）。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
@@ -23,6 +23,9 @@ import org.bukkit.scoreboard.Team;
  * EssentialsX {@code /nick} 等昵称）强制 rank 色；头顶名牌受计分板 team entry 限制
  * 只能用真实名着色（与 vanilla+EssentialsX 自身行为一致）。</p>
  *
+ * <p>{@code nametag_enabled} / {@code tab_enabled} 可独立开关头顶名牌与 Tab 着色
+ * （默认均开）；关闭时该界面还原 displayName 纯文本，聊天着色不受影响。</p>
+ *
  * <p>OP 与四级权限是独立体系：{@code player.isOp()} 优先显示 {@code op_color}，与等级组无关。</p>
  *
  * <p><b>冲突感知（只动自家队伍）</b>：只创建/管理 {@code orzmc-*} 队伍，绝不删改外部队伍；
@@ -79,8 +82,8 @@ public final class PlayerRankDisplayService {
     /**
      * 重设某在线玩家的头顶名牌队伍 + Tab 名（幂等）。必须在调度线程调用。
      *
-     * <p>关闭 {@code enabled}/{@code nametag_enabled} 时清理队伍并还原 Tab 名
-     * （还原为 displayName 纯文本，保留 EssentialsX 昵称）。</p>
+     * <p>关闭 {@code enabled} 时清理队伍并还原 Tab 名；{@code tab_enabled} 关闭时仅
+     * 还原 Tab 名（保留头顶/聊天着色）。还原均用 displayName 纯文本（保留 EssentialsX 昵称）。</p>
      */
     public void applyTo(Player player) {
         if (player == null || !player.isOnline()) {
@@ -90,17 +93,19 @@ public final class PlayerRankDisplayService {
         if (!config.enabled()) {
             removeFor(player);
             // 还原用 displayName 文本而非真实名：避免丢掉 EssentialsX /nick 昵称
-            player.playerListName(Component.text(displayNameText(player)));
+            player.playerListName(plainTabName(player));
             return;
         }
         boolean op = player.isOp();
         // OP 时等级组不参与颜色与队伍命名，跳过 LP 查询（微优化）
         String group = op ? null : currentGroupOf(player.getUniqueId());
         NamedTextColor color = op ? config.opColor() : colorFor(config, group);
+        // Tab 名组件：tab_enabled 关闭时还原 displayName 纯文本（保留昵称），仅头顶/聊天着色
+        Component tabName = config.tabEnabled() ? coloredTabName(player, color) : plainTabName(player);
         if (!config.nametagEnabled()) {
-            // 只关头顶名牌：聊天+Tab 仍着色（避让占用计分板队伍的插件时用）
+            // 只关头顶名牌：不建/不碰队伍；Tab 按 tab_enabled 着色或还原（避让占用计分板队伍的插件时用）
             removeFor(player);
-            player.playerListName(coloredTabName(player, color));
+            player.playerListName(tabName);
             return;
         }
         Scoreboard board = mainScoreboard();
@@ -115,7 +120,7 @@ public final class PlayerRankDisplayService {
         Team existing = board.getEntryTeam(entry);
         if (existing != null && !existing.getName().startsWith(TEAM_PREFIX)) {
             LOGGER.fine("玩家 " + entry + " 头顶队伍已被其它插件接管(" + existing.getName() + ")，让位跳过头顶着色");
-            player.playerListName(coloredTabName(player, color));
+            player.playerListName(tabName);
             return;
         }
         if (existing != null) {
@@ -123,14 +128,14 @@ public final class PlayerRankDisplayService {
         }
         Team team = ensureTeam(board, displayKey, color);
         if (team == null) {
-            // 队伍名超协议上限（自定义超长 track 组名）→ 跳过头顶着色，Tab 仍着色
-            player.playerListName(coloredTabName(player, color));
+            // 队伍名超协议上限（自定义超长 track 组名）→ 跳过头顶着色，Tab 按开关着色/还原
+            player.playerListName(tabName);
             return;
         }
         // 强制刷新：removeEntry+addEntry 重发队伍包，让客户端重绘头顶名（规避 Paper 已知刷新遗漏）
         team.removeEntry(entry);
         team.addEntry(entry);
-        player.playerListName(coloredTabName(player, color));
+        player.playerListName(tabName);
     }
 
     /** 从 orzmc-* 队伍移除玩家 entry（退出/禁用时）。必须在调度线程调用。 */
@@ -178,6 +183,11 @@ public final class PlayerRankDisplayService {
     /** Tab 名组件：displayName 纯文本（保留 EssentialsX /nick 昵称）强制 rank 色。 */
     private static Component coloredTabName(Player player, NamedTextColor color) {
         return Component.text(displayNameText(player)).color(color);
+    }
+
+    /** Tab 名组件：displayName 纯文本（保留昵称），不强制颜色（tab_enabled 关闭时还原用）。 */
+    private static Component plainTabName(Player player) {
+        return Component.text(displayNameText(player));
     }
 
     /** displayName 纯文本；为 null/空则回退真实名（Paper 默认 displayName 即真实名）。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
@@ -24,8 +24,9 @@ import org.bukkit.scoreboard.Team;
  * 只能用真实名着色（与 vanilla+EssentialsX 自身行为一致）。</p>
  *
  * <p>{@code nametag_enabled} / {@code tab_enabled} 可独立开关头顶名牌与 Tab 着色
- * （默认均开）；关闭时 Tab 名 {@code playerListName} 置空，交由 client 计分板队伍/vanilla
- * 渲染（恢复原 team 前缀），聊天着色不受影响。</p>
+ * （默认均开）；{@code tab_enabled} 关闭时 Tab 名 {@code playerListName} 置空，交由 client
+ * 计分板队伍/vanilla 渲染（恢复原 team 前缀），聊天着色不受影响。总开关关闭时还原
+ * displayName 文本（保留昵称）。</p>
  *
  * <p>OP 与四级权限是独立体系：{@code player.isOp()} 优先显示 {@code op_color}，与等级组无关。</p>
  *
@@ -83,10 +84,11 @@ public final class PlayerRankDisplayService {
     /**
      * 重设某在线玩家的头顶名牌队伍 + Tab 名（幂等）。必须在调度线程调用。
      *
-     * <p>关闭 {@code enabled} 时清理队伍并还原 Tab 名；{@code tab_enabled} 关闭时仅
-     * 还原 Tab 名（保留头顶/聊天着色）。还原即 {@code playerListName} 置空，交由 client
-     * 的计分板队伍/vanilla 渲染（恢复原 team 前缀+名字）；若 {@code nametag_enabled} 开着
-     * 玩家仍在 orzmc 队伍，Tab 回退会沿用该队伍色——team 机制固有交互。</p>
+     * <p>关闭 {@code enabled} 时清理队伍并还原 Tab 名（displayName 文本，保留昵称）；
+     * {@code tab_enabled} 关闭时仅还原 Tab 名（保留头顶/聊天着色）——{@code playerListName}
+     * 置空交由 client 计分板队伍/vanilla 渲染（恢复原 team 前缀+名字）；若
+     * {@code nametag_enabled} 开着玩家仍在 orzmc 队伍，Tab 回退会沿用该队伍色——team 机制
+     * 固有交互。</p>
      */
     public void applyTo(Player player) {
         if (player == null || !player.isOnline()) {
@@ -95,9 +97,8 @@ public final class PlayerRankDisplayService {
         RankColorsConfig config = configSupplier.get();
         if (!config.enabled()) {
             removeFor(player);
-            // 还原服务器原显示策略：playerListName 置空，交由 client 的计分板队伍/vanilla 渲染
-            // （恢复原 team 前缀+名字；置空是唯一能让 client 走 team 回退路径的方式）
-            player.playerListName(null);
+            // 总开关关闭：还原 displayName 文本（保留 EssentialsX /nick 昵称），与 1.0.22 既有行为一致
+            player.playerListName(Component.text(displayNameText(player)));
             return;
         }
         boolean op = player.isOp();

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayService.java
@@ -24,8 +24,8 @@ import org.bukkit.scoreboard.Team;
  * 只能用真实名着色（与 vanilla+EssentialsX 自身行为一致）。</p>
  *
  * <p>{@code nametag_enabled} / {@code tab_enabled} 可独立开关头顶名牌与 Tab 着色
- * （默认均开）；关闭时该界面还原服务器原 displayName 组件（保留昵称及格式），
- * 聊天着色不受影响。</p>
+ * （默认均开）；关闭时 Tab 名 {@code playerListName} 置空，交由 client 计分板队伍/vanilla
+ * 渲染（恢复原 team 前缀），聊天着色不受影响。</p>
  *
  * <p>OP 与四级权限是独立体系：{@code player.isOp()} 优先显示 {@code op_color}，与等级组无关。</p>
  *
@@ -84,8 +84,9 @@ public final class PlayerRankDisplayService {
      * 重设某在线玩家的头顶名牌队伍 + Tab 名（幂等）。必须在调度线程调用。
      *
      * <p>关闭 {@code enabled} 时清理队伍并还原 Tab 名；{@code tab_enabled} 关闭时仅
-     * 还原 Tab 名（保留头顶/聊天着色）。还原均用服务器原 displayName 组件
-     * （保留 EssentialsX 昵称及其格式），即恢复 OrzMC 介入前的显示策略。</p>
+     * 还原 Tab 名（保留头顶/聊天着色）。还原即 {@code playerListName} 置空，交由 client
+     * 的计分板队伍/vanilla 渲染（恢复原 team 前缀+名字）；若 {@code nametag_enabled} 开着
+     * 玩家仍在 orzmc 队伍，Tab 回退会沿用该队伍色——team 机制固有交互。</p>
      */
     public void applyTo(Player player) {
         if (player == null || !player.isOnline()) {
@@ -94,16 +95,17 @@ public final class PlayerRankDisplayService {
         RankColorsConfig config = configSupplier.get();
         if (!config.enabled()) {
             removeFor(player);
-            // 还原服务器原显示策略：displayName 原组件（保留 EssentialsX /nick 昵称及格式）
-            player.playerListName(restoredTabName(player));
+            // 还原服务器原显示策略：playerListName 置空，交由 client 的计分板队伍/vanilla 渲染
+            // （恢复原 team 前缀+名字；置空是唯一能让 client 走 team 回退路径的方式）
+            player.playerListName(null);
             return;
         }
         boolean op = player.isOp();
         // OP 时等级组不参与颜色与队伍命名，跳过 LP 查询（微优化）
         String group = op ? null : currentGroupOf(player.getUniqueId());
         NamedTextColor color = op ? config.opColor() : colorFor(config, group);
-        // Tab 名组件：tab_enabled 关闭时还原服务器原 displayName 组件（保留昵称及格式），仅头顶/聊天着色
-        Component tabName = config.tabEnabled() ? coloredTabName(player, color) : restoredTabName(player);
+        // Tab 名组件：tab_enabled 关闭时置空（恢复服务器原显示策略，保留原 team 前缀），仅头顶/聊天着色
+        Component tabName = config.tabEnabled() ? coloredTabName(player, color) : null;
         if (!config.nametagEnabled()) {
             // 只关头顶名牌：不建/不碰队伍；Tab 按 tab_enabled 着色或还原（避让占用计分板队伍的插件时用）
             removeFor(player);
@@ -185,20 +187,6 @@ public final class PlayerRankDisplayService {
     /** Tab 名组件：displayName 纯文本（保留 EssentialsX /nick 昵称）强制 rank 色。 */
     private static Component coloredTabName(Player player, NamedTextColor color) {
         return Component.text(displayNameText(player)).color(color);
-    }
-
-    /**
-     * Tab 名还原组件：服务器原 displayName 原组件（保留 EssentialsX /nick 昵称及其格式），
-     * 不强制任何颜色——即恢复 OrzMC 介入前的显示策略（tab_enabled / 总开关关闭时用）。
-     * displayName 为 null/空文本时回退真实名组件。
-     */
-    private static Component restoredTabName(Player player) {
-        Component displayName = player.displayName();
-        if (displayName == null) {
-            return Component.text(player.getName());
-        }
-        String text = PlainTextComponentSerializer.plainText().serialize(displayName);
-        return text.isBlank() ? Component.text(player.getName()) : displayName;
     }
 
     /** displayName 纯文本；为 null/空则回退真实名（Paper 默认 displayName 即真实名）。 */

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPath.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPath.java
@@ -90,6 +90,7 @@ public final class ConfigPath {
         // rank_colors (config.yml)
         reg(map, "config", "rank_colors.enabled", Boolean.class, true, "玩家名颜色总开关");
         reg(map, "config", "rank_colors.nametag_enabled", Boolean.class, true, "头顶名牌着色开关");
+        reg(map, "config", "rank_colors.tab_enabled", Boolean.class, true, "Tab列表着色开关");
         reg(map, "config", "rank_colors.op_color", String.class, "gold", "OP 玩家名颜色(命名色)");
         reg(map, "config", "rank_colors.colors.admin", String.class, "red", "管理员名颜色(命名色)");
         reg(map, "config", "rank_colors.colors.builder", String.class, "green", "建造者名颜色(命名色)");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigService.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigService.java
@@ -41,6 +41,7 @@ public final class ConfigService {
         // 玩家名颜色（按权限等级）：仅缺失键写入默认值，不覆盖管理员修改（幂等）
         configManager.getOrSetDefault("config", "rank_colors.enabled", true);
         configManager.getOrSetDefault("config", "rank_colors.nametag_enabled", true);
+        configManager.getOrSetDefault("config", "rank_colors.tab_enabled", true);
         configManager.getOrSetDefault("config", "rank_colors.op_color", "gold");
         configManager.getOrSetDefault("config", "rank_colors.colors.admin", "red");
         configManager.getOrSetDefault("config", "rank_colors.colors.builder", "green");

--- a/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/RankColorsConfig.java
+++ b/src/main/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/RankColorsConfig.java
@@ -11,14 +11,19 @@ import org.bukkit.configuration.ConfigurationSection;
  * 玩家名颜色（按权限等级）配置。
  *
  * <p>对应 config.yml 的 {@code rank_colors:} 段：是否启用、是否启用头顶名牌着色、
- * OP 专用色（OP 与四级权限独立，isOp 优先），以及四级权限组 → 命名色映射。</p>
+ * 是否启用 Tab 列表着色、OP 专用色（OP 与四级权限独立，isOp 优先），
+ * 以及四级权限组 → 命名色映射。</p>
  *
  * <p>计分板队伍颜色协议只支持 16 个命名色（NamedTextColor，无任意 hex 重载）：
  * 为让头顶名牌/聊天/Tab 三处颜色完全一致，配置统一用命名色；也兼容
  * {@code #RRGGBB}，自动吸附到最近的命名色。解析失败的键保留默认值。</p>
  */
 public record RankColorsConfig(
-        boolean enabled, boolean nametagEnabled, NamedTextColor opColor, Map<String, NamedTextColor> colors) {
+        boolean enabled,
+        boolean nametagEnabled,
+        boolean tabEnabled,
+        NamedTextColor opColor,
+        Map<String, NamedTextColor> colors) {
 
     /** 默认 OP 色（金色）。 */
     public static final NamedTextColor DEFAULT_OP_COLOR = NamedTextColor.GOLD;
@@ -32,7 +37,7 @@ public record RankColorsConfig(
 
     public static RankColorsConfig from(ConfigurationSection cfg) {
         if (cfg == null) {
-            return new RankColorsConfig(true, true, DEFAULT_OP_COLOR, DEFAULTS);
+            return new RankColorsConfig(true, true, true, DEFAULT_OP_COLOR, DEFAULTS);
         }
         Map<String, NamedTextColor> colors = new HashMap<>();
         ConfigurationSection colorsSection = cfg.getConfigurationSection("colors");
@@ -50,6 +55,7 @@ public record RankColorsConfig(
         return new RankColorsConfig(
                 cfg.getBoolean("enabled", true),
                 cfg.getBoolean("nametag_enabled", true),
+                cfg.getBoolean("tab_enabled", true),
                 opColor != null ? opColor : DEFAULT_OP_COLOR,
                 Map.copyOf(colors));
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -231,7 +231,7 @@ exploit_hardening:
 # 头顶名牌受计分板限制只能用真实名着色。若存在其它聊天格式化插件（如 EssentialsChat），
 # 聊天颜色自动让位给该插件，rank 色仍体现在 Tab + 头顶名牌。
 rank_colors:
-  # 总开关：关闭后三处着色全部停用（头顶名/聊天/Tab 还原默认）
+  # 总开关：关闭后三处着色全部停用（Tab 名置空，恢复服务器原计分板队伍/vanilla 渲染，保留 team 前缀）
   enabled: true
   # 头顶名牌着色开关：关闭后仅聊天+Tab 着色（避让占用计分板队伍的其它插件时可关）
   nametag_enabled: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -235,7 +235,7 @@ rank_colors:
   enabled: true
   # 头顶名牌着色开关：关闭后仅聊天+Tab 着色（避让占用计分板队伍的其它插件时可关）
   nametag_enabled: true
-  # Tab 列表着色开关：关闭后仅头顶+聊天着色（Tab 名恢复服务器原 displayName 显示，保留昵称与格式）
+  # Tab 列表着色开关：关闭后仅头顶+聊天着色（Tab 名置空，恢复服务器原计分板队伍/vanilla 渲染，保留 team 前缀）
   tab_enabled: true
   # OP 专用色（玩家 isOp 即显示此色，与等级组无关；优先级最高）
   op_color: "gold"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -235,7 +235,7 @@ rank_colors:
   enabled: true
   # 头顶名牌着色开关：关闭后仅聊天+Tab 着色（避让占用计分板队伍的其它插件时可关）
   nametag_enabled: true
-  # Tab 列表着色开关：关闭后仅头顶+聊天着色（Tab 名还原 displayName 纯文本，保留昵称）
+  # Tab 列表着色开关：关闭后仅头顶+聊天着色（Tab 名恢复服务器原 displayName 显示，保留昵称与格式）
   tab_enabled: true
   # OP 专用色（玩家 isOp 即显示此色，与等级组无关；优先级最高）
   op_color: "gold"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -235,6 +235,8 @@ rank_colors:
   enabled: true
   # 头顶名牌着色开关：关闭后仅聊天+Tab 着色（避让占用计分板队伍的其它插件时可关）
   nametag_enabled: true
+  # Tab 列表着色开关：关闭后仅头顶+聊天着色（Tab 名还原 displayName 纯文本，保留昵称）
+  tab_enabled: true
   # OP 专用色（玩家 isOp 即显示此色，与等级组无关；优先级最高）
   op_color: "gold"
   # 四级权限组 → 命名色（非 OP 玩家按所属组显示）

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/commands/OrzConfigCommandTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/commands/OrzConfigCommandTest.java
@@ -277,6 +277,66 @@ class OrzConfigCommandTest {
         assertEquals(1, reloads.get());
     }
 
+    @Test
+    void set_rankColorPath_notifiesRankColorsReload() {
+        when(configService.saveConfig("config")).thenReturn(true);
+        when(configService.reloadConfig("config")).thenReturn(true);
+        AtomicInteger rankReloads = new AtomicInteger();
+        cmd.setRankColorsReload(rankReloads::incrementAndGet);
+
+        cmd.onCommand(sender, command, "orzmc", new String[] {"set", "rank_colors.tab_enabled", "false"});
+
+        assertEquals(1, rankReloads.get());
+    }
+
+    @Test
+    void set_nonRankColorPath_doesNotNotifyRankColors() {
+        when(configService.saveConfig("config")).thenReturn(true);
+        when(configService.reloadConfig("config")).thenReturn(true);
+        AtomicInteger rankReloads = new AtomicInteger();
+        cmd.setRankColorsReload(rankReloads::incrementAndGet);
+
+        cmd.onCommand(sender, command, "orzmc", new String[] {"set", "tnt.enable", "false"});
+
+        assertEquals(0, rankReloads.get());
+    }
+
+    @Test
+    void reset_rankColorPath_notifiesRankColorsReload() {
+        when(configService.saveConfig("config")).thenReturn(true);
+        when(configService.reloadConfig("config")).thenReturn(true);
+        AtomicInteger rankReloads = new AtomicInteger();
+        cmd.setRankColorsReload(rankReloads::incrementAndGet);
+
+        cmd.onCommand(sender, command, "orzmc", new String[] {"reset", "rank_colors.tab_enabled"});
+
+        assertEquals(1, rankReloads.get());
+    }
+
+    @Test
+    void reload_config_notifiesRankColorsReload() {
+        when(configService.reloadConfig("config")).thenReturn(true);
+        AtomicInteger rankReloads = new AtomicInteger();
+        cmd.setRankColorsReload(rankReloads::incrementAndGet);
+
+        cmd.onCommand(sender, command, "orzmc", new String[] {"reload", "config"});
+
+        assertEquals(1, rankReloads.get());
+    }
+
+    @Test
+    void reload_all_notifiesBothEasyBotAndRankColors() {
+        AtomicInteger easyBotReloads = new AtomicInteger();
+        AtomicInteger rankReloads = new AtomicInteger();
+        OrzConfigCommand both = new OrzConfigCommand(configService, textStyles, easyBotReloads::incrementAndGet);
+        both.setRankColorsReload(rankReloads::incrementAndGet);
+
+        both.onCommand(sender, command, "orzmc", new String[] {"reload"});
+
+        assertEquals(1, easyBotReloads.get());
+        assertEquals(1, rankReloads.get());
+    }
+
     // ---------------------------------------------------------------
     // parseValue
     // ---------------------------------------------------------------

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzRankDisplayEventTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/events/OrzRankDisplayEventTest.java
@@ -85,7 +85,7 @@ class OrzRankDisplayEventTest {
         PlayerRankDisplayService disabled = new PlayerRankDisplayService(
                 serverFacade,
                 rankService,
-                () -> new RankColorsConfig(false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS));
+                () -> new RankColorsConfig(false, true, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS));
 
         new OrzRankDisplayEvent(plugin, disabled).onAsyncChat(event);
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
@@ -204,7 +204,7 @@ class PlayerRankDisplayServiceTest {
     }
 
     @Test
-    void applyTo_tabDisabled_colorsNametagButPlainTab() {
+    void applyTo_tabDisabled_colorsNametagRestoresTab() {
         Player p = mockPlayer("Steve", false);
         when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
         when(board.getEntryTeam("Steve")).thenReturn(null);
@@ -215,16 +215,17 @@ class PlayerRankDisplayServiceTest {
 
         service(cfg).applyTo(p);
 
-        // 只关 Tab：头顶队伍仍着色，Tab 名还原纯文本
+        // 只关 Tab：头顶队伍仍着色，Tab 名恢复服务器原 displayName（无强制色）
         verify(team).color(NamedTextColor.AQUA);
         verify(team).addEntry("Steve");
         verify(p).playerListName(Component.text("Steve"));
     }
 
     @Test
-    void applyTo_tabDisabled_preservesDisplayNameNickInPlainTab() {
+    void applyTo_tabDisabled_restoresDisplayNameNickAndFormatting() {
         Player p = mockPlayer("Steve", false);
-        when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
+        // 服务器原 displayName：昵称 + 自有格式（如 EssentialsX /nick 带色）——还原时必须原样保留
+        when(p.displayName()).thenReturn(Component.text("CoolGuy").color(NamedTextColor.YELLOW));
         when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
         when(board.getEntryTeam("Steve")).thenReturn(null);
         when(board.getTeam("orzmc-member")).thenReturn(null);
@@ -234,13 +235,16 @@ class PlayerRankDisplayServiceTest {
 
         service(cfg).applyTo(p);
 
-        // Tab 关闭还原时仍保留昵称（displayName 文本），头顶队伍 entry 用真实名
-        verify(p).playerListName(Component.text("CoolGuy"));
+        // Tab 恢复为服务器原 displayName 组件：昵称与格式都保留，不被剥成纯文本
+        ArgumentCaptor<Component> cap = ArgumentCaptor.forClass(Component.class);
+        verify(p).playerListName(cap.capture());
+        assertEquals("CoolGuy", PlainTextComponentSerializer.plainText().serialize(cap.getValue()));
+        assertEquals(NamedTextColor.YELLOW, cap.getValue().color());
         verify(team).addEntry("Steve");
     }
 
     @Test
-    void applyTo_tabDisabled_nametagDisabled_plainTabNoTeam() {
+    void applyTo_tabDisabled_nametagDisabled_restoresTabNoTeam() {
         Player p = mockPlayer("Steve", false);
         when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
         when(board.getEntryTeam("Steve")).thenReturn(null);
@@ -248,13 +252,13 @@ class PlayerRankDisplayServiceTest {
 
         service(cfg).applyTo(p);
 
-        // 头顶+Tab 都关：不建/不碰队伍，Tab 还原纯文本（聊天由 colorFor 独立着色）
+        // 头顶+Tab 都关：不建/不碰队伍，Tab 恢复服务器原 displayName（聊天由 colorFor 独立着色）
         verify(p).playerListName(Component.text("Steve"));
         verify(board, never()).registerNewTeam(anyString());
     }
 
     @Test
-    void applyTo_disabled_cleansTeamAndResetsPlainTab() {
+    void applyTo_disabled_cleansTeamAndRestoresTab() {
         Player p = mockPlayer("Steve", false);
         RankColorsConfig disabled =
                 new RankColorsConfig(false, true, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
@@ -269,7 +273,7 @@ class PlayerRankDisplayServiceTest {
     }
 
     @Test
-    void applyTo_disabled_preservesDisplayNameNickInTab() {
+    void applyTo_disabled_restoresDisplayNameNickInTab() {
         Player p = mockPlayer("Steve", false);
         when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
         RankColorsConfig disabled =
@@ -277,7 +281,7 @@ class PlayerRankDisplayServiceTest {
 
         service(disabled).applyTo(p);
 
-        // 禁用还原时保留昵称（displayName 文本），而非还原真实名丢掉 /nick
+        // 禁用还原时保留昵称（displayName 组件），而非还原真实名丢掉 /nick
         verify(p).playerListName(Component.text("CoolGuy"));
     }
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
@@ -256,7 +256,7 @@ class PlayerRankDisplayServiceTest {
     }
 
     @Test
-    void applyTo_disabled_cleansTeamAndResetsTab() {
+    void applyTo_disabled_cleansTeamAndRestoresDisplayNameTab() {
         Player p = mockPlayer("Steve", false);
         RankColorsConfig disabled =
                 new RankColorsConfig(false, true, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
@@ -267,12 +267,12 @@ class PlayerRankDisplayServiceTest {
         service(disabled).applyTo(p);
 
         verify(orzmc).removeEntry("Steve");
-        // Tab 名置空→恢复服务器原显示策略（team/vanilla 渲染，含原 team 前缀）
-        verify(p).playerListName(null);
+        // 总开关关闭：还原 displayName 文本（与 1.0.22 既有行为一致，保昵称）
+        verify(p).playerListName(Component.text("Steve"));
     }
 
     @Test
-    void applyTo_disabled_resetsTabRegardlessOfNick() {
+    void applyTo_disabled_preservesDisplayNameNickInTab() {
         Player p = mockPlayer("Steve", false);
         when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
         RankColorsConfig disabled =
@@ -280,8 +280,8 @@ class PlayerRankDisplayServiceTest {
 
         service(disabled).applyTo(p);
 
-        // 禁用还原同样置空：恢复服务器原策略优先，昵称不强行写进 Tab
-        verify(p).playerListName(null);
+        // 总开关关闭还原时保留昵称（displayName 文本），而非还原真实名丢掉 /nick
+        verify(p).playerListName(Component.text("CoolGuy"));
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
@@ -72,7 +72,8 @@ class PlayerRankDisplayServiceTest {
     @Test
     void colorFor_disabled_returnsNull() {
         Player p = mockPlayer("Steve", false);
-        RankColorsConfig disabled = new RankColorsConfig(false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+        RankColorsConfig disabled =
+                new RankColorsConfig(false, true, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
         assertNull(service(disabled).colorFor(p));
     }
 
@@ -193,7 +194,7 @@ class PlayerRankDisplayServiceTest {
         Player p = mockPlayer("Steve", false);
         when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
         when(board.getEntryTeam("Steve")).thenReturn(null);
-        RankColorsConfig cfg = new RankColorsConfig(true, false, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+        RankColorsConfig cfg = new RankColorsConfig(true, false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
 
         service(cfg).applyTo(p);
 
@@ -203,9 +204,60 @@ class PlayerRankDisplayServiceTest {
     }
 
     @Test
+    void applyTo_tabDisabled_colorsNametagButPlainTab() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+        when(board.getTeam("orzmc-member")).thenReturn(null);
+        Team team = mock(Team.class);
+        when(board.registerNewTeam("orzmc-member")).thenReturn(team);
+        RankColorsConfig cfg = new RankColorsConfig(true, true, false, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+
+        service(cfg).applyTo(p);
+
+        // 只关 Tab：头顶队伍仍着色，Tab 名还原纯文本
+        verify(team).color(NamedTextColor.AQUA);
+        verify(team).addEntry("Steve");
+        verify(p).playerListName(Component.text("Steve"));
+    }
+
+    @Test
+    void applyTo_tabDisabled_preservesDisplayNameNickInPlainTab() {
+        Player p = mockPlayer("Steve", false);
+        when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+        when(board.getTeam("orzmc-member")).thenReturn(null);
+        Team team = mock(Team.class);
+        when(board.registerNewTeam("orzmc-member")).thenReturn(team);
+        RankColorsConfig cfg = new RankColorsConfig(true, true, false, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+
+        service(cfg).applyTo(p);
+
+        // Tab 关闭还原时仍保留昵称（displayName 文本），头顶队伍 entry 用真实名
+        verify(p).playerListName(Component.text("CoolGuy"));
+        verify(team).addEntry("Steve");
+    }
+
+    @Test
+    void applyTo_tabDisabled_nametagDisabled_plainTabNoTeam() {
+        Player p = mockPlayer("Steve", false);
+        when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
+        when(board.getEntryTeam("Steve")).thenReturn(null);
+        RankColorsConfig cfg = new RankColorsConfig(true, false, false, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+
+        service(cfg).applyTo(p);
+
+        // 头顶+Tab 都关：不建/不碰队伍，Tab 还原纯文本（聊天由 colorFor 独立着色）
+        verify(p).playerListName(Component.text("Steve"));
+        verify(board, never()).registerNewTeam(anyString());
+    }
+
+    @Test
     void applyTo_disabled_cleansTeamAndResetsPlainTab() {
         Player p = mockPlayer("Steve", false);
-        RankColorsConfig disabled = new RankColorsConfig(false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+        RankColorsConfig disabled =
+                new RankColorsConfig(false, true, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
         Team orzmc = mock(Team.class);
         when(orzmc.getName()).thenReturn("orzmc-default");
         when(board.getEntryTeam("Steve")).thenReturn(orzmc);
@@ -220,7 +272,8 @@ class PlayerRankDisplayServiceTest {
     void applyTo_disabled_preservesDisplayNameNickInTab() {
         Player p = mockPlayer("Steve", false);
         when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
-        RankColorsConfig disabled = new RankColorsConfig(false, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
+        RankColorsConfig disabled =
+                new RankColorsConfig(false, true, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
 
         service(disabled).applyTo(p);
 

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
@@ -256,7 +256,7 @@ class PlayerRankDisplayServiceTest {
     }
 
     @Test
-    void applyTo_disabled_cleansTeamAndRestoresDisplayNameTab() {
+    void applyTo_disabled_cleansTeamAndNullsTab() {
         Player p = mockPlayer("Steve", false);
         RankColorsConfig disabled =
                 new RankColorsConfig(false, true, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
@@ -267,12 +267,12 @@ class PlayerRankDisplayServiceTest {
         service(disabled).applyTo(p);
 
         verify(orzmc).removeEntry("Steve");
-        // 总开关关闭：还原 displayName 文本（与 1.0.22 既有行为一致，保昵称）
-        verify(p).playerListName(Component.text("Steve"));
+        // 总开关关闭同样置空：恢复服务器原显示策略（team/vanilla 渲染，含原 team 前缀）
+        verify(p).playerListName(null);
     }
 
     @Test
-    void applyTo_disabled_preservesDisplayNameNickInTab() {
+    void applyTo_disabled_nullsTabRegardlessOfNick() {
         Player p = mockPlayer("Steve", false);
         when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
         RankColorsConfig disabled =
@@ -280,8 +280,8 @@ class PlayerRankDisplayServiceTest {
 
         service(disabled).applyTo(p);
 
-        // 总开关关闭还原时保留昵称（displayName 文本），而非还原真实名丢掉 /nick
-        verify(p).playerListName(Component.text("CoolGuy"));
+        // 置空优先于保留昵称：恢复服务器原策略（真实名 + team 前缀），昵称不强行写进 Tab
+        verify(p).playerListName(null);
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/features/rank/PlayerRankDisplayServiceTest.java
@@ -204,7 +204,7 @@ class PlayerRankDisplayServiceTest {
     }
 
     @Test
-    void applyTo_tabDisabled_colorsNametagRestoresTab() {
+    void applyTo_tabDisabled_colorsNametagResetsTab() {
         Player p = mockPlayer("Steve", false);
         when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
         when(board.getEntryTeam("Steve")).thenReturn(null);
@@ -215,16 +215,17 @@ class PlayerRankDisplayServiceTest {
 
         service(cfg).applyTo(p);
 
-        // 只关 Tab：头顶队伍仍着色，Tab 名恢复服务器原 displayName（无强制色）
+        // 只关 Tab：头顶队伍仍着色，Tab 名置空→client 走 team/vanilla 回退（恢复原 team 前缀）
         verify(team).color(NamedTextColor.AQUA);
         verify(team).addEntry("Steve");
-        verify(p).playerListName(Component.text("Steve"));
+        verify(p).playerListName(null);
     }
 
     @Test
-    void applyTo_tabDisabled_restoresDisplayNameNickAndFormatting() {
+    void applyTo_tabDisabled_resetsTabRegardlessOfDisplayName() {
         Player p = mockPlayer("Steve", false);
-        // 服务器原 displayName：昵称 + 自有格式（如 EssentialsX /nick 带色）——还原时必须原样保留
+        // 有 EssentialsX /nick 昵称也一律置空：还原「服务器原策略」优先于保留昵称
+        // （置空后 client 用真实名+team 前缀渲染，与 vanilla 一致）
         when(p.displayName()).thenReturn(Component.text("CoolGuy").color(NamedTextColor.YELLOW));
         when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
         when(board.getEntryTeam("Steve")).thenReturn(null);
@@ -235,16 +236,13 @@ class PlayerRankDisplayServiceTest {
 
         service(cfg).applyTo(p);
 
-        // Tab 恢复为服务器原 displayName 组件：昵称与格式都保留，不被剥成纯文本
-        ArgumentCaptor<Component> cap = ArgumentCaptor.forClass(Component.class);
-        verify(p).playerListName(cap.capture());
-        assertEquals("CoolGuy", PlainTextComponentSerializer.plainText().serialize(cap.getValue()));
-        assertEquals(NamedTextColor.YELLOW, cap.getValue().color());
+        // Tab 名置空（不携带任何 displayName/格式），头顶队伍 entry 仍用真实名
+        verify(p).playerListName(null);
         verify(team).addEntry("Steve");
     }
 
     @Test
-    void applyTo_tabDisabled_nametagDisabled_restoresTabNoTeam() {
+    void applyTo_tabDisabled_nametagDisabled_resetsTabNoTeam() {
         Player p = mockPlayer("Steve", false);
         when(rankService.currentGroup(p.getUniqueId())).thenReturn("member");
         when(board.getEntryTeam("Steve")).thenReturn(null);
@@ -252,13 +250,13 @@ class PlayerRankDisplayServiceTest {
 
         service(cfg).applyTo(p);
 
-        // 头顶+Tab 都关：不建/不碰队伍，Tab 恢复服务器原 displayName（聊天由 colorFor 独立着色）
-        verify(p).playerListName(Component.text("Steve"));
+        // 头顶+Tab 都关：不建/不碰队伍，Tab 名置空→恢复服务器原策略（聊天由 colorFor 独立着色）
+        verify(p).playerListName(null);
         verify(board, never()).registerNewTeam(anyString());
     }
 
     @Test
-    void applyTo_disabled_cleansTeamAndRestoresTab() {
+    void applyTo_disabled_cleansTeamAndResetsTab() {
         Player p = mockPlayer("Steve", false);
         RankColorsConfig disabled =
                 new RankColorsConfig(false, true, true, NamedTextColor.GOLD, RankColorsConfig.DEFAULTS);
@@ -269,11 +267,12 @@ class PlayerRankDisplayServiceTest {
         service(disabled).applyTo(p);
 
         verify(orzmc).removeEntry("Steve");
-        verify(p).playerListName(Component.text("Steve"));
+        // Tab 名置空→恢复服务器原显示策略（team/vanilla 渲染，含原 team 前缀）
+        verify(p).playerListName(null);
     }
 
     @Test
-    void applyTo_disabled_restoresDisplayNameNickInTab() {
+    void applyTo_disabled_resetsTabRegardlessOfNick() {
         Player p = mockPlayer("Steve", false);
         when(p.displayName()).thenReturn(Component.text("CoolGuy")); // EssentialsX /nick 昵称
         RankColorsConfig disabled =
@@ -281,8 +280,8 @@ class PlayerRankDisplayServiceTest {
 
         service(disabled).applyTo(p);
 
-        // 禁用还原时保留昵称（displayName 组件），而非还原真实名丢掉 /nick
-        verify(p).playerListName(Component.text("CoolGuy"));
+        // 禁用还原同样置空：恢复服务器原策略优先，昵称不强行写进 Tab
+        verify(p).playerListName(null);
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPathTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigPathTest.java
@@ -11,7 +11,7 @@ class ConfigPathTest {
     void all_containsExpectedEntries() {
         Map<String, ConfigPath> all = ConfigPath.all();
         assertNotNull(all);
-        assertEquals(36, all.size());
+        assertEquals(37, all.size());
     }
 
     @Test

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigServiceTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/ConfigServiceTest.java
@@ -96,4 +96,25 @@ class ConfigServiceTest {
     void manager_returnsNonNull() {
         assertNotNull(configService.manager());
     }
+
+    @Test
+    void setup_backfillsMissingRankColorsKeys() {
+        // mock 插件无资源文件 → 磁盘配置为空，等价于旧版服务器升级（config.yml 缺新键）。
+        // setup() 的 getOrSetDefault 需把 rank_colors 全键（含 tab_enabled）回填进磁盘配置，
+        // 否则 /orzmc config get 显示 <null>（行为虽默认 true，但 UI 与 7 个兄弟键不一致）。
+        configService.setup();
+        org.bukkit.configuration.file.FileConfiguration cfg = configService.getConfig("config");
+        for (String path : java.util.List.of(
+                "rank_colors.enabled",
+                "rank_colors.nametag_enabled",
+                "rank_colors.tab_enabled",
+                "rank_colors.op_color",
+                "rank_colors.colors.admin",
+                "rank_colors.colors.builder",
+                "rank_colors.colors.member",
+                "rank_colors.colors.default")) {
+            assertTrue(cfg.contains(path), "缺键未回填: " + path);
+        }
+        assertTrue(cfg.getBoolean("rank_colors.tab_enabled"));
+    }
 }

--- a/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/RankColorsConfigTest.java
+++ b/src/test/java/com/jokerhub/paper/plugin/orzmc/infra/config/configs/RankColorsConfigTest.java
@@ -15,6 +15,7 @@ class RankColorsConfigTest {
         RankColorsConfig cfg = RankColorsConfig.from(null);
         assertTrue(cfg.enabled());
         assertTrue(cfg.nametagEnabled());
+        assertTrue(cfg.tabEnabled());
         assertEquals(NamedTextColor.GOLD, cfg.opColor());
         assertEquals(NamedTextColor.GRAY, cfg.colors().get("default"));
         assertEquals(NamedTextColor.AQUA, cfg.colors().get("member"));
@@ -32,12 +33,14 @@ class RankColorsConfigTest {
         ConfigurationSection cfg = mock(ConfigurationSection.class);
         when(cfg.getBoolean("enabled", true)).thenReturn(false);
         when(cfg.getBoolean("nametag_enabled", true)).thenReturn(false);
+        when(cfg.getBoolean("tab_enabled", true)).thenReturn(false);
         when(cfg.getString("op_color")).thenReturn("gold");
         when(cfg.getConfigurationSection("colors")).thenReturn(colors);
 
         RankColorsConfig parsed = RankColorsConfig.from(cfg);
         assertFalse(parsed.enabled());
         assertFalse(parsed.nametagEnabled());
+        assertFalse(parsed.tabEnabled());
         assertEquals(NamedTextColor.GOLD, parsed.opColor());
         assertEquals(NamedTextColor.RED, parsed.colors().get("admin"));
         assertEquals(NamedTextColor.GREEN, parsed.colors().get("builder"));
@@ -55,6 +58,7 @@ class RankColorsConfigTest {
         ConfigurationSection cfg = mock(ConfigurationSection.class);
         when(cfg.getBoolean("enabled", true)).thenReturn(true);
         when(cfg.getBoolean("nametag_enabled", true)).thenReturn(true);
+        when(cfg.getBoolean("tab_enabled", true)).thenReturn(true);
         when(cfg.getString("op_color")).thenReturn(null);
         when(cfg.getConfigurationSection("colors")).thenReturn(colors);
 
@@ -76,6 +80,7 @@ class RankColorsConfigTest {
         ConfigurationSection cfg = mock(ConfigurationSection.class);
         when(cfg.getBoolean("enabled", true)).thenReturn(true);
         when(cfg.getBoolean("nametag_enabled", true)).thenReturn(true);
+        when(cfg.getBoolean("tab_enabled", true)).thenReturn(true);
         when(cfg.getString("op_color")).thenReturn("not-a-color");
         when(cfg.getConfigurationSection("colors")).thenReturn(colors);
 


### PR DESCRIPTION
## 概述

给 `rank_colors` 新增 `tab_enabled` 开关，与既有 `nametag_enabled` 对等，可独立控制 **Tab 列表**是否按权限着色。同时修复：`/orzmc config set/reset rank_colors.*` 后存量在线玩家要等最长 ~60s 周期自愈才生效（热生效）。

## 行为矩阵

| enabled | nametag_enabled | tab_enabled | 头顶名牌 | Tab | 聊天 |
|---|---|---|---|---|---|
| false | — | — | 还原 | 置空（team 回退） | 还原 |
| true | false | true | 还原 | ✅ 着色 | ✅ |
| true | true | false | ✅ 着色 | 置空（team 回退） | ✅ |
| true | false | false | 还原 | 置空（team 回退） | ✅ |

## 关键语义

- **`enabled=false` 与 `tab_enabled=false` 一致：`playerListName(null)`**。置空是唯一让 vanilla client 走「计分板队伍回退」的方式，**恢复服务器原 team 前缀 + 真实名**（实测确认：设非 null 组件会压制 team 前缀）。
- **昵称取舍**：置空后 Tab 用真实名（team 回退），EssentialsX `/nick` 昵称不进 Tab——恢复原 team 显示策略的必然结果（头顶/聊天仍显示昵称）。
- **⚠️ 固有交互**：若 `nametag_enabled=true`，玩家被移入 orzmc 队伍（头顶着色的机制），置空后 Tab 回退沿用该队伍 rank 色。要 Tab 完全还原原前缀显示，需 `nametag_enabled=false`。
- 热生效：`set/reset rank_colors.*` 按路径门控精确触发；`reload`（文件级）无法判断具体改动项，无条件重刷（幂等，接受）。

## 改动

- `RankColorsConfig`：record 新增 `tabEnabled`（默认 true）+ 解析
- `PlayerRankDisplayService.applyTo`：`tabName`（着色/置空）贯穿 4 个分支；总开关与 tab 开关关闭均置空
- `config.yml` / `ConfigPath` / `ConfigService.setup`（播种回填）：注册 `rank_colors.tab_enabled`
- **F1**：`OrzConfigCommand` 新增 `rankColorsReload` 回调，经 `runSync` 立即 `refreshAllOnline()`（Folia 线程安全）

## 独立审查处置（`/code-review 221 high` × 2 轮 + 测试服实测）

| # | 发现 | 处置 |
|---|------|------|
| 1 | `tab_enabled=false` + `nametag_enabled=true` 时 Tab 仍显示 orzmc 队伍色 | **固有交互**（team 机制），文档说明，接受 |
| 2 | `playerListName(null)` 丢昵称 + `enabled=false` 被改超范围 | **用户实测要求确认**：总开关与 tab 开关关闭均置空，语义统一 |
| 3 | `reload` 无条件重刷 | **接受**：文件级 reload 无法判断改动项；set/reset 已正确按路径门控 |

## 测试

`./gradlew spotlessApply && ./gradlew test` 全绿：
- `RankColorsConfigTest` / `ConfigPathTest`：`tab_enabled` 默认/解析/注册
- `PlayerRankDisplayServiceTest`：tab/总开关关闭置空（含 nametag 组合、昵称不影响置空）
- `ConfigServiceTest`：`rank_colors.tab_enabled` 缺键回填
- `OrzConfigCommandTest`：rankColorsReload 回调 5 用例
